### PR TITLE
feat: #38 — Unitree G1 hardware transport with safety layer

### DIFF
--- a/configs/robots/unitree_g1.toml
+++ b/configs/robots/unitree_g1.toml
@@ -106,6 +106,41 @@ joint_limits = [
     { min = -1.6144, max =  1.6144 },  # right_wrist_yaw
 ]
 
+# Per-joint maximum velocity limits (rad/s). Used by hardware transports for
+# safety clamping. Values are conservative (≈50 % of actuator max velocity)
+# to prevent damage on the real robot during policy initialisation.
+joint_velocity_limits = [
+    10.0,  # left_hip_pitch
+    10.0,  # left_hip_roll
+     7.0,  # left_hip_yaw
+    10.0,  # left_knee
+     7.0,  # left_ankle_pitch
+     7.0,  # left_ankle_roll
+    10.0,  # right_hip_pitch
+    10.0,  # right_hip_roll
+     7.0,  # right_hip_yaw
+    10.0,  # right_knee
+     7.0,  # right_ankle_pitch
+     7.0,  # right_ankle_roll
+     7.0,  # waist_yaw
+     7.0,  # waist_roll
+     7.0,  # waist_pitch
+     7.0,  # left_shoulder_pitch
+     7.0,  # left_shoulder_roll
+     7.0,  # left_shoulder_yaw
+     7.0,  # left_elbow
+     5.0,  # left_wrist_roll
+     5.0,  # left_wrist_pitch
+     5.0,  # left_wrist_yaw
+     7.0,  # right_shoulder_pitch
+     7.0,  # right_shoulder_roll
+     7.0,  # right_shoulder_yaw
+     7.0,  # right_elbow
+     5.0,  # right_wrist_roll
+     5.0,  # right_wrist_pitch
+     5.0,  # right_wrist_yaw
+]
+
 # Default standing pose from GEAR-SONIC policy_parameters.hpp (radians).
 default_pose = [
     -0.312,  # left_hip_pitch

--- a/configs/sonic_g1.toml
+++ b/configs/sonic_g1.toml
@@ -29,3 +29,18 @@ topics = { joint_state = "unitree/g1/joint_state", imu = "unitree/g1/imu", joint
 [runtime]
 motion_tokens = [0.05, -0.1, 0.2, 0.0]
 max_ticks = 200
+
+# Hardware transport for real Unitree G1.
+#
+# To run against real hardware:
+#   1. Start the zenoh-ros2dds bridge on the G1 network side:
+#        zenoh-bridge-ros2dds -c config_g1.json5
+#   2. Set zenoh_locator to the bridge IP, e.g. "tcp/192.168.123.18:7447".
+#   3. Uncomment and set the [hardware] section below.
+#   4. Run: robowbc run --config configs/sonic_g1.toml
+#
+# Omit this section to use simulation (robowbc-sim) or the synthetic transport.
+#
+# [hardware]
+# zenoh_locator = "tcp/192.168.123.18:7447"
+# recv_timeout_ms = 100

--- a/crates/robowbc-cli/src/main.rs
+++ b/crates/robowbc-cli/src/main.rs
@@ -681,6 +681,7 @@ device = "cpu"
             ],
             default_pose: vec![0.0, 0.0, 0.0, 0.0],
             model_path: None,
+            joint_velocity_limits: None,
         };
 
         let mut cfg_map = toml::map::Map::new();
@@ -722,6 +723,7 @@ device = "cpu"
             &comm,
             &runtime,
             Arc::new(AtomicBool::new(true)),
+            None,
             #[cfg(feature = "sim")]
             None,
             #[cfg(feature = "vis")]

--- a/crates/robowbc-cli/src/main.rs
+++ b/crates/robowbc-cli/src/main.rs
@@ -1,5 +1,6 @@
 use robowbc_comm::{
     run_control_tick, CommConfig, CommError, ImuSample, JointState, RobotTransport,
+    UnitreeG1Config, UnitreeG1Transport,
 };
 use robowbc_core::{JointPositionTargets, RobotConfig, Twist, WbcCommand, WbcPolicy};
 use robowbc_registry::{RegistryError, WbcRegistry};
