### PR TITLE
fix: #9 — Performance benchmarks — compare against NVIDIA C++ deployment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2361,6 +2361,7 @@ dependencies = [
 name = "robowbc-comm"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "robowbc-core",
  "serde",
  "thiserror 2.0.18",

--- a/crates/robowbc-comm/Cargo.toml
+++ b/crates/robowbc-comm/Cargo.toml
@@ -18,7 +18,12 @@ tokio = { version = "1", features = ["time"] }
 zenoh = "1.8"
 
 [dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
 tokio = { version = "1", features = ["rt", "macros"] }
+
+[[bench]]
+name = "control_loop"
+harness = false
 
 [lints]
 workspace = true

--- a/crates/robowbc-comm/benches/control_loop.rs
+++ b/crates/robowbc-comm/benches/control_loop.rs
@@ -1,0 +1,105 @@
+//! Benchmarks for control-loop latency and frequency stability.
+//!
+//! Run with: `cargo bench -p robowbc-comm`
+//!
+//! Measures the overhead of the control-tick pipeline (transport I/O +
+//! policy callback invocation) using an in-memory transport and a trivial
+//! policy closure.
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use robowbc_comm::{ImuSample, InMemoryTransport, JointState};
+use robowbc_core::{JointPositionTargets, Observation, WbcCommand};
+use std::time::Instant;
+
+fn sample_joint_state(n: usize) -> JointState {
+    JointState {
+        positions: vec![0.1; n],
+        velocities: vec![0.0; n],
+        timestamp: Instant::now(),
+    }
+}
+
+fn sample_imu() -> ImuSample {
+    ImuSample {
+        gravity_vector: [0.0, 0.0, -1.0],
+        timestamp: Instant::now(),
+    }
+}
+
+fn passthrough_policy(obs: Observation) -> robowbc_core::Result<JointPositionTargets> {
+    Ok(JointPositionTargets {
+        positions: obs.joint_positions,
+        timestamp: obs.timestamp,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Single control tick: transport read + policy + transport write
+// ---------------------------------------------------------------------------
+
+fn bench_control_tick(c: &mut Criterion) {
+    let mut group = c.benchmark_group("comm/control_tick");
+
+    for &joint_count in &[4, 29] {
+        group.bench_with_input(
+            BenchmarkId::new("joints", joint_count),
+            &joint_count,
+            |b, &n| {
+                b.iter_custom(|iters| {
+                    let mut transport = InMemoryTransport::new();
+                    for _ in 0..iters {
+                        transport.push_joint_state(sample_joint_state(n));
+                        transport.push_imu(sample_imu());
+                    }
+
+                    let start = Instant::now();
+                    for _ in 0..iters {
+                        robowbc_comm::run_control_tick(
+                            &mut transport,
+                            WbcCommand::MotionTokens(vec![1.0; n]),
+                            passthrough_policy,
+                        )
+                        .expect("tick should succeed");
+                    }
+                    start.elapsed()
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// End-to-end: observation assembly + policy + target publish
+// ---------------------------------------------------------------------------
+
+fn bench_end_to_end_pipeline(c: &mut Criterion) {
+    let joint_count = 29;
+    let mut group = c.benchmark_group("comm/end_to_end");
+
+    group.bench_function("29_joints", |b| {
+        b.iter_custom(|iters| {
+            let mut transport = InMemoryTransport::new();
+            for _ in 0..iters {
+                transport.push_joint_state(sample_joint_state(joint_count));
+                transport.push_imu(sample_imu());
+            }
+
+            let start = Instant::now();
+            for _ in 0..iters {
+                robowbc_comm::run_control_tick(
+                    &mut transport,
+                    WbcCommand::MotionTokens(vec![1.0; joint_count]),
+                    passthrough_policy,
+                )
+                .expect("tick should succeed");
+            }
+            start.elapsed()
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_control_tick, bench_end_to_end_pipeline);
+criterion_main!(benches);

--- a/crates/robowbc-ort/benches/inference.rs
+++ b/crates/robowbc-ort/benches/inference.rs
@@ -1,4 +1,4 @@
-//! Benchmarks for single-inference latency on ONNX models.
+//! Benchmarks for single-inference latency on ONNX models and WBC policies.
 //!
 //! Run with: `cargo bench -p robowbc-ort`
 //!
@@ -6,17 +6,70 @@
 //! ```sh
 //! python3 tests/fixtures/gen_test_models.py
 //! ```
+//!
+//! ## Metrics
+//!
+//! Criterion reports P50 (median), plus confidence intervals. Use
+//! `--output-format bencher` for machine-readable output. For P99/P999
+//! analysis, use the raw JSON data in `target/criterion/`.
 
-use criterion::{criterion_group, criterion_main, Criterion};
-use robowbc_ort::OrtBackend;
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use robowbc_core::{JointLimit, Observation, PdGains, RobotConfig, WbcCommand, WbcPolicy};
+use robowbc_ort::{
+    DecoupledWbcConfig, DecoupledWbcPolicy, GearSonicConfig, GearSonicPolicy, OrtBackend, OrtConfig,
+};
 use std::path::PathBuf;
+use std::time::Instant;
 
 fn fixture_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
 }
 
+fn identity_model() -> PathBuf {
+    fixture_dir().join("test_identity.onnx")
+}
+
+fn dynamic_identity_model() -> PathBuf {
+    fixture_dir().join("test_dynamic_identity.onnx")
+}
+
+fn relu_model() -> PathBuf {
+    fixture_dir().join("test_relu.onnx")
+}
+
+fn test_ort_config(model_path: PathBuf) -> OrtConfig {
+    OrtConfig {
+        model_path,
+        execution_provider: robowbc_ort::ExecutionProvider::Cpu,
+        optimization_level: robowbc_ort::OptimizationLevel::Extended,
+        num_threads: 1,
+    }
+}
+
+fn test_robot_config(joint_count: usize) -> RobotConfig {
+    RobotConfig {
+        name: "bench_robot".to_owned(),
+        joint_count,
+        joint_names: (0..joint_count).map(|i| format!("j{i}")).collect(),
+        pd_gains: vec![PdGains { kp: 1.0, kd: 0.1 }; joint_count],
+        joint_limits: vec![
+            JointLimit {
+                min: -1.0,
+                max: 1.0
+            };
+            joint_count
+        ],
+        default_pose: vec![0.0; joint_count],
+        model_path: None,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OrtBackend: raw single-model inference
+// ---------------------------------------------------------------------------
+
 fn bench_identity_inference(c: &mut Criterion) {
-    let model_path = fixture_dir().join("test_identity.onnx");
+    let model_path = identity_model();
     if !model_path.exists() {
         eprintln!(
             "skipping identity benchmark: model not found at {}",
@@ -28,7 +81,7 @@ fn bench_identity_inference(c: &mut Criterion) {
     let mut backend = OrtBackend::from_file(&model_path).expect("model should load");
     let input_data: Vec<f32> = vec![1.0, 2.0, 3.0, 4.0];
 
-    c.bench_function("identity_1x4", |b| {
+    c.bench_function("ort/identity_1x4", |b| {
         b.iter(|| {
             backend
                 .run(&[("input", &input_data, &[1, 4])])
@@ -38,7 +91,7 @@ fn bench_identity_inference(c: &mut Criterion) {
 }
 
 fn bench_relu_inference(c: &mut Criterion) {
-    let model_path = fixture_dir().join("test_relu.onnx");
+    let model_path = relu_model();
     if !model_path.exists() {
         eprintln!(
             "skipping relu benchmark: model not found at {}",
@@ -50,7 +103,7 @@ fn bench_relu_inference(c: &mut Criterion) {
     let mut backend = OrtBackend::from_file(&model_path).expect("model should load");
     let input_data: Vec<f32> = vec![-3.0, -1.0, 0.0, 1.0, 2.0, 5.0, -0.5, 10.0];
 
-    c.bench_function("relu_1x8", |b| {
+    c.bench_function("ort/relu_1x8", |b| {
         b.iter(|| {
             backend
                 .run(&[("input", &input_data, &[1, 8])])
@@ -59,5 +112,117 @@ fn bench_relu_inference(c: &mut Criterion) {
     });
 }
 
-criterion_group!(benches, bench_identity_inference, bench_relu_inference);
+fn bench_dynamic_identity_scaling(c: &mut Criterion) {
+    let model_path = dynamic_identity_model();
+    if !model_path.exists() {
+        eprintln!(
+            "skipping dynamic identity benchmark: model not found at {}",
+            model_path.display()
+        );
+        return;
+    }
+
+    let mut group = c.benchmark_group("ort/dynamic_identity");
+    for &size in &[4, 29, 64, 256] {
+        let mut backend = OrtBackend::from_file(&model_path).expect("model should load");
+        let input_data: Vec<f32> = vec![1.0; size];
+        let shape = [1, size as i64];
+
+        group.bench_with_input(BenchmarkId::from_parameter(size), &size, |b, _| {
+            b.iter(|| {
+                backend
+                    .run(&[("input", &input_data, &shape)])
+                    .expect("inference should succeed");
+            });
+        });
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// GearSonicPolicy: full encoder → planner → decoder pipeline
+// ---------------------------------------------------------------------------
+
+fn bench_gear_sonic_predict(c: &mut Criterion) {
+    let model_path = identity_model();
+    if !model_path.exists() {
+        eprintln!(
+            "skipping gear_sonic benchmark: model not found at {}",
+            model_path.display()
+        );
+        return;
+    }
+
+    let config = GearSonicConfig {
+        encoder: test_ort_config(model_path.clone()),
+        decoder: test_ort_config(model_path.clone()),
+        planner: test_ort_config(model_path),
+        robot: test_robot_config(4),
+    };
+    let policy = GearSonicPolicy::new(config).expect("policy should build");
+
+    let obs = Observation {
+        joint_positions: vec![0.0; 4],
+        joint_velocities: vec![0.0; 4],
+        gravity_vector: [0.0, 0.0, -1.0],
+        command: WbcCommand::MotionTokens(vec![0.25, -0.25, 0.5, -0.5]),
+        timestamp: Instant::now(),
+    };
+
+    c.bench_function("policy/gear_sonic_predict", |b| {
+        b.iter(|| {
+            policy.predict(&obs).expect("prediction should succeed");
+        });
+    });
+}
+
+// ---------------------------------------------------------------------------
+// DecoupledWbcPolicy: RL lower-body + analytical upper-body
+// ---------------------------------------------------------------------------
+
+fn bench_decoupled_wbc_predict(c: &mut Criterion) {
+    let model_path = dynamic_identity_model();
+    if !model_path.exists() {
+        eprintln!(
+            "skipping decoupled_wbc benchmark: model not found at {}",
+            model_path.display()
+        );
+        return;
+    }
+
+    let config = DecoupledWbcConfig {
+        rl_model: test_ort_config(model_path),
+        robot: test_robot_config(4),
+        lower_body_joints: vec![0, 1],
+        upper_body_joints: vec![2, 3],
+        control_frequency_hz: 50,
+    };
+    let policy = DecoupledWbcPolicy::new(config).expect("policy should build");
+
+    let obs = Observation {
+        joint_positions: vec![0.5, -0.3, 0.1, 0.2],
+        joint_velocities: vec![0.01, -0.02, 0.0, 0.0],
+        gravity_vector: [0.0, 0.0, -1.0],
+        command: WbcCommand::Velocity(robowbc_core::Twist {
+            linear: [0.2, 0.0, 0.0],
+            angular: [0.0, 0.0, 0.1],
+        }),
+        timestamp: Instant::now(),
+    };
+
+    c.bench_function("policy/decoupled_wbc_predict", |b| {
+        b.iter(|| {
+            policy.predict(&obs).expect("prediction should succeed");
+        });
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_identity_inference,
+    bench_relu_inference,
+    bench_dynamic_identity_scaling,
+    bench_gear_sonic_predict,
+    bench_decoupled_wbc_predict,
+);
 criterion_main!(benches);

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -1,0 +1,82 @@
+# Performance Benchmarks
+
+Reproducible benchmarks for RoboWBC inference latency and control-loop performance.
+
+## Running Benchmarks
+
+```bash
+# All benchmarks
+cargo bench
+
+# Inference-only (OrtBackend + policy predict)
+cargo bench -p robowbc-ort
+
+# Control loop (transport I/O + tick overhead)
+cargo bench -p robowbc-comm
+```
+
+## What Is Measured
+
+### Inference Latency (`robowbc-ort`)
+
+| Benchmark | Description |
+|-----------|-------------|
+| `ort/identity_1x4` | Baseline ONNX Runtime overhead — identity model, 4 elements |
+| `ort/relu_1x8` | Minimal compute — ReLU activation, 8 elements |
+| `ort/dynamic_identity/{N}` | Tensor size scaling — identity model at 4, 29, 64, 256 elements |
+| `policy/gear_sonic_predict` | Full GEAR-SONIC pipeline: encoder → planner → decoder (3 models) |
+| `policy/decoupled_wbc_predict` | Decoupled WBC: RL lower-body + analytical upper-body |
+
+### Control Loop Latency (`robowbc-comm`)
+
+| Benchmark | Description |
+|-----------|-------------|
+| `comm/control_tick/joints/{N}` | Single tick: transport read → policy → transport write |
+| `comm/end_to_end/29_joints` | Full pipeline with 29-DOF robot (Unitree G1 scale) |
+
+## Interpreting Results
+
+Criterion reports the **median** (P50) with 95% confidence intervals. For tail
+latency analysis (P99, P999), inspect the raw JSON output:
+
+```
+target/criterion/<benchmark_name>/new/raw.csv
+```
+
+## Comparison With NVIDIA C++ Deployment
+
+The table below is a template for recording comparison data. Fill in measured
+values on matching hardware (same GPU, same ONNX model, same input shapes).
+
+| Metric | RoboWBC (Rust + ort) | NVIDIA C++ | Notes |
+|--------|---------------------|------------|-------|
+| Single inference P50 (ms) | _run `cargo bench`_ | — | Same ONNX model + opset |
+| Single inference P99 (ms) | _see raw CSV_ | — | |
+| Control loop frequency (Hz) | _from CLI metrics_ | — | Target: 50 Hz |
+| Memory RSS (MB) | _measure with `/usr/bin/time -v`_ | — | |
+| GPU utilization (%) | _measure with `nvidia-smi`_ | — | CUDA/TensorRT EP only |
+
+### How to Collect Comparison Data
+
+1. **RoboWBC inference latency**: `cargo bench -p robowbc-ort`
+2. **NVIDIA C++ latency**: Run the NVIDIA deployment binary with matching model
+   and record its reported inference time.
+3. **Memory**: `command time -v cargo bench -p robowbc-ort 2>&1 | grep "Maximum resident"`
+4. **GPU utilization**: `nvidia-smi dmon -s u -d 1` while benchmark runs (CUDA EP only).
+5. **Control loop frequency**: `cargo run -- run --config configs/sonic_g1.toml`
+   and observe the achieved frequency in the output metrics.
+
+## Test Models
+
+Current benchmarks use minimal test fixtures (identity, ReLU). These measure
+**framework overhead** — the cost of ONNX Runtime session execution, tensor
+marshalling, mutex locking, and policy pipeline coordination.
+
+For production-representative latency, replace the test model paths in the
+benchmark configuration with real GEAR-SONIC or Decoupled WBC ONNX models.
+
+## Hardware Requirements
+
+- **CPU benchmarks**: Any x86-64 or aarch64 machine.
+- **CUDA benchmarks**: Requires `ort` built with CUDA EP and a compatible NVIDIA GPU.
+- **TensorRT benchmarks**: Requires TensorRT libraries matching the `ort` version.


### PR DESCRIPTION
## Summary

- Expand criterion benchmarks in robowbc-ort to cover GearSonicPolicy and DecoupledWbcPolicy predict() latency, plus OrtBackend scaling across tensor sizes (4, 29, 64, 256 elements)
- Add new robowbc-comm control-loop benchmarks measuring single control-tick overhead and end-to-end pipeline latency
- Create docs/benchmarks/README.md with methodology, comparison template for NVIDIA C++ deployment, and instructions for collecting P50/P99/P999 metrics

Closes #9

## Test plan

- [x] cargo build succeeds
- [x] cargo test - all 56 tests pass
- [x] cargo clippy -- -D warnings - clean
- [x] cargo fmt --check - clean
- [x] cargo bench --no-run - both benchmark executables compile

https://claude.ai/code/session_01Aeg6LHPjfBKXvedVcKETw5