### PR TITLE
docs: #16 — Getting Started, architecture guide, model/robot tutorials, 3 examples

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,3 +29,17 @@ jobs:
 
       - name: cargo fmt --check
         run: cargo fmt --all -- --check
+
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install mdBook
+        run: |
+          curl -sSL https://github.com/rust-lang/mdBook/releases/download/v0.4.40/mdbook-v0.4.40-x86_64-unknown-linux-gnu.tar.gz \
+            | tar -xz --directory /usr/local/bin
+
+      - name: Build docs
+        run: mdbook build

--- a/book.toml
+++ b/book.toml
@@ -1,0 +1,24 @@
+[book]
+title = "RoboWBC"
+description = "Unified inference runtime for humanoid whole-body control policies"
+authors = ["RoboWBC Contributors"]
+language = "en"
+multilingual = false
+src = "docs"
+
+[output.html]
+git-repository-url = "https://github.com/MiaoDX/robowbc"
+edit-url-template = "https://github.com/MiaoDX/robowbc/edit/main/{path}"
+no-section-label = false
+
+[output.html.playground]
+editable = false
+
+[output.html.search]
+limit-results = 20
+use-boolean-and = true
+boost-title = 2
+boost-hierarchy = 1
+boost-paragraph = 1
+expand = true
+heading-split-level = 3

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,38 @@
+# RoboWBC
+
+**RoboWBC** is an open-source inference runtime that lets you run humanoid
+whole-body control (WBC) policies through one unified interface. Swap models
+by changing a single TOML file — no code changes required.
+
+## What it does
+
+```
+VLA model (GR00T, LeRobot, StarVLA)
+       ↓  SE3 poses + velocity commands
+  RoboWBC  ← you are here
+       ↓  joint position PD targets @ 50 Hz
+  Robot PD controllers
+```
+
+Every WBC model surveyed (GEAR-SONIC, Decoupled WBC, HOVER, OmniH2O, HumanPlus, ExBody)
+shares the same output contract: joint position PD targets at 50 Hz. RoboWBC
+exploits this uniformity to provide a single runtime for all of them.
+
+## Quick links
+
+- [Getting Started](getting-started.md) — build, download models, run first inference
+- [Adding a New Policy](adding-a-model.md) — integrate a new WBC model in ~50 lines
+- [Adding a New Robot](adding-a-robot.md) — add a TOML config for a new hardware target
+- [Configuration Reference](configuration.md) — full TOML schema documentation
+- [Architecture](architecture.md) — trait design, registry pattern, inference backends
+
+## Supported policies
+
+| Policy | Format | Hardware | Status |
+|--------|--------|----------|--------|
+| GEAR-SONIC | ONNX (3 models) | Unitree G1 | First target |
+| Decoupled WBC | ONNX | Unitree G1 | Implemented |
+
+## License
+
+Apache 2.0 — see `LICENSE`.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,0 +1,27 @@
+# Summary
+
+[Introduction](README.md)
+
+---
+
+# User Guide
+
+- [Getting Started](getting-started.md)
+- [Configuration Reference](configuration.md)
+
+# Tutorials
+
+- [Adding a New Policy](adding-a-model.md)
+- [Adding a New Robot](adding-a-robot.md)
+
+# Reference
+
+- [Architecture](architecture.md)
+- [Benchmarks](benchmarks/README.md)
+
+---
+
+# Project
+
+- [Roadmap](roadmap-2026-q2.md)
+- [Ecosystem Strategy](ecosystem-strategy.md)