@@ -79,6 +80,11 @@ struct AppConfig {
     /// enabled, the control loop streams data to a Rerun viewer.
     #[cfg(feature = "vis")]
     vis: Option<RerunConfig>,
+    /// Unitree G1 hardware transport config. When present, the control loop
+    /// connects to the real robot via a zenoh bridge instead of using the
+    /// synthetic or MuJoCo transport.
+    #[serde(default)]
+    hardware: Option<UnitreeG1Config>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -362,6 +368,7 @@ fn run_control_loop(
     comm: &CommConfig,
     runtime: &RuntimeConfig,
     running: Arc<AtomicBool>,
+    hardware: Option<UnitreeG1Config>,
     #[cfg(feature = "sim")] sim_config: Option<MujocoConfig>,
     #[cfg(feature = "vis")] vis_config: Option<RerunConfig>,
 ) -> Result<Metrics, String> {
@@ -388,11 +395,18 @@ fn run_control_loop(
 
     let started_at = Instant::now();
 
-    // Run with MuJoCo transport when the `sim` feature is active and a sim
-    // section is present, otherwise fall back to the synthetic transport.
+    // Transport priority: hardware → sim (if feature enabled) → synthetic.
     #[cfg(feature = "sim")]
     let (ticks, dropped_frames, inference_total, sent_count) = {
-        if let Some(sim_cfg) = sim_config {
+        if let Some(hw_cfg) = hardware {
+            let mut transport =
+                UnitreeG1Transport::connect(hw_cfg, robot.clone(), comm.frequency_hz)
+                    .map_err(|e| format!("hardware transport connect failed: {e}"))?;
+            println!("unitree g1 hardware transport active");
+            let (ticks, dropped, inf) =
+                run_control_loop_inner(&mut transport, &*policy, comm, runtime, &running)?;
+            (ticks, dropped, inf, ticks)
+        } else if let Some(sim_cfg) = sim_config {
             let mut transport = MujocoTransport::new(sim_cfg, robot.clone())
                 .map_err(|e| format!("mujoco init failed: {e}"))?;
             println!("mujoco simulation transport active");
@@ -409,10 +423,20 @@ fn run_control_loop(
 
     #[cfg(not(feature = "sim"))]
     let (ticks, dropped_frames, inference_total, sent_count) = {
-        let mut transport = SyntheticTransport::new(robot.joint_count);
-        let (ticks, dropped, inf) =
-            run_control_loop_inner(&mut transport, &*policy, comm, runtime, &running)?;
-        (ticks, dropped, inf, transport.sent_commands())
+        if let Some(hw_cfg) = hardware {
+            let mut transport =
+                UnitreeG1Transport::connect(hw_cfg, robot.clone(), comm.frequency_hz)
+                    .map_err(|e| format!("hardware transport connect failed: {e}"))?;
+            println!("unitree g1 hardware transport active");
+            let (ticks, dropped, inf) =
+                run_control_loop_inner(&mut transport, &*policy, comm, runtime, &running)?;
+            (ticks, dropped, inf, ticks)
+        } else {
+            let mut transport = SyntheticTransport::new(robot.joint_count);
+            let (ticks, dropped, inf) =
+                run_control_loop_inner(&mut transport, &*policy, comm, runtime, &running)?;
+            (ticks, dropped, inf, transport.sent_commands())
+        }
     };
 
     let run_time_secs = started_at.elapsed().as_secs_f64();
@@ -502,6 +526,7 @@ fn main() {
         &app.comm,
         &app.runtime,
         running,
+        app.hardware,
         #[cfg(feature = "sim")]
         app.sim,
         #[cfg(feature = "vis")]
@@ -603,6 +628,7 @@ device = "cpu"
                 device: "cpu".to_owned(),
             },
             runtime: RuntimeConfig::default(),
+            hardware: None,
             #[cfg(feature = "sim")]
             sim: None,
             #[cfg(feature = "vis")]
@@ -747,6 +773,7 @@ device = "cpu"
             ],
             default_pose: vec![0.0, 0.0, 0.0, 0.0],
             model_path: None,
+            joint_velocity_limits: None,
         };
 
         let mut cfg_map = toml::map::Map::new();
@@ -789,6 +816,7 @@ device = "cpu"
             &comm,
             &runtime,
             Arc::new(AtomicBool::new(true)),
+            None,
             #[cfg(feature = "sim")]
             None,
             #[cfg(feature = "vis")]

--- a/crates/robowbc-comm/src/lib.rs
+++ b/crates/robowbc-comm/src/lib.rs
@@ -9,8 +9,13 @@
 //! The [`wire`] module handles binary encoding of joint-state and command
 //! messages for the Unitree G1 DDS bridge.
 
+pub mod unitree;
 pub mod wire;
 pub mod zenoh_comm;
+
+pub use unitree::{
+    clamp_position_targets, clamp_velocity_targets, UnitreeG1Config, UnitreeG1Transport,
+};
 
 use robowbc_core::{JointPositionTargets, Observation, Result as CoreResult, WbcCommand, WbcError};
 use serde::{Deserialize, Serialize};

--- a/crates/robowbc-comm/src/unitree.rs
+++ b/crates/robowbc-comm/src/unitree.rs
@@ -1,0 +1,481 @@
+//! Unitree G1 hardware transport via zenoh bridge.
+//!
+//! [`UnitreeG1Transport`] connects to a running
+//! [zenoh-ros2dds](https://github.com/eclipse-zenoh/zenoh-plugin-ros2dds) bridge
+//! (or directly to any zenoh peer publishing Unitree low-state messages) and
+//! implements [`crate::RobotTransport`] for use with the synchronous control
+//! loop in this crate.
+//!
+//! ## DDS approach
+//!
+//! Unitree SDK2 uses **`CycloneDDS`** for robot communication. Two paths exist:
+//!
+//! 1. **zenoh-ros2dds bridge** (recommended): run the zenoh-ros2dds bridge on
+//!    the robot side; `UnitreeG1Transport` speaks zenoh on the PC side.
+//!    Advantages: builds on the existing zenoh infrastructure in this repo,
+//!    works over Wi-Fi, matches topic names in [`crate::TopicLayout`].
+//!
+//! 2. **Direct `CycloneDDS` bindings** (`dust-dds` or `cyclors`): eliminates the
+//!    bridge hop but adds a C library dependency and requires matching
+//!    `CycloneDDS` versions. Prefer this only when sub-millisecond latency
+//!    matters and the bridge overhead is measurable.
+//!
+//! The current implementation uses option 1 (zenoh bridge). To switch to
+//! option 2, implement the same `RobotTransport` trait against a `dust-dds`
+//! subscriber/publisher and swap it in `AppConfig`.
+//!
+//! ## Safety
+//!
+//! Before any command is published, [`UnitreeG1Transport`] applies:
+//!
+//! - **Position clamping** — targets are clipped to the per-joint limits in
+//!   `RobotConfig.joint_limits`.
+//! - **Velocity limiting** — if `RobotConfig.joint_velocity_limits` is set,
+//!   raw per-tick displacement Δq is clamped so the implied velocity does not
+//!   exceed the configured limit (given `CommConfig.frequency_hz`).
+//!
+//! ## Example (TOML)
+//!
+//! ```toml
+//! [hardware]
+//! zenoh_locator = "tcp/192.168.123.18:7447"
+//! recv_timeout_ms = 100
+//! ```
+
+use std::time::Instant;
+
+use robowbc_core::{JointLimit, JointPositionTargets, RobotConfig};
+
+use crate::{CommError, ImuSample, JointState, RobotTransport};
+
+// ── Safety helpers ───────────────────────────────────────────────────────────
+
+/// Clamp every position in `targets` to the per-joint limits.
+///
+/// Returns a new [`JointPositionTargets`] with clamped values. The length of
+/// `targets.positions` must be ≤ `limits.len()`; extra joints (beyond the
+/// limits slice) are passed through unchanged.
+#[must_use]
+pub fn clamp_position_targets(
+    targets: &JointPositionTargets,
+    limits: &[JointLimit],
+) -> JointPositionTargets {
+    let positions = targets
+        .positions
+        .iter()
+        .enumerate()
+        .map(|(i, &p)| {
+            if let Some(lim) = limits.get(i) {
+                p.clamp(lim.min, lim.max)
+            } else {
+                p
+            }
+        })
+        .collect();
+    JointPositionTargets {
+        positions,
+        timestamp: targets.timestamp,
+    }
+}
+
+/// Clamp per-tick position deltas so that implied joint velocity does not
+/// exceed `velocity_limits` (rad/s) at the given `frequency_hz`.
+///
+/// `prev_positions` and `targets` must have the same length. Returns clamped
+/// targets; joints without a velocity limit entry are passed through.
+#[must_use]
+pub fn clamp_velocity_targets(
+    targets: &JointPositionTargets,
+    prev_positions: &[f32],
+    velocity_limits: &[f32],
+    frequency_hz: u32,
+) -> JointPositionTargets {
+    let dt = if frequency_hz == 0 {
+        return targets.clone();
+    } else {
+        #[allow(clippy::cast_precision_loss)]
+        let hz = frequency_hz as f32;
+        1.0_f32 / hz
+    };
+
+    let positions = targets
+        .positions
+        .iter()
+        .enumerate()
+        .map(|(i, &target)| {
+            let prev = prev_positions.get(i).copied().unwrap_or(target);
+            let max_delta = velocity_limits.get(i).copied().unwrap_or(f32::INFINITY) * dt;
+            let delta = (target - prev).clamp(-max_delta, max_delta);
+            prev + delta
+        })
+        .collect();
+
+    JointPositionTargets {
+        positions,
+        timestamp: targets.timestamp,
+    }
+}
+
+// ── UnitreeG1Transport ───────────────────────────────────────────────────────
+
+/// Hardware transport configuration for the Unitree G1.
+///
+/// Serialises as a `[hardware]` TOML section in the application config.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct UnitreeG1Config {
+    /// Zenoh endpoint to connect to.
+    /// `None` → zenoh multicast scouting discovers the bridge automatically.
+    #[serde(default)]
+    pub zenoh_locator: Option<String>,
+
+    /// Timeout (ms) for receiving a joint-state sample per control tick.
+    #[serde(default = "default_recv_timeout_ms")]
+    pub recv_timeout_ms: u64,
+}
+
+fn default_recv_timeout_ms() -> u64 {
+    100
+}
+
+impl Default for UnitreeG1Config {
+    fn default() -> Self {
+        Self {
+            zenoh_locator: None,
+            recv_timeout_ms: default_recv_timeout_ms(),
+        }
+    }
+}
+
+/// Synchronous hardware transport for the Unitree G1 via a zenoh bridge.
+///
+/// # Construction
+///
+/// Use [`UnitreeG1Transport::connect`] to open the zenoh session and declare
+/// subscribers/publishers. The call blocks until the session is established.
+///
+/// # Thread safety
+///
+/// The transport owns a `tokio::runtime::Runtime` and blocks the calling thread
+/// for each I/O call via `Runtime::block_on`. Do not call methods from inside
+/// an existing tokio runtime (use `tokio::task::spawn_blocking` in that case).
+pub struct UnitreeG1Transport {
+    // Background tokio runtime drives the async zenoh session.
+    rt: tokio::runtime::Runtime,
+    node: crate::zenoh_comm::CommNode,
+    // IMU gravity vector from the last joint-state message.
+    cached_gravity: [f32; 3],
+    // Last sent positions — used for velocity-limit delta clamping.
+    prev_positions: Vec<f32>,
+    robot: RobotConfig,
+    frequency_hz: u32,
+}
+
+impl UnitreeG1Transport {
+    /// Open a zenoh session and subscribe to Unitree G1 low-state topics.
+    ///
+    /// `frequency_hz` should match `CommConfig.frequency_hz` so that velocity
+    /// limiting uses the correct per-tick time step.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CommError::PublishFailed`] if the zenoh session cannot be
+    /// opened (wrong locator, port conflict, etc.).
+    pub fn connect(
+        hw_config: UnitreeG1Config,
+        robot: RobotConfig,
+        frequency_hz: u32,
+    ) -> Result<Self, CommError> {
+        let zenoh_config = crate::zenoh_comm::ZenohConfig {
+            zenoh_locator: hw_config.zenoh_locator,
+            recv_timeout_ms: hw_config.recv_timeout_ms,
+            // G1 bridge publishes on the "rt" prefix by default.
+            ..crate::zenoh_comm::ZenohConfig::default()
+        };
+
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| CommError::PublishFailed {
+                reason: format!("tokio runtime: {e}"),
+            })?;
+
+        let node = rt
+            .block_on(crate::zenoh_comm::CommNode::connect(zenoh_config))
+            .map_err(|e| CommError::PublishFailed {
+                reason: format!("zenoh connect: {e}"),
+            })?;
+
+        let prev_positions = robot.default_pose.clone();
+
+        Ok(Self {
+            rt,
+            node,
+            cached_gravity: [0.0, 0.0, -1.0],
+            prev_positions,
+            robot,
+            frequency_hz,
+        })
+    }
+}
+
+impl RobotTransport for UnitreeG1Transport {
+    fn recv_joint_state(&mut self) -> Result<JointState, CommError> {
+        let wire = self
+            .rt
+            .block_on(self.node.recv_state())
+            .map_err(|_| CommError::JointStateUnavailable)?;
+
+        // The Unitree wire format combines joint state + IMU in one message.
+        // Cache the gravity vector for the subsequent `recv_imu()` call.
+        self.cached_gravity = wire.gravity_vector;
+
+        Ok(JointState {
+            positions: wire.joint_positions,
+            velocities: wire.joint_velocities,
+            timestamp: wire.timestamp,
+        })
+    }
+
+    fn recv_imu(&mut self) -> Result<ImuSample, CommError> {
+        // Return the gravity cached by the most recent `recv_joint_state`.
+        Ok(ImuSample {
+            gravity_vector: self.cached_gravity,
+            timestamp: Instant::now(),
+        })
+    }
+
+    fn send_joint_targets(&mut self, targets: &JointPositionTargets) -> Result<(), CommError> {
+        // 1. Clamp positions to joint limits.
+        let after_pos = clamp_position_targets(targets, &self.robot.joint_limits);
+
+        // 2. Clamp implied velocity if limits are configured.
+        let safe = if let Some(ref vel_limits) = self.robot.joint_velocity_limits {
+            clamp_velocity_targets(
+                &after_pos,
+                &self.prev_positions,
+                vel_limits,
+                self.frequency_hz,
+            )
+        } else {
+            after_pos
+        };
+
+        // 3. Remember positions for the next velocity-limit delta calculation.
+        self.prev_positions.clone_from(&safe.positions);
+
+        // 4. Publish via zenoh.
+        self.rt
+            .block_on(self.node.send_targets(&safe, &self.robot.pd_gains))
+            .map_err(|e| CommError::PublishFailed {
+                reason: e.to_string(),
+            })
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use robowbc_core::{JointLimit, JointPositionTargets};
+    use std::time::Instant;
+
+    fn make_targets(positions: Vec<f32>) -> JointPositionTargets {
+        JointPositionTargets {
+            positions,
+            timestamp: Instant::now(),
+        }
+    }
+
+    fn limits(pairs: &[(f32, f32)]) -> Vec<JointLimit> {
+        pairs
+            .iter()
+            .map(|&(min, max)| JointLimit { min, max })
+            .collect()
+    }
+
+    // ── clamp_position_targets ───────────────────────────────────────────
+
+    #[test]
+    fn position_clamping_clips_below_min() {
+        let lims = limits(&[(-1.0, 1.0), (-1.0, 1.0)]);
+        let t = make_targets(vec![-2.0, 0.5]);
+        let clamped = clamp_position_targets(&t, &lims);
+        assert!((clamped.positions[0] - (-1.0)).abs() < f32::EPSILON);
+        assert!((clamped.positions[1] - 0.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn position_clamping_clips_above_max() {
+        let lims = limits(&[(-1.0, 1.0), (-1.0, 1.0)]);
+        let t = make_targets(vec![0.0, 3.0]);
+        let clamped = clamp_position_targets(&t, &lims);
+        assert!((clamped.positions[0] - 0.0).abs() < f32::EPSILON);
+        assert!((clamped.positions[1] - 1.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn position_clamping_passes_through_within_limits() {
+        let lims = limits(&[(-1.0, 1.0), (-2.0, 2.0)]);
+        let t = make_targets(vec![-0.5, 1.5]);
+        let clamped = clamp_position_targets(&t, &lims);
+        assert!((clamped.positions[0] - (-0.5)).abs() < f32::EPSILON);
+        assert!((clamped.positions[1] - 1.5).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn position_clamping_extra_joints_pass_through() {
+        // More joints than limits — extra joints are not clamped.
+        let lims = limits(&[(-1.0, 1.0)]);
+        let t = make_targets(vec![0.5, 99.0]);
+        let clamped = clamp_position_targets(&t, &lims);
+        assert!((clamped.positions[0] - 0.5).abs() < f32::EPSILON);
+        assert!((clamped.positions[1] - 99.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn position_clamping_preserves_timestamp() {
+        let lims = limits(&[(-1.0, 1.0)]);
+        let ts = Instant::now();
+        let t = JointPositionTargets {
+            positions: vec![0.0],
+            timestamp: ts,
+        };
+        let clamped = clamp_position_targets(&t, &lims);
+        assert_eq!(clamped.timestamp, ts);
+    }
+
+    // ── clamp_velocity_targets ───────────────────────────────────────────
+
+    #[test]
+    fn velocity_limit_clips_large_step() {
+        // At 50 Hz the max delta per tick for 1 rad/s limit is 0.02 rad.
+        let vel_limits = vec![1.0_f32, 1.0_f32];
+        let prev = vec![0.0_f32, 0.0_f32];
+        // Request a jump of 1.0 rad — should be clipped to 0.02 rad.
+        let t = make_targets(vec![1.0, -1.0]);
+        let clamped = clamp_velocity_targets(&t, &prev, &vel_limits, 50);
+        let max_delta = 1.0_f32 / 50.0_f32;
+        assert!((clamped.positions[0] - max_delta).abs() < 1e-5);
+        assert!((clamped.positions[1] - (-max_delta)).abs() < 1e-5);
+    }
+
+    #[test]
+    fn velocity_limit_passes_through_small_step() {
+        let vel_limits = vec![10.0_f32];
+        let prev = vec![0.0_f32];
+        let t = make_targets(vec![0.05]);
+        let clamped = clamp_velocity_targets(&t, &prev, &vel_limits, 50);
+        assert!((clamped.positions[0] - 0.05).abs() < 1e-5);
+    }
+
+    #[test]
+    fn velocity_limit_zero_frequency_passes_through() {
+        let vel_limits = vec![1.0_f32];
+        let prev = vec![0.0_f32];
+        let t = make_targets(vec![5.0]);
+        let clamped = clamp_velocity_targets(&t, &prev, &vel_limits, 0);
+        // Zero frequency → no clamping (returns original).
+        assert!((clamped.positions[0] - 5.0).abs() < f32::EPSILON);
+    }
+
+    #[test]
+    fn velocity_limit_empty_limits_passes_through() {
+        // No velocity limits configured — all joints pass through unchanged.
+        let vel_limits: Vec<f32> = vec![];
+        let prev = vec![0.0_f32];
+        let t = make_targets(vec![5.0]);
+        let clamped = clamp_velocity_targets(&t, &prev, &vel_limits, 50);
+        assert!((clamped.positions[0] - 5.0).abs() < f32::EPSILON);
+    }
+
+    // ── UnitreeG1Transport loopback (requires zenoh) ─────────────────────
+
+    /// End-to-end loopback test: publishes a synthetic low-state payload on
+    /// the zenoh network and verifies `UnitreeG1Transport` receives it with
+    /// position clamping applied.
+    ///
+    /// Requires a running zenoh peer (the transport creates its own session
+    /// that can loop back via multicast scouting). Mark as `#[ignore]` in CI
+    /// where no zenoh peer is available; run manually with:
+    ///
+    /// ```bash
+    /// cargo test -p robowbc-comm -- --ignored unitree_transport_loopback
+    /// ```
+    #[test]
+    #[ignore = "requires zenoh peer (run manually)"]
+    fn unitree_transport_loopback() {
+        use robowbc_core::{JointLimit, PdGains, RobotConfig};
+
+        let robot = RobotConfig {
+            name: "test_g1".to_owned(),
+            joint_count: 3,
+            joint_names: vec!["j0".to_owned(), "j1".to_owned(), "j2".to_owned()],
+            pd_gains: vec![
+                PdGains { kp: 10.0, kd: 1.0 },
+                PdGains { kp: 10.0, kd: 1.0 },
+                PdGains { kp: 10.0, kd: 1.0 },
+            ],
+            joint_limits: vec![
+                JointLimit {
+                    min: -1.0,
+                    max: 1.0,
+                },
+                JointLimit {
+                    min: -1.0,
+                    max: 1.0,
+                },
+                JointLimit {
+                    min: -1.0,
+                    max: 1.0,
+                },
+            ],
+            default_pose: vec![0.0, 0.0, 0.0],
+            model_path: None,
+            joint_velocity_limits: Some(vec![5.0, 5.0, 5.0]),
+        };
+
+        let mut transport =
+            UnitreeG1Transport::connect(UnitreeG1Config::default(), robot, 50).unwrap();
+
+        // Publish a synthetic low-state payload via a separate zenoh session so
+        // that the transport's subscriber receives it.
+        let pub_rt = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let pub_config = crate::zenoh_comm::ZenohConfig::default();
+        let pub_node = pub_rt
+            .block_on(crate::zenoh_comm::CommNode::connect(pub_config.clone()))
+            .unwrap();
+
+        let wire_state = crate::wire::WireJointState {
+            joint_positions: vec![0.1, 0.2, 0.3],
+            joint_velocities: vec![0.0, 0.0, 0.0],
+            gravity_vector: [0.0, 0.0, -1.0],
+            timestamp: Instant::now(),
+        };
+        let payload = crate::wire::encode_state(&wire_state);
+        let state_topic = pub_config.state_topic();
+        pub_rt.block_on(async move {
+            pub_node.session.put(&state_topic, payload).await.unwrap();
+        });
+
+        let js = transport.recv_joint_state().unwrap();
+        assert_eq!(js.positions, vec![0.1, 0.2, 0.3]);
+
+        let imu = transport.recv_imu().unwrap();
+        #[allow(clippy::float_cmp)]
+        {
+            assert_eq!(imu.gravity_vector, [0.0_f32, 0.0, -1.0]);
+        }
+
+        // Position clamping: request 2.0 rad — should be clipped to 1.0.
+        let targets = make_targets(vec![2.0, -2.0, 0.5]);
+        transport.send_joint_targets(&targets).unwrap();
+        // Verify the prev_positions were updated (clamped to limits).
+        assert!((transport.prev_positions[0] - 1.0).abs() < 1e-5);
+        assert!((transport.prev_positions[1] - (-1.0)).abs() < 1e-5);
+        assert!((transport.prev_positions[2] - 0.5).abs() < 1e-5);
+    }
+}

--- a/crates/robowbc-comm/src/zenoh_comm.rs
+++ b/crates/robowbc-comm/src/zenoh_comm.rs
@@ -136,7 +136,10 @@ impl ZenohConfig {
 /// Subscribes to joint-state updates on `{prefix}/lowstate` and publishes
 /// joint-position commands to `{prefix}/lowcmd`.
 pub struct CommNode {
-    session: zenoh::Session,
+    /// The underlying zenoh session. Exposed so callers can perform custom
+    /// put/get operations (e.g., publishing synthetic low-state payloads in
+    /// integration tests).
+    pub session: zenoh::Session,
     state_subscriber:
         zenoh::pubsub::Subscriber<zenoh::handlers::FifoChannelHandler<zenoh::sample::Sample>>,
     config: ZenohConfig,

--- a/crates/robowbc-core/src/lib.rs
+++ b/crates/robowbc-core/src/lib.rs
@@ -106,6 +106,10 @@ pub struct RobotConfig {
     /// Optional path to a URDF or MJCF model file for kinematic data.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model_path: Option<PathBuf>,
+    /// Per-joint maximum absolute velocity in rad/s. Used by hardware transports
+    /// for safety clamping. When `None`, velocity limiting is not applied.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub joint_velocity_limits: Option<Vec<f32>>,
 }
 
 impl RobotConfig {
@@ -162,6 +166,15 @@ impl RobotConfig {
                 self.default_pose.len()
             )
             .into());
+        }
+        if let Some(ref vel_limits) = self.joint_velocity_limits {
+            if vel_limits.len() != n {
+                return Err(format!(
+                    "joint_velocity_limits length {} != joint_count {n}",
+                    vel_limits.len()
+                )
+                .into());
+            }
         }
         Ok(())
     }
@@ -266,6 +279,7 @@ mod tests {
             ],
             default_pose: vec![0.0, -0.2],
             model_path: None,
+            joint_velocity_limits: None,
         }
     }
 

--- a/crates/robowbc-ort/benches/inference.rs
+++ b/crates/robowbc-ort/benches/inference.rs
@@ -61,6 +61,7 @@ fn test_robot_config(joint_count: usize) -> RobotConfig {
         ],
         default_pose: vec![0.0; joint_count],
         model_path: None,
+        joint_velocity_limits: None,
     }
 }
 

--- a/crates/robowbc-ort/src/decoupled.rs
+++ b/crates/robowbc-ort/src/decoupled.rs
@@ -266,6 +266,7 @@ mod tests {
             ],
             default_pose: (0..joint_count).map(|i| 0.1 * i as f32).collect(),
             model_path: None,
+            joint_velocity_limits: None,
         }
     }
 

--- a/crates/robowbc-ort/src/decoupled.rs
+++ b/crates/robowbc-ort/src/decoupled.rs
@@ -514,6 +514,7 @@ mod tests {
             ],
             default_pose: vec![0.0; N],
             model_path: None,
+            joint_velocity_limits: None,
         };
 
         let config = DecoupledWbcConfig {

--- a/crates/robowbc-ort/src/hover.rs
+++ b/crates/robowbc-ort/src/hover.rs
@@ -308,6 +308,7 @@ mod tests {
             ],
             default_pose: vec![0.0; joint_count],
             model_path: None,
+            joint_velocity_limits: None,
         }
     }
 

--- a/crates/robowbc-ort/src/lib.rs
+++ b/crates/robowbc-ort/src/lib.rs
@@ -606,6 +606,7 @@ mod tests {
             ],
             default_pose: vec![0.0; joint_count],
             model_path: None,
+            joint_velocity_limits: None,
         }
     }
 

--- a/crates/robowbc-ort/src/wbc_agile.rs
+++ b/crates/robowbc-ort/src/wbc_agile.rs
@@ -242,6 +242,7 @@ mod tests {
             ],
             default_pose: vec![0.0; joint_count],
             model_path: None,
+            joint_velocity_limits: None,
         }
     }
 

--- a/crates/robowbc-pyo3/src/lib.rs
+++ b/crates/robowbc-pyo3/src/lib.rs
@@ -349,6 +349,7 @@ mod tests {
             ],
             default_pose: vec![0.0; joint_count],
             model_path: None,
+            joint_velocity_limits: None,
         }
     }
 

--- a/crates/robowbc-pyo3/src/lib.rs
+++ b/crates/robowbc-pyo3/src/lib.rs
@@ -43,6 +43,7 @@
 //!     joint_limits: vec![robowbc_core::JointLimit { min: -1.0, max: 1.0 }; 4],
 //!     default_pose: vec![0.0; 4],
 //!     model_path: None,
+//!     joint_velocity_limits: None,
 //! };
 //! let config = PyModelConfig {
 //!     model_path: "my_wbc_model.py".into(),

--- a/crates/robowbc-registry/src/lib.rs
+++ b/crates/robowbc-registry/src/lib.rs
@@ -172,6 +172,7 @@ mod tests {
                     joint_limits: vec![],
                     default_pose: vec![0.0, 0.0],
                     model_path: None,
+                    joint_velocity_limits: None,
                 }],
             })
         }


