### PR TITLE
fix: add joint_velocity_limits to BfmZero and WholeBodyVla test helpers

### DIFF
--- a/crates/robowbc-ort/src/bfm_zero.rs
+++ b/crates/robowbc-ort/src/bfm_zero.rs
@@ -230,6 +230,7 @@ mod tests {
             ],
             default_pose: vec![0.0; n],
             model_path: None,
+            joint_velocity_limits: None,
         }
     }
 

--- a/crates/robowbc-ort/src/wholebody_vla.rs
+++ b/crates/robowbc-ort/src/wholebody_vla.rs
@@ -263,6 +263,7 @@ mod tests {
             ],
             default_pose: vec![0.0; n],
             model_path: None,
+            joint_velocity_limits: None,
         }
     }
 


### PR DESCRIPTION
PR #62 was merged before PR #61 added `joint_velocity_limits: Option<Vec<f32>>` to `RobotConfig`, leaving both `test_robot()` helpers in `bfm_zero.rs` and `wholebody_vla.rs` missing the new required field. This breaks the main branch CI.

## Changes

- `crates/robowbc-ort/src/bfm_zero.rs`: add `joint_velocity_limits: None` to `test_robot()`
- `crates/robowbc-ort/src/wholebody_vla.rs`: add `joint_velocity_limits: None` to `test_robot()`

https://claude.ai/code/session_01XXq8YU7feAgYYBK6YUjrFM