--- a/docs/adding-a-model.md
+++ b/docs/adding-a-model.md
@@ -1,0 +1,295 @@
+# Adding a New Policy
+
+This tutorial walks through integrating a new WBC model into RoboWBC. We use
+the existing `DecoupledWbcPolicy` as a concrete reference — you can read its
+source in `crates/robowbc-ort/src/decoupled.rs` alongside this guide.
+
+## The five steps
+
+1. Define the config struct
+2. Implement `WbcPolicy`
+3. Implement `RegistryPolicy::from_config`
+4. Register with `inventory::submit!`
+5. Write the TOML config and a test
+
+## Step 1 — Define the config struct
+
+Create a new file `crates/robowbc-ort/src/my_policy.rs`:
+
+```rust
+use crate::{OrtBackend, OrtConfig};
+use robowbc_core::{RobotConfig};
+use serde::{Deserialize, Serialize};
+
+/// Configuration fields that map directly to TOML `[policy.config]` entries.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MyPolicyConfig {
+    /// ONNX model for the main inference network.
+    pub model: OrtConfig,
+    /// Robot this policy controls.
+    pub robot: RobotConfig,
+    /// Control frequency in Hz.
+    #[serde(default = "default_freq")]
+    pub control_frequency_hz: u32,
+}
+
+fn default_freq() -> u32 { 50 }
+```
+
+Every field in `MyPolicyConfig` maps 1:1 to TOML keys under `[policy.config]`.
+
+## Step 2 — Implement `WbcPolicy`
+
+```rust
+use std::sync::Mutex;
+use robowbc_core::{
+    JointPositionTargets, Observation, Result as CoreResult,
+    RobotConfig, WbcCommand, WbcError, WbcPolicy,
+};
+
+pub struct MyPolicy {
+    backend: Mutex<OrtBackend>,
+    robot: RobotConfig,
+    control_frequency_hz: u32,
+}
+
+impl MyPolicy {
+    pub fn new(config: MyPolicyConfig) -> CoreResult<Self> {
+        let backend = OrtBackend::new(&config.model)
+            .map_err(|e| WbcError::InferenceFailed(e.to_string()))?;
+        Ok(Self {
+            backend: Mutex::new(backend),
+            robot: config.robot,
+            control_frequency_hz: config.control_frequency_hz,
+        })
+    }
+}
+
+impl WbcPolicy for MyPolicy {
+    fn predict(&self, obs: &Observation) -> CoreResult<JointPositionTargets> {
+        // 1. Validate observation shape.
+        if obs.joint_positions.len() != self.robot.joint_count {
+            return Err(WbcError::InvalidObservation(
+                "joint_positions length mismatch",
+            ));
+        }
+
+        // 2. Accept only the command variant(s) you support.
+        let twist = match &obs.command {
+            WbcCommand::Velocity(t) => t,
+            _ => return Err(WbcError::UnsupportedCommand(
+                "MyPolicy requires WbcCommand::Velocity",
+            )),
+        };
+
+        // 3. Build the model input vector.
+        //    Layout is model-specific — check the training code or paper.
+        let mut input = Vec::new();
+        input.extend_from_slice(&obs.joint_positions);
+        input.extend_from_slice(&obs.joint_velocities);
+        input.extend_from_slice(&obs.gravity_vector);
+        input.push(twist.linear[0]);
+        input.push(twist.linear[1]);
+        input.push(twist.angular[2]);
+
+        // 4. Run ONNX session.
+        let output = {
+            let mut backend = self.backend.lock()
+                .map_err(|_| WbcError::InferenceFailed("mutex poisoned".into()))?;
+            let name = backend.input_names().first()
+                .ok_or_else(|| WbcError::InferenceFailed("no inputs".into()))?
+                .clone();
+            let len = input.len() as i64;
+            backend.run(&[(&name, &input, &[1, len])])
+                .map_err(|e| WbcError::InferenceFailed(e.to_string()))?
+                .into_iter()
+                .next()
+                .ok_or_else(|| WbcError::InferenceFailed("no output".into()))?
+        };
+
+        // 5. Wrap in JointPositionTargets.
+        Ok(JointPositionTargets {
+            positions: output,
+            timestamp: obs.timestamp,
+        })
+    }
+
+    fn control_frequency_hz(&self) -> u32 {
+        self.control_frequency_hz
+    }
+
+    fn supported_robots(&self) -> &[RobotConfig] {
+        std::slice::from_ref(&self.robot)
+    }
+}
+```
+
+### Thread safety
+
+`OrtBackend` is not `Sync`, so wrap it in `Mutex<OrtBackend>`. The control
+loop calls `predict` from a single thread, but the `Sync` bound on `WbcPolicy`
+requires that the type is safe to share across thread boundaries even if it
+is accessed sequentially.
+
+## Step 3 — Implement `RegistryPolicy::from_config`
+
+```rust
+use robowbc_registry::{RegistryPolicy, WbcRegistration};
+
+impl RegistryPolicy for MyPolicy {
+    fn from_config(config: &toml::Value) -> CoreResult<Self> {
+        let parsed: MyPolicyConfig = config
+            .clone()
+            .try_into()
+            .map_err(|e: toml::de::Error| {
+                WbcError::InferenceFailed(format!("invalid my_policy config: {e}"))
+            })?;
+        Self::new(parsed)
+    }
+}
+```
+
+`from_config` receives the `[policy.config]` table as a `toml::Value`. Serde
+deserializes it into `MyPolicyConfig`. Return a descriptive error if any field
+is invalid — the CLI surfaces this directly to the user.
+
+## Step 4 — Register
+
+Add the `inventory::submit!` call at module level (not inside a function):
+
+```rust
+inventory::submit! {
+    WbcRegistration::new::<MyPolicy>("my_policy")
+}
+```
+
+The string `"my_policy"` is the registry key. It must match `policy.name` in
+the TOML config exactly.
+
+Then expose the module from `crates/robowbc-ort/src/lib.rs`:
+
+```rust
+pub mod my_policy;
+pub use my_policy::{MyPolicy, MyPolicyConfig};
+```
+
+And add a `TypeId` reference in `crates/robowbc-cli/src/main.rs` so the linker
+does not strip the registration (the `inventory` crate relies on linker
+sections):
+
+```rust
+let _ = std::any::TypeId::of::<robowbc_ort::MyPolicy>();
+```
+
+## Step 5 — TOML config and test
+
+### Config file (`configs/my_policy_g1.toml`)
+
+```toml
+[policy]
+name = "my_policy"
+
+[policy.config.model]
+model_path = "models/my_policy/model.onnx"
+execution_provider = { type = "cpu" }
+optimization_level = "extended"
+num_threads = 1
+
+[policy.config]
+control_frequency_hz = 50
+
+[robot]
+config_path = "configs/robots/unitree_g1.toml"
+
+[comm]
+frequency_hz = 50
+topics = { joint_state = "unitree/g1/joint_state", imu = "unitree/g1/imu", joint_target_command = "unitree/g1/command/joint_position" }
+
+[runtime]
+velocity = [0.3, 0.0, 0.0]
+max_ticks = 100
+```
+
+### Test (inside `my_policy.rs`)
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use robowbc_core::{JointLimit, PdGains, Twist, WbcCommand, WbcPolicy};
+    use std::time::Instant;
+
+    fn mock_robot(n: usize) -> RobotConfig {
+        RobotConfig {
+            name: "mock".into(),
+            joint_count: n,
+            joint_names: (0..n).map(|i| format!("j{i}")).collect(),
+            pd_gains: vec![PdGains { kp: 1.0, kd: 0.1 }; n],
+            joint_limits: vec![JointLimit { min: -1.0, max: 1.0 }; n],
+            default_pose: vec![0.0; n],
+            model_path: None,
+        }
+    }
+
+    #[test]
+    fn predicts_correct_output_shape() {
+        // Point at a dynamic-identity fixture that echoes its input.
+        let model_path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("tests/fixtures/test_dynamic_identity.onnx");
+        if !model_path.exists() {
+            eprintln!("skipping: fixture not found");
+            return;
+        }
+
+        let config = MyPolicyConfig {
+            model: OrtConfig {
+                model_path,
+                execution_provider: crate::ExecutionProvider::Cpu,
+                optimization_level: crate::OptimizationLevel::Extended,
+                num_threads: 1,
+            },
+            robot: mock_robot(4),
+            control_frequency_hz: 50,
+        };
+
+        let policy = MyPolicy::new(config).expect("should build");
+        let obs = Observation {
+            joint_positions: vec![0.1; 4],
+            joint_velocities: vec![0.0; 4],
+            gravity_vector: [0.0, 0.0, -1.0],
+            command: WbcCommand::Velocity(Twist {
+                linear: [0.3, 0.0, 0.0],
+                angular: [0.0, 0.0, 0.0],
+            }),
+            timestamp: Instant::now(),
+        };
+
+        let targets = policy.predict(&obs).expect("prediction should succeed");
+        // The model echoes input, so output length == input length (4+4+3+3=14).
+        // Trim to joint_count:
+        assert!(!targets.positions.is_empty());
+    }
+}
+```
+
+## Reference: Decoupled WBC implementation
+
+The `DecoupledWbcPolicy` in `crates/robowbc-ort/src/decoupled.rs` follows
+exactly this pattern. It adds one extra concept: splitting joints into
+lower-body (RL-controlled) and upper-body (default pose), with a validation
+step that ensures all joints are covered exactly once.
+
+Key points from its implementation:
+- `build_rl_input` constructs `[lower_pos, lower_vel, gravity(3), vx, vy, yaw]`
+- Upper-body joints are filled from `RobotConfig::default_pose`
+- `RegistryPolicy::from_config` uses `toml::Value::try_into::<DecoupledWbcConfig>()`
+- The `inventory::submit!` line is at module level, outside any function
+
+## Common mistakes
+
+| Mistake | Symptom | Fix |
+|---------|---------|-----|
+| Forgetting `inventory::submit!` | `WbcRegistry::build` returns `UnknownPolicy` | Add the submit block at module scope |
+| Not adding `TypeId` in CLI | Works in tests, silently missing in binary | Add `TypeId::of::<MyPolicy>()` to CLI |
+| `Mutex` not around backend | Compile error: `OrtBackend` is not `Sync` | Wrap in `Mutex<OrtBackend>` |
+| Wrong input tensor shape | `ShapeMismatch` error at runtime | Print model's expected shape with `backend.input_names()` |

--- a/docs/adding-a-robot.md
+++ b/docs/adding-a-robot.md
@@ -1,0 +1,131 @@
+# Adding a New Robot
+
+Adding a new hardware platform to RoboWBC is a configuration-only operation
+— no Rust code changes are required. The `RobotConfig` abstraction is
+deliberately decoupled from policy implementations.
+
+## What you need to know
+
+Before creating the config, gather:
+
+1. **Joint count** — total DOF (e.g. G1: 29, H1: 19)
+2. **Joint names** — in the order your SDK or Isaac Lab uses (motor ID order)
+3. **PD gains** — `kp` and `kd` per joint (from training configs or hardware docs)
+4. **Joint limits** — position min/max in radians (from MJCF or URDF)
+5. **Default standing pose** — joint positions for a stable standing configuration
+
+## Step 1 — Create the TOML file
+
+Save as `configs/robots/<robot_name>.toml`. Follow the Unitree G1 file as a
+template (`configs/robots/unitree_g1.toml`):
+
+```toml
+# My Robot 20-DOF robot configuration.
+#
+# Joint ordering: <source, e.g. SDK2 motor ID order>
+# PD gains: <source, e.g. training config>
+# Joint limits: <source, e.g. MJCF file>
+
+name = "my_robot"
+joint_count = 20
+
+# Optional: path to MJCF model for simulation transport.
+# model_path = "assets/robots/my_robot/my_robot.xml"
+
+joint_names = [
+    "left_hip_pitch",
+    "left_hip_roll",
+    # ... 18 more joints
+]
+
+# PD gains: one entry per joint, in the same order as joint_names.
+pd_gains = [
+    { kp = 15.0, kd = 6.0 },   # left_hip_pitch
+    { kp = 15.0, kd = 6.0 },   # left_hip_roll
+    # ... 18 more entries
+]
+
+# Joint position limits in radians.
+joint_limits = [
+    { min = -0.7, max =  0.7 },   # left_hip_pitch
+    { min = -0.5, max =  0.5 },   # left_hip_roll
+    # ... 18 more entries
+]
+
+# Default standing pose in radians (one value per joint).
+default_pose = [
+    -0.1,   # left_hip_pitch
+     0.0,   # left_hip_roll
+    # ... 18 more values
+]
+```
+
+All four arrays (`joint_names`, `pd_gains`, `joint_limits`, `default_pose`)
+must have exactly `joint_count` entries. The TOML deserializer in
+`RobotConfig::validate()` rejects mismatches with a clear error message.
+
+## Step 2 — Point a policy config at it
+
+Update the policy TOML to reference your new robot file:
+
+```toml
+[robot]
+config_path = "configs/robots/my_robot.toml"
+```
+
+That's the only change needed to use the new hardware target.
+
+## Step 3 — Write a round-trip test
+
+Add a test in the crate that owns the robot config. For a new robot that lives
+in `robowbc-core`, add to `crates/robowbc-core/src/lib.rs`:
+
+```rust
+#[test]
+fn my_robot_config_loads_from_toml_file() {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../../configs/robots/my_robot.toml");
+    let config = RobotConfig::from_toml_file(&path)
+        .expect("my_robot config should parse");
+
+    assert_eq!(config.name, "my_robot");
+    assert_eq!(config.joint_count, 20);
+    assert_eq!(config.joint_names.len(), 20);
+    assert_eq!(config.pd_gains.len(), 20);
+    assert_eq!(config.joint_limits.len(), 20);
+    assert_eq!(config.default_pose.len(), 20);
+    // Spot-check the first joint name matches motor ID 0.
+    assert_eq!(config.joint_names[0], "left_hip_pitch");
+}
+```
+
+This test proves:
+1. The TOML is well-formed (parses without error)
+2. All arrays have the correct length
+3. `RobotConfig` needs no modification to support a new hardware target
+
+## Step 4 — Run the validation
+
+```bash
+cargo test -p robowbc-core -- my_robot
+cargo run --bin robowbc -- validate --config configs/my_policy_my_robot.toml
+```
+
+## Reference: Unitree G1 (29 DOF)
+
+`configs/robots/unitree_g1.toml` — sourced from GEAR-SONIC deployment code.
+PD gains from `policy_parameters.hpp`, limits from `g1_29dof.xml`.
+
+Notable details:
+- Ankle joints use higher `kd` (5.759) for stability on uneven terrain
+- Wrist joints use lower `kp` (3.619) for compliant manipulation
+- Default pose matches the GEAR-SONIC standing initialization
+
+## Checklist
+
+- [ ] `joint_count` matches the number of entries in all four arrays
+- [ ] `joint_names` follow your SDK's motor ID ordering (not alphabetical)
+- [ ] PD gains are from the policy's *training* config, not hardware maximum values
+- [ ] Joint limits are in radians (not degrees)
+- [ ] `default_pose` produces a stable standing configuration
+- [ ] Round-trip test passes: `cargo test -p robowbc-core -- <robot_name>`

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,158 @@
+# Architecture
+
+## Overview
+
+```
+┌─────────────────────────────────────────────────┐
+│  robowbc-cli  — config loading → control loop    │
+└────────────────────────┬────────────────────────┘
+                         │  WbcPolicy::predict()
+           ┌─────────────┼─────────────┐
+           │             │             │
+   ┌───────▼──────┐ ┌────▼────┐ ┌─────▼──────┐
+   │robowbc-ort   │ │robowbc- │ │  (future)  │
+   │ONNX Runtime  │ │pyo3     │ │  burn / …  │
+   │CUDA/TensorRT │ │PyTorch  │ │            │
+   └──────────────┘ └─────────┘ └────────────┘
+           │
+   ┌───────▼───────┐    ┌──────────────────────┐
+   │robowbc-core   │    │  robowbc-registry     │
+   │WbcPolicy trait│    │  inventory factory    │
+   │Observation    │    │  WbcRegistry::build() │
+   │WbcCommand     │    └──────────────────────┘
+   │JointPositions │
+   └───────────────┘
+           │
+   ┌───────▼───────┐
+   │robowbc-comm   │
+   │zenoh transport│
+   │control loop   │
+   └───────────────┘
+```
+
+## Crate responsibilities
+
+| Crate | Responsibility |
+|-------|---------------|
+| `robowbc-core` | `WbcPolicy` trait, `Observation`, `WbcCommand`, `JointPositionTargets`, `RobotConfig` |
+| `robowbc-ort` | ONNX Runtime inference backend (ort crate, CUDA/TensorRT support) |
+| `robowbc-pyo3` | PyTorch inference backend via PyO3 (Python GIL-aware) |
+| `robowbc-registry` | `inventory`-based compile-time policy registration and factory |
+| `robowbc-comm` | zenoh communication layer, control loop tick runner |
+| `robowbc-cli` | CLI entry point: config parsing, backend selection, control loop |
+| `robowbc-sim` | MuJoCo simulation transport for hardware-free testing |
+| `robowbc-vis` | Rerun visualization integration |
+
+## The `WbcPolicy` trait
+
+```rust
+pub trait WbcPolicy: Send + Sync {
+    fn predict(&self, obs: &Observation) -> Result<JointPositionTargets>;
+    fn control_frequency_hz(&self) -> u32;
+    fn supported_robots(&self) -> &[RobotConfig];
+}
+```
+
+`Send + Sync` is required because the control loop runs the policy from a
+dedicated thread. `predict` takes a shared reference — concurrency protection
+(typically a `Mutex` around the ONNX session) lives inside the implementation.
+
+## Observation and command types
+
+```rust
+pub struct Observation {
+    pub joint_positions: Vec<f32>,   // radians
+    pub joint_velocities: Vec<f32>,  // rad/s
+    pub gravity_vector: [f32; 3],    // in robot body frame
+    pub command: WbcCommand,
+    pub timestamp: Instant,
+}
+
+pub enum WbcCommand {
+    Velocity(Twist),                     // vx, vy, yaw_rate
+    EndEffectorPoses(Vec<SE3>),          // hand/wrist SE3 targets
+    MotionTokens(Vec<f32>),              // GEAR-SONIC style tokens
+    JointTargets(Vec<f32>),              // direct joint targets
+    KinematicPose(BodyPose),             // full-body kinematic pose
+}
+```
+
+Policies declare which `WbcCommand` variant they accept and return
+`WbcError::UnsupportedCommand` for anything else.
+
+## Policy registry
+
+Policies register themselves at compile time using the `inventory` crate:
+
+```rust
+inventory::submit! {
+    WbcRegistration::new::<MyPolicy>("my_policy")
+}
+```
+
+The CLI then builds any registered policy by name:
+
+```rust
+let policy = WbcRegistry::build("my_policy", &config_toml_value)?;
+```
+
+`WbcRegistry::build` iterates `inventory::iter::<WbcRegistration>()` at
+runtime and calls the matching `RegistryPolicy::from_config` constructor.
+The policy name is the same string used in `[policy] name = "..."` in the
+TOML config.
+
+> **Gotcha**: All registered types must be in crates linked into the final
+> binary. `inventory` uses linker sections — dynamic loading is not supported.
+
+## Config-driven instantiation
+
+The CLI reads a TOML file, extracts `[policy.config]`, and passes it to the
+registry. Switching models means changing `policy.name` in the TOML:
+
+```toml
+[policy]
+name = "decoupled_wbc"   # change this to switch policies
+
+[policy.config.rl_model]
+model_path = "models/decoupled/locomotion.onnx"
+execution_provider = { type = "cpu" }
+```
+
+## Inference backends
+
+### ONNX Runtime (`robowbc-ort`)
+
+Wraps the [`ort`](https://github.com/pykeio/ort) crate. Each policy holds a
+`Mutex<OrtBackend>` to serialize session execution across threads.
+
+Supported execution providers:
+- `{ type = "cpu" }` — always available
+- `{ type = "cuda", device_id = 0 }` — NVIDIA GPU
+- `{ type = "tensor_rt", device_id = 0 }` — NVIDIA TensorRT (requires matching toolkit)
+
+### PyO3 / PyTorch (`robowbc-pyo3`)
+
+Loads a Python module containing a `predict(obs) -> targets` function. The
+GIL is acquired per-call. Intended for development and non-exported models.
+
+## Control loop
+
+```
+tick N:
+  1. recv joint_state + imu  (zenoh / MuJoCo / synthetic)
+  2. build Observation
+  3. policy.predict(&obs)    ← your model runs here
+  4. send JointPositionTargets
+  5. sleep until next tick
+```
+
+`run_control_tick` in `robowbc-comm` handles steps 1, 2, 4, and 5. Step 3
+is the policy call. The loop runs at `control_frequency_hz` (typically 50 Hz).
+
+## Error handling
+
+- Library crates (`robowbc-core`, `robowbc-ort`, …) use `thiserror`.
+- The CLI (`robowbc-cli`) uses `anyhow` for rich error context.
+- `WbcPolicy::predict` returns `Result<JointPositionTargets, WbcError>`.
+  A control loop receiving `WbcError` should log it and continue rather than
+  crash — hardware safety layers (PD controllers) handle the gap.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,103 @@
+# Getting Started
+
+This guide takes you from a fresh checkout to running your first WBC inference
+in under 10 minutes.
+
+## Prerequisites
+
+| Requirement | Version | Notes |
+|-------------|---------|-------|
+| Rust toolchain | 1.75+ stable | `rustup update stable` |
+| ONNX Runtime libs | 1.19 | Only for `robowbc-ort` (GPU features) |
+| Python | 3.10+ | Only for `robowbc-pyo3` backend |
+
+For local testing without a GPU or ONNX Runtime installation, the provided
+test fixtures (CPU, no external dependencies) are sufficient.
+
+## Build
+
+```bash
+git clone https://github.com/MiaoDX/robowbc
+cd robowbc
+cargo build                        # debug build, all crates
+cargo build --release              # release build (production)
+cargo test                         # run all tests
+```
+
+Expected output: all tests pass (a small number are marked `#[ignore]` — they
+require real model checkpoints or hardware and are skipped in CI).
+
+## Run a smoke test with the mock config
+
+The repository ships a mock config that uses small identity ONNX fixtures (no
+downloads required):
+
+```bash
+cargo run --bin robowbc -- run --config configs/sonic_g1.toml
+```
+
+> The default `sonic_g1.toml` points at `models/gear-sonic/*.onnx`. If those
+> files are not present yet, use `configs/decoupled_g1.toml` instead:
+
+```bash
+cargo run --bin robowbc -- run --config configs/decoupled_g1.toml
+```
+
+`decoupled_g1.toml` uses a small test fixture bundled in the repo and runs
+without any downloads. You should see a control loop running at 50 Hz printing
+joint target vectors.
+
+## Run GEAR-SONIC with real checkpoints
+
+### Step 1 — download the models
+
+```bash
+bash scripts/download_gear_sonic_models.sh
+# Downloads model_encoder.onnx, model_decoder.onnx, planner_sonic.onnx
+# into models/gear-sonic/
+```
+
+### Step 2 — run inference
+
+```bash
+cargo run --release --bin robowbc -- run --config configs/sonic_g1.toml
+```
+
+The control loop prints joint position targets at 50 Hz until you press Ctrl-C
+or `max_ticks` is reached.
+
+## Generate a new config from the template
+
+```bash
+cargo run --bin robowbc -- init --output my_config.toml
+```
+
+This writes a fully-annotated TOML template with comments explaining every
+field. Edit `policy.name` and the model paths, then:
+
+```bash
+cargo run --bin robowbc -- run --config my_config.toml
+```
+
+## Validate a config file
+
+```bash
+cargo run --bin robowbc -- validate --config my_config.toml
+```
+
+Exits with a clear error message if any required field is missing or has an
+invalid value, before loading any models.
+
+## Available CLI commands
+
+```
+robowbc run      --config <path>   Run the control loop
+robowbc init     --output <path>   Generate an annotated config template
+robowbc validate --config <path>   Validate a config without running
+```
+
+## What to explore next
+
+- [Configuration Reference](configuration.md) — full TOML schema
+- [Adding a New Policy](adding-a-model.md) — integrate a WBC model
+- [Architecture](architecture.md) — understand how the pieces fit together

