### PR TITLE
fix: #1 — add GEAR-SONIC model download helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ RoboWBC is grounded in recent whole-body control research and is designed to pro
 
 These works motivate RoboWBC's core abstraction: policy-specific model internals, but a shared runtime contract (`Observation` in, joint-position targets out).
 
+
+## Download GEAR-SONIC ONNX Models
+
+RoboWBC includes a helper script to fetch NVIDIA's public GEAR-SONIC checkpoints from HuggingFace:
+
+```bash
+./scripts/download_gear_sonic_models.sh
+```
+
+By default, files are written to `models/gear-sonic/` and line up with `configs/sonic_g1.toml`.
+
 ## Architecture
 
 ```rust

--- a/configs/sonic_g1.toml
+++ b/configs/sonic_g1.toml
@@ -2,25 +2,25 @@
 name = "gear_sonic"
 
 [policy.config.encoder]
-model_path = "crates/robowbc-ort/tests/fixtures/test_identity.onnx"
+model_path = "models/gear-sonic/model_encoder.onnx"
 execution_provider = { type = "cpu" }
 optimization_level = "extended"
 num_threads = 1
 
 [policy.config.decoder]
-model_path = "crates/robowbc-ort/tests/fixtures/test_identity.onnx"
+model_path = "models/gear-sonic/model_decoder.onnx"
 execution_provider = { type = "cpu" }
 optimization_level = "extended"
 num_threads = 1
 
 [policy.config.planner]
-model_path = "crates/robowbc-ort/tests/fixtures/test_identity.onnx"
+model_path = "models/gear-sonic/planner_sonic.onnx"
 execution_provider = { type = "cpu" }
 optimization_level = "extended"
 num_threads = 1
 
 [robot]
-config_path = "configs/robots/unitree_g1_mock.toml"
+config_path = "configs/robots/unitree_g1.toml"
 
 [comm]
 frequency_hz = 50
@@ -28,4 +28,4 @@ topics = { joint_state = "unitree/g1/joint_state", imu = "unitree/g1/imu", joint
 
 [runtime]
 motion_tokens = [0.05, -0.1, 0.2, 0.0]
-max_ticks = 1
+max_ticks = 200

--- a/scripts/download_gear_sonic_models.sh
+++ b/scripts/download_gear_sonic_models.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DEST_DIR="${1:-models/gear-sonic}"
+BASE_URL="https://huggingface.co/nvidia/GEAR-SONIC/resolve/main"
+
+mkdir -p "${DEST_DIR}"
+
+models=(
+  "model_encoder.onnx"
+  "model_decoder.onnx"
+  "planner_sonic.onnx"
+)
+
+for model in "${models[@]}"; do
+  target="${DEST_DIR}/${model}"
+  echo "[download] ${model} -> ${target}"
+  curl --fail --location --retry 3 --retry-delay 2 \
+    "${BASE_URL}/${model}" \
+    --output "${target}"
+  if [[ ! -s "${target}" ]]; then
+    echo "[error] downloaded file is empty: ${target}" >&2
+    exit 1
+  fi
+  echo "[ok] ${model} ($(wc -c < "${target}") bytes)"
+done
+
+echo "Downloaded GEAR-SONIC ONNX models to ${DEST_DIR}."


### PR DESCRIPTION
### Motivation
- Move the repo from using small ONNX fixtures toward running real GEAR-SONIC ONNX checkpoints so roadmap item A (real model inference) can be exercised. 
- Provide a single, reproducible step to populate the expected model paths used by `configs/sonic_g1.toml` to make local end-to-end runs easier. 

### Description
- Add `scripts/download_gear_sonic_models.sh`, a small downloader that fetches `model_encoder.onnx`, `model_decoder.onnx`, and `planner_sonic.onnx` from the public HuggingFace release with retries and non-empty file checks. 
- Update `configs/sonic_g1.toml` to point policy encoder/decoder/planner `model_path`s to `models/gear-sonic/*`, switch the robot config to `configs/robots/unitree_g1.toml`, and increase `max_ticks` for practical runs. 
- Document the new helper in `README.md` under a “Download GEAR-SONIC ONNX Models” section so users can run `./scripts/download_gear_sonic_models.sh` to populate `models/gear-sonic/`.

### Testing
- Verified toolchain with `rustc --version` and `cargo --version` successfully. 
- Ran `cargo build`, `cargo check`, and `cargo test`, and all tests completed successfully. 
- Ran `cargo clippy -- -D warnings` and `cargo fmt --check`, both completed without failures. 
- Ran `cargo doc --no-deps` which completed but produced existing rustdoc unresolved-link warnings (pre-existing) rather than failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9b53a7438832da9d9c47321b947c9)