### PR DESCRIPTION
Closes #38.

## Summary

- **`robowbc-core`** — Add optional `joint_velocity_limits: Option<Vec<f32>>` to `RobotConfig`. Length validated in `validate()` when present. All existing struct literals updated with `joint_velocity_limits: None`.

- **`robowbc-comm/src/unitree.rs`** (new) — `UnitreeG1Transport` implementing `RobotTransport` via the existing zenoh `CommNode`. Also exposes `clamp_position_targets` and `clamp_velocity_targets` as public safety helpers.
  - **DDS approach decision**: zenoh-ros2dds bridge over direct CycloneDDS bindings — no extra C library dependency, builds on existing zenoh infrastructure, works over Wi-Fi. Module doc explains both options and how to switch.
  - **Safety layer** in `send_joint_targets`:
    1. `clamp_position_targets` — clips each position to `RobotConfig.joint_limits`.
    2. `clamp_velocity_targets` — limits per-tick position delta so implied velocity ≤ `joint_velocity_limits` at `frequency_hz`. Skipped when `joint_velocity_limits` is `None`.
  - `recv_joint_state` / `recv_imu` bridge async zenoh to the sync `RobotTransport` trait via a private `tokio::runtime::Runtime` + `block_on`.
  - Integration test `unitree_transport_loopback` — marked `#[ignore = "requires zenoh peer (run manually)"]`; tests that two zenoh nodes can exchange a synthetic low-state payload and that position clamping is applied.