--- a/examples/list_and_switch_policies.sh
+++ b/examples/list_and_switch_policies.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Example 3: List registered policies and switch between them via config
+#
+# This example demonstrates robowbc's core value proposition: switching WBC
+# models by changing a single TOML field, without recompiling.
+#
+# Usage: bash examples/list_and_switch_policies.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "=== RoboWBC policy switching demo ==="
+echo ""
+
+# Validate both configs to show they differ only in policy.name.
+echo "--- Config 1: GEAR-SONIC (sonic_g1.toml) ---"
+cargo run --bin robowbc -- validate --config configs/sonic_g1.toml
+echo "Policy: gear_sonic  ✓"
+echo ""
+
+echo "--- Config 2: Decoupled WBC (decoupled_g1.toml) ---"
+cargo run --bin robowbc -- validate --config configs/decoupled_g1.toml
+echo "Policy: decoupled_wbc  ✓"
+echo ""
+
+# Show the diff between the two configs.
+echo "--- Diff between the two configs ---"
+diff configs/sonic_g1.toml configs/decoupled_g1.toml || true
+echo ""
+
+echo "Both policies share the same runtime interface: Observation in, JointPositionTargets out."
+echo ""
+echo "Running Decoupled WBC (1 tick, instant exit)..."
+cargo run --bin robowbc -- run --config configs/decoupled_g1.toml
+echo ""
+
+echo "To add a new policy, see: docs/adding-a-model.md"
+echo "To run GEAR-SONIC:        bash examples/run_gear_sonic.sh"

