### PR TITLE
feat: #15 — manylinux wheels, PyPI publish workflow, Python SDK docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,22 +53,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install stable Rust
-        uses: dtolnay/rust-toolchain@stable
-
-      - name: Cache cargo artifacts
-        uses: Swatinem/rust-cache@v2
-
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
-      - name: Install maturin
-        run: pip install "maturin>=1.4,<2.0"
-
-      - name: Build robowbc wheel
-        run: maturin build --out /tmp/robowbc-dist
+      - name: Build manylinux wheel
+        uses: PyO3/maturin-action@v1
+        with:
+          args: --release --out /tmp/robowbc-dist
+          manylinux: auto
 
       - name: Install robowbc wheel
         run: pip install /tmp/robowbc-dist/*.whl

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,59 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build manylinux wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          args: --release --out dist
+          manylinux: auto
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@v4
+        with:
+          name: wheels-linux
+          path: dist
+
+  sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist
+
+      - name: Upload sdist
+        uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist
+
+  publish:
+    runs-on: ubuntu-latest
+    needs: [linux, sdist]
+    environment: pypi
+    permissions:
+      id-token: write  # required for PyPI trusted publishing
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -7,6 +7,7 @@
 # User Guide
 
 - [Getting Started](getting-started.md)
+- [Python SDK](python-sdk.md)
 - [Configuration Reference](configuration.md)
 
 # Tutorials

--- a/docs/python-sdk.md
+++ b/docs/python-sdk.md
@@ -1,0 +1,163 @@
+# Python SDK
+
+RoboWBC ships a first-class Python SDK backed by the same Rust runtime.
+Install it from PyPI, load any registered policy by name, and call
+`policy.predict(obs)` — no Rust required.
+
+## Installation
+
+```bash
+pip install robowbc
+```
+
+Python 3.10 or later is required.
+The wheel is a native extension built for `manylinux2014` (glibc ≥ 2.17),
+which covers all modern Linux distributions used in robotics research.
+
+### Build from source
+
+```bash
+# Requires Rust stable ≥ 1.75 and maturin
+pip install "maturin>=1.4,<2.0"
+maturin develop          # installs an editable build into the current venv
+```
+
+## Quick start
+
+```python
+from robowbc import Registry, Observation
+
+# List all policies compiled into the wheel
+print(Registry.list_policies())
+# → ['bfm_zero', 'decoupled_wbc', 'gear_sonic', 'hover', 'wbc_agile', ...]
+
+# Load GEAR-SONIC from a TOML config file
+policy = Registry.build("gear_sonic", "configs/sonic_g1.toml")
+print(policy)                          # Policy(control_frequency_hz=50)
+print(policy.control_frequency_hz())  # 50
+
+# Build an observation for a Unitree G1 (23 DOF)
+obs = Observation(
+    joint_positions=[0.0] * 23,
+    joint_velocities=[0.0] * 23,
+    gravity_vector=[0.0, 0.0, -1.0],
+    command_type="motion_tokens",
+    command_data=[0.05, -0.1, 0.2, 0.0],
+)
+
+# Run one inference step
+targets = policy.predict(obs)
+print(targets.positions[:5])   # first 5 joint position targets (radians)
+```
+
+## API Reference
+
+### `Observation`
+
+Standardized sensor input passed to every policy.
+
+```python
+Observation(
+    joint_positions: list[float],   # current joint angles (radians)
+    joint_velocities: list[float],  # current joint velocities (rad/s)
+    gravity_vector: tuple[float, float, float],  # gravity in body frame
+    command_type: str,              # "velocity" | "motion_tokens" | "joint_targets"
+    command_data: list[float],      # payload — see table below
+)
+```
+
+**Command types:**
+
+| `command_type`    | `command_data` layout                              |
+|-------------------|----------------------------------------------------|
+| `"velocity"`      | `[vx, vy, vz, wx, wy, wz]` — 6 floats             |
+| `"motion_tokens"` | arbitrary-length token vector                      |
+| `"joint_targets"` | per-joint target positions                         |
+
+All fields are readable and writable attributes.
+
+### `JointPositionTargets`
+
+Return value of `Policy.predict`.
+
+| Attribute    | Type         | Description                                 |
+|--------------|--------------|---------------------------------------------|
+| `positions`  | `list[float]`| Per-joint target positions in radians.      |
+
+### `Policy`
+
+A loaded policy ready for inference. Obtain via `Registry`.
+
+| Method / Property            | Description                                    |
+|------------------------------|------------------------------------------------|
+| `predict(obs) → targets`     | Run one inference step.                        |
+| `control_frequency_hz() → int` | Required loop rate (typically 50 Hz).        |
+
+### `Registry`
+
+Factory for building registered policies.
+
+| Static method                                   | Description                               |
+|-------------------------------------------------|-------------------------------------------|
+| `Registry.list_policies() → list[str]`          | All compiled-in policy names.             |
+| `Registry.build(name, config_path) → Policy`    | Build from a robowbc TOML config file.    |
+| `Registry.build_from_str(toml_str) → Policy`    | Build from a TOML string.                 |
+
+## Examples
+
+### Config-driven policy switching
+
+```python
+from robowbc import Registry, Observation
+
+# Same observation, different policy — just change the config file
+for config in ["configs/sonic_g1.toml", "configs/decoupled_g1.toml"]:
+    policy = Registry.build("gear_sonic" if "sonic" in config else "decoupled_wbc", config)
+    print(f"{config}: {policy.control_frequency_hz()} Hz")
+```
+
+### 50 Hz control loop
+
+```python
+import time
+from robowbc import Registry, Observation
+
+policy = Registry.build("gear_sonic", "configs/sonic_g1.toml")
+dt = 1.0 / policy.control_frequency_hz()   # 0.02 s
+
+obs = Observation(
+    joint_positions=[0.0] * 23,
+    joint_velocities=[0.0] * 23,
+    gravity_vector=[0.0, 0.0, -1.0],
+    command_type="velocity",
+    command_data=[0.5, 0.0, 0.0, 0.0, 0.0, 0.3],
+)
+
+for _ in range(100):                        # 2 seconds at 50 Hz
+    t0 = time.perf_counter()
+    targets = policy.predict(obs)
+    elapsed = time.perf_counter() - t0
+    time.sleep(max(0.0, dt - elapsed))
+```
+
+A full runnable example is at `examples/python/gear_sonic_inference.py`.
+
+## Publishing new releases
+
+Wheels are built automatically on every `v*` tag via
+`.github/workflows/publish.yml`.  The workflow:
+
+1. Builds `manylinux2014` wheels via `PyO3/maturin-action`.
+2. Builds an sdist.
+3. Publishes everything to PyPI using [trusted publishing] (no API token
+   needed — configure the `pypi` GitHub environment in repo Settings →
+   Environments, then add the `miaodx/robowbc` publisher in your PyPI project).
+
+To cut a release:
+
+```bash
+git tag v0.2.0
+git push origin v0.2.0
+```
+
+[trusted publishing]: https://docs.pypi.org/trusted-publishers/


### PR DESCRIPTION
Closes #15

## Summary

- **Manylinux wheel CI**: upgrades the `python-sdk` CI job from a plain `maturin build` to `PyO3/maturin-action@v1` with `manylinux: auto`, so wheels are verified to be `manylinux2014`-compatible on every PR
- **PyPI publish workflow**: adds `.github/workflows/publish.yml` triggered on `v*` tags; builds `manylinux2014` wheels + sdist and publishes to PyPI using [trusted publishing](https://docs.pypi.org/trusted-publishers/) (no API token needed)
- **Python SDK docs**: adds `docs/python-sdk.md` — installation, API reference for `Observation`, `JointPositionTargets`, `Policy`, `Registry`, and two usage examples; linked from `SUMMARY.md`

## What remains before `pip install robowbc` works end-to-end

- [ ] In repo **Settings → Environments**, create a `pypi` environment
- [ ] On PyPI, configure a trusted publisher for `miaodx/robowbc` pointing at `publish.yml`
- [ ] Cut a release: `git tag v0.1.0 && git push origin v0.1.0`

## Test plan

- [x] `cargo check --workspace --all-targets` — passes
- [x] `cargo test --workspace --all-targets` — 8 tests pass, 0 failed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

https://claude.ai/code/session_01CJXvH9mhQbaeeXr1FLFF8H