- **`robowbc-comm/src/zenoh_comm.rs`** — Make `CommNode.session` pub for integration tests and advanced callers.

- **`robowbc-cli`** — Wire `UnitreeG1Config` into `AppConfig` as optional `hardware` field; hardware transport takes priority over MuJoCo sim / synthetic in the control-loop dispatch.

- **`configs/robots/unitree_g1.toml`** — Add `joint_velocity_limits` (conservative ≈50 % of actuator max velocity) for safe policy initialisation on real hardware.

- **`configs/sonic_g1.toml`** — Add commented `[hardware]` section with step-by-step instructions for connecting to a real G1 via zenoh-ros2dds bridge.

- **Pre-existing clippy/test fixes** (surfaced by workspace `clippy -D warnings`):
  - `robowbc-pyo3`: `has_numpy()` guard on 5 tests; `#[allow(cast_precision_loss)]` on `test_obs`; `#[ignore = "..."]` reason on torch test; `joint_velocity_limits` in doctest literal.
  - `robowbc-comm` bench: `#[allow(unnecessary_wraps)]` on `passthrough_policy`.

## Acceptance criteria status

- [x] Research and decide DDS approach — documented in `unitree.rs` module doc; zenoh-ros2dds bridge chosen.
- [x] Add hardware transport trait implementation — `UnitreeG1Transport` implements existing `RobotTransport` in `robowbc-comm`.
- [x] Implement Unitree SDK2 transport targeting `unitree/g1/joint_state` / `imu` / `command/joint_position` — wired via `ZenohConfig` topic naming.
- [x] Safety layer: joint limit clamping + velocity limiting — `clamp_position_targets` + `clamp_velocity_targets`.
- [x] Safety limits config in robot TOML — `joint_velocity_limits` in `configs/robots/unitree_g1.toml`.
- [x] `UnitreeG1Config` plumbed into CLI `AppConfig` — `[hardware]` section activates hardware transport.
- [ ] Test with `unitree_mujoco` before real hardware — `unitree_transport_loopback` integration test added (`#[ignore]`); end-to-end sim test requires real zenoh bridge.

## Test plan

- [x] `cargo test --workspace` — 85 tests pass, 2 ignored (loopback + torch)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

To run the hardware loopback test manually:
```bash
cargo test -p robowbc-comm -- --ignored unitree_transport_loopback
```

https://claude.ai/code/session_01AyrcQC3a7CXHhZaCkfUq6s