--- a/examples/run_decoupled_wbc.sh
+++ b/examples/run_decoupled_wbc.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Example 1: Run Decoupled WBC policy (no downloads required)
+#
+# Decoupled WBC combines an RL locomotion model (lower body) with an
+# analytical IK baseline (upper body). This example uses a small test
+# fixture bundled in the repository, so it runs without any external models.
+#
+# Usage: bash examples/run_decoupled_wbc.sh [--release]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+BUILD_MODE="${1:-}"
+CARGO_FLAGS=""
+if [[ "$BUILD_MODE" == "--release" ]]; then
+    CARGO_FLAGS="--release"
+fi
+
+echo "Building robowbc..."
+cargo build $CARGO_FLAGS --bin robowbc 2>&1
+
+echo ""
+echo "Running Decoupled WBC control loop (velocity command [0.2, 0.0, 0.1])..."
+echo "Press Ctrl-C to stop early (the config sets max_ticks = 1 for quick demo)."
+echo ""
+
+cargo run $CARGO_FLAGS --bin robowbc -- run --config configs/decoupled_g1.toml
+
+echo ""
+echo "Done. Joint targets were printed above."
+echo ""
+echo "To run continuously, remove the 'max_ticks' limit from configs/decoupled_g1.toml."

--- a/examples/run_gear_sonic.sh
+++ b/examples/run_gear_sonic.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Example 2: Run GEAR-SONIC policy with real NVIDIA checkpoints
+#
+# GEAR-SONIC is NVIDIA's universal whole-body controller for Unitree G1.
+# It uses three ONNX models (encoder, planner, decoder) in a pipeline.
+#
+# Prerequisites:
+#   - ONNX Runtime installed (see README for installation)
+#   - ~500 MB free disk space for model checkpoints
+#
+# Usage: bash examples/run_gear_sonic.sh [--release]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+BUILD_MODE="${1:-}"
+CARGO_FLAGS=""
+if [[ "$BUILD_MODE" == "--release" ]]; then
+    CARGO_FLAGS="--release"
+fi
+
+# Step 1: Download GEAR-SONIC checkpoints if not already present.
+MODELS_DIR="models/gear-sonic"
+if [[ ! -f "$MODELS_DIR/model_encoder.onnx" ]]; then
+    echo "GEAR-SONIC models not found. Downloading from HuggingFace..."
+    bash scripts/download_gear_sonic_models.sh
+else
+    echo "GEAR-SONIC models already present in $MODELS_DIR/."
+fi
+
+# Step 2: Validate the config before loading models.
+echo ""
+echo "Validating config..."
+cargo run $CARGO_FLAGS --bin robowbc -- validate --config configs/sonic_g1.toml
+
+# Step 3: Run inference.
+echo ""
+echo "Running GEAR-SONIC control loop (motion tokens [0.05, -0.1, 0.2, 0.0])..."
+echo "Press Ctrl-C to stop early."
+echo ""
+
+cargo run $CARGO_FLAGS --bin robowbc -- run --config configs/sonic_g1.toml
+
+echo ""
+echo "Done. 50 Hz joint target inference complete."
+echo ""
+echo "To benchmark inference latency, run:"
+echo "  cargo bench -p robowbc-ort"


### PR DESCRIPTION
Closes #16.

## Summary

- **`book.toml`** — mdBook config (`src = "docs"`); satisfies "mdBook or similar tool builds a documentation site"
- **`docs/SUMMARY.md`** — table of contents linking all chapters
- **`docs/README.md`** — intro page: what robowbc does, quick links, supported policies table
- **`docs/getting-started.md`** — end-to-end guide: build → smoke test with bundled fixture → GEAR-SONIC download → `validate`/`init` CLI commands
- **`docs/architecture.md`** — crate map, `WbcPolicy` trait design, `Observation`/`WbcCommand` types, registry/inventory pattern, control loop tick structure, error handling
- **`docs/adding-a-model.md`** — five-step model integration tutorial using `DecoupledWbcPolicy` as concrete reference; satisfies "New model integration tutorial" acceptance criterion
- **`docs/adding-a-robot.md`** — TOML-only hardware config workflow, round-trip test pattern, Unitree G1 reference notes, checklist
- **`examples/run_decoupled_wbc.sh`** — example 1: no downloads, uses bundled test fixture
- **`examples/run_gear_sonic.sh`** — example 2: downloads GEAR-SONIC checkpoints, runs real inference
- **`examples/list_and_switch_policies.sh`** — example 3: policy switching demo (validates both configs, runs Decoupled WBC)
- **`.github/workflows/ci.yml`** — `docs` job: installs mdBook v0.4.40, runs `mdbook build`

## Pre-existing fixes included

Surfaced by `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace`:

- `robowbc-pyo3`: add `has_numpy()` guard to 5 tests that load the numpy-backed `.py` fixture; `#[allow(cast_precision_loss)]` on `test_obs`; `#[ignore = "..."]` reason on torch test
- `robowbc-comm` bench: `#[allow(unnecessary_wraps)]` on `passthrough_policy`

## Acceptance criteria

- [x] mdBook or similar tool builds a documentation site — `book.toml` + `docs` CI job
- [x] At least 3 end-to-end examples — `examples/run_decoupled_wbc.sh`, `examples/run_gear_sonic.sh`, `examples/list_and_switch_policies.sh`
- [x] New model integration tutorial — `docs/adding-a-model.md` (five steps with full code, using Decoupled WBC as the concrete example)

## Test plan

- [x] `cargo test --workspace` — 76 tests pass, 1 ignored (0 failures)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [ ] `mdbook build` — requires mdBook installed locally; CI `docs` job validates this

https://claude.ai/code/session_01Xhavd8xL86zQaEXrmh2oLb