### PR TITLE
docs: #17 — GR00T-WBC integration guide, LeRobot RFC, and blog post drafts

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -25,3 +25,12 @@
 
 - [Roadmap](roadmap-2026-q2.md)
 - [Ecosystem Strategy](ecosystem-strategy.md)
+
+# Community
+
+- [GR00T-WBC Integration Guide](community/groot-wbc-integration.md)
+- [LeRobot RFC](community/lerobot-rfc.md)
+- [Blog Post Drafts](community/blog-posts.md)
+- [Awesome List Submissions](community/awesome-submissions.md)
+- [Rust Community Outreach](community/rust-community.md)
+- [Academic Engagement](community/academic-engagement.md)

--- a/docs/community/blog-posts.md
+++ b/docs/community/blog-posts.md
@@ -1,0 +1,257 @@
+# Blog Post Drafts
+
+_Tracks issue [#17](https://github.com/MiaoDX/robowbc/issues/17) and [#47](https://github.com/MiaoDX/robowbc/issues/47)._
+_Two drafts: English for Medium / HuggingFace blog; Chinese for Zhihu / WeChat / SegmentFault._
+
+**Publish after:** GEAR-SONIC real model inference works (issue #37) and benchmark numbers are ready.
+
+---
+
+## Status
+
+| Channel | Status | Link |
+|---------|--------|------|
+| English — Medium draft | [ ] Not published | — |
+| English — HuggingFace blog draft | [ ] Not published | — |
+| English — Hacker News submission | [ ] Not submitted | — |
+| English — ROS Discourse cross-post | [ ] Not submitted | — |
+| Chinese — Zhihu draft | [ ] Not published | — |
+| Chinese — WeChat article | [ ] Not published | — |
+
+---
+
+## English Draft
+
+### Title
+
+> **Why Every Humanoid Team Rebuilds WBC Deployment from Scratch — and How to Stop**
+
+### Subtitle / deck
+
+> 30+ papers in 2025 shipped bespoke C++ control stacks for the same Unitree G1.
+> NVIDIA has four WBC implementations that still aren't unified.
+> Here's what a one-interface solution looks like.
+
+---
+
+We surveyed 30+ whole-body control (WBC) papers from 2025 that validated on real Unitree G1
+or H1 hardware. Every single one ships its own deployment stack: custom C++ inference code,
+custom ZMQ or ROS wrappers, custom TOML/YAML configs. None of them reuse each other's runtime.
+
+This isn't laziness. The researchers are world-class. It's a structural gap: there was no
+reusable WBC inference runtime to reach for.
+
+### The scale of the problem
+
+| Metric | 2025 | 2026 (projected) |
+|--------|------|-----------------|
+| Humanoid robots shipped | 14,500+ | 30,000+ |
+| G1/H1 WBC papers | 30+ | 8+ from ICLR 2026 alone |
+| Unified open-source WBC runtimes | **0** | — |
+
+NVIDIA alone has four WBC implementations: GEAR-SONIC, Decoupled WBC, HOVER, and WBC-AGILE.
+They are not unified. Switching from GEAR-SONIC to HOVER requires touching inference code,
+communication code, and config structure. Every team that deploys two models duplicates work.
+
+### What the models all have in common
+
+We analysed the output contract of 10 validated WBC implementations:
+
+| Property | Consensus |
+|----------|-----------|
+| Output type | Joint position PD targets |
+| Control frequency | 50 Hz (SoFTA: 100/50 Hz asymmetric) |
+| Input | Proprioception + SE3/velocity command |
+| Inference backend | ONNX Runtime or PyTorch |
+
+Every model takes the same input shape and produces the same output shape. The only thing
+that differs is the internal model architecture. This uniformity makes a thin abstraction
+layer both possible and **natural**.
+
+### The abstraction: one trait, many policies
+
+```rust
+pub trait WbcPolicy: Send + Sync {
+    fn predict(&self, obs: &Observation) -> Result<JointPositionTargets>;
+}
+```
+
+`Observation` encodes joint state + IMU + velocity command. `JointPositionTargets` is a
+fixed-length vector of position setpoints at 50 Hz. Every WBC model we've seen maps onto
+this contract.
+
+robowbc implements this trait for GEAR-SONIC, Decoupled WBC, HOVER, BFM-Zero, WholeBodyVLA,
+and WBC-AGILE. Switching models is a config change:
+
+```bash
+# GEAR-SONIC on G1
+cargo run --release --bin robowbc -- run --config configs/sonic_g1.toml
+
+# HOVER on H1 — same binary, different TOML
+cargo run --release --bin robowbc -- run --config configs/hover_h1.toml
+```
+
+No code changes. No recompilation.
+
+### Benchmarks
+
+[TBD — to be filled in after GEAR-SONIC real model inference is confirmed. Include:
+inference latency (μs), control loop jitter, comparison with reference C++ runtime.]
+
+| Metric | NVIDIA C++ | robowbc (Rust) |
+|--------|-----------|----------------|
+| GEAR-SONIC inference (p50) | TBD | TBD |
+| GEAR-SONIC inference (p99) | TBD | TBD |
+| Control loop @ 50 Hz jitter | TBD | TBD |
+
+### Python API
+
+For teams using LeRobot or other Python frameworks:
+
+```python
+import robowbc
+
+policy = robowbc.load("gear_sonic", config_path="configs/sonic_g1.toml")
+targets = policy.predict(observation)  # → JointPositionTargets at 50 Hz
+```
+
+`pip install robowbc` installs the Rust core as a compiled extension — no Rust toolchain
+needed at runtime.
+
+### What's next
+
+robowbc is in early development. The current priorities:
+
+1. **GEAR-SONIC real inference** — validate against NVIDIA's reference stack on real G1
+2. **Python SDK** — `pip install robowbc` on PyPI
+3. **LeRobot backend** — robowbc as an inference backend for `GrootLocomotionController`
+4. **Multi-embodiment** — Booster T1, Fourier GR-1, AGIBOT X2 via config-driven robot profiles
+
+The goal is for robowbc to be to WBC what LeRobot is to manipulation: one interface, every
+policy, config-driven switching.
+
+**GitHub:** https://github.com/MiaoDX/robowbc
+
+---
+
+## Chinese Draft
+
+### 标题
+
+> **为什么每个人形机器人团队都在重复造全身控制部署的轮子——以及如何终结这一现状**
+
+### 副标题
+
+> 2025 年超过 30 篇论文在 Unitree G1/H1 上做了全身控制实验，每篇都自己写了 C++ 部署代码。
+> NVIDIA 有四套 WBC 实现，至今没有统一。这是一个可以解决的问题。
+
+---
+
+我们调研了 2025 年 30 多篇在真实 Unitree G1 或 H1 上验证的全身控制（WBC）论文。每一篇都
+自带了一套部署栈：自定义 C++ 推理代码、自定义 ZMQ 或 ROS 封装、自定义配置文件格式。没有任
+何两篇论文复用同一套运行时。
+
+这不是研究者的问题。是结构性的空缺：**根本没有可以直接拿来用的统一 WBC 推理运行时**。
+
+### 问题的规模
+
+| 指标 | 2025 年 | 2026 年（预测） |
+|------|---------|----------------|
+| 人形机器人出货量 | 14,500+ | 30,000+ |
+| G1/H1 WBC 论文 | 30+ | 仅 ICLR 2026 就有 8+ |
+| 统一开源 WBC 运行时 | **0** | — |
+
+NVIDIA 自己就有四套 WBC 实现：GEAR-SONIC、Decoupled WBC、HOVER、WBC-AGILE。它们之间
+没有统一。从 GEAR-SONIC 切换到 HOVER，需要改推理代码、通信代码和配置结构。每个需要
+同时部署两个模型的团队都在重复同样的工作。
+
+### 这些模型的共同点
+
+我们分析了 10 个经过真机验证的 WBC 实现的输出契约：
+
+| 属性 | 共识 |
+|------|------|
+| 输出类型 | 关节位置 PD 目标 |
+| 控制频率 | 50 Hz（SoFTA：100/50 Hz 上下肢异步） |
+| 输入 | 本体感知 + SE3/速度指令 |
+| 推理后端 | ONNX Runtime 或 PyTorch |
+
+所有模型的输入输出形状完全一致。唯一的差异是内部模型架构。这种一致性使得一个薄抽象层
+既**可行**又**自然**。
+
+### 抽象层：一个 Trait，支持所有策略
+
+```rust
+pub trait WbcPolicy: Send + Sync {
+    fn predict(&self, obs: &Observation) -> Result<JointPositionTargets>;
+}
+```
+
+`Observation` 包含关节状态 + IMU + 速度指令。`JointPositionTargets` 是 50 Hz 的位置
+目标向量。我们见过的每个 WBC 模型都能映射到这个契约。
+
+robowbc 为 GEAR-SONIC、Decoupled WBC、HOVER、BFM-Zero、WholeBodyVLA 和 WBC-AGILE
+实现了这个 trait。切换模型只需改配置文件：
+
+```bash
+# G1 上运行 GEAR-SONIC
+cargo run --release --bin robowbc -- run --config configs/sonic_g1.toml
+
+# H1 上运行 HOVER —— 同一个二进制，换一个 TOML
+cargo run --release --bin robowbc -- run --config configs/hover_h1.toml
+```
+
+不改代码。不重新编译。
+
+### 性能基准
+
+[待填充——在 GEAR-SONIC 真实模型推理验证后补充。包含：推理延迟（μs）、控制循环抖动、
+与参考 C++ 运行时的对比。]
+
+| 指标 | NVIDIA C++ | robowbc（Rust） |
+|------|-----------|-----------------|
+| GEAR-SONIC 推理（p50） | 待测 | 待测 |
+| GEAR-SONIC 推理（p99） | 待测 | 待测 |
+| 50 Hz 控制循环抖动 | 待测 | 待测 |
+
+### Python API
+
+对于使用 LeRobot 或其他 Python 框架的团队：
+
+```python
+import robowbc
+
+policy = robowbc.load("gear_sonic", config_path="configs/sonic_g1.toml")
+targets = policy.predict(observation)  # → 50 Hz 关节位置目标
+```
+
+`pip install robowbc` 将 Rust 核心安装为编译好的扩展模块——运行时不需要 Rust 工具链。
+
+### 下一步
+
+robowbc 目前处于早期开发阶段。当前优先级：
+
+1. **GEAR-SONIC 真实推理** — 在真实 G1 上与 NVIDIA 参考栈对比验证
+2. **Python SDK** — `pip install robowbc` 发布到 PyPI
+3. **LeRobot 后端** — 将 robowbc 作为 `GrootLocomotionController` 的推理后端
+4. **多机体支持** — 通过配置驱动的机器人配置文件支持 Booster T1、Fourier GR-1、AGIBOT X2
+
+目标是让 robowbc 成为 WBC 领域的 LeRobot：一个接口，所有策略，配置切换。
+
+**GitHub:** https://github.com/MiaoDX/robowbc
+
+---
+
+## Publishing checklist
+
+When ready to publish (after GEAR-SONIC demo + benchmarks):
+
+- [ ] Fill in all benchmark tables with real numbers
+- [ ] Add screenshots or terminal output showing policy running
+- [ ] English: publish on Medium, then cross-post to HuggingFace blog
+- [ ] English: submit to Hacker News (`Show HN: robowbc — unified WBC inference runtime for humanoid robots`)
+- [ ] English: post on ROS Discourse (Rust/humanoid threads)
+- [ ] English: post on r/robotics and r/rust
+- [ ] Chinese: publish on Zhihu
+- [ ] Chinese: post in WeChat robotics communities (机器人学 公众号 groups)
+- [ ] Tag GEAR-SONIC / HOVER / BFM-Zero authors on social media

--- a/docs/community/groot-wbc-integration.md
+++ b/docs/community/groot-wbc-integration.md
@@ -1,0 +1,204 @@
+# GR00T-WholeBodyControl Integration Guide
+
+_Tracks issue [#17](https://github.com/MiaoDX/robowbc/issues/17). Ready-to-submit PR content for [NVlabs/GR00T-WholeBodyControl](https://github.com/NVlabs/GR00T-WholeBodyControl)._
+
+---
+
+## Status
+
+| Item | Status | Link / Notes |
+|------|--------|--------------|
+| GEAR-SONIC inference working locally | [ ] | Requires real model checkpoints (#37) |
+| Benchmark vs NVIDIA C++ runtime measured | [ ] | See `docs/benchmarks/` |
+| GR00T-WBC community discussion opened | [ ] | — |
+| Integration guide PR submitted | [ ] | — |
+
+Update this table with the PR URL once submitted.
+
+---
+
+## What to submit
+
+Open a PR to `NVlabs/GR00T-WholeBodyControl` that adds `docs/robowbc-integration.md`
+to their repository. The PR should be framed as a community contribution — a technical
+guide showing users how to run GEAR-SONIC models through robowbc, not a competing project.
+
+**Tone:** contributor, not promoter. Show working code and benchmarks first.
+
+---
+
+## PR title
+
+```
+docs: add robowbc integration guide (Rust unified WBC inference runtime)
+```
+
+## PR body
+
+```markdown
+## Summary
+
+This PR adds a community integration guide for [robowbc](https://github.com/MiaoDX/robowbc),
+an open-source Rust-based inference runtime that wraps GEAR-SONIC, Decoupled WBC, HOVER, and
+WBC-AGILE behind a single unified `WbcPolicy` trait.
+
+The guide shows GR00T-WholeBodyControl users how to run NVIDIA's models through robowbc
+for config-driven multi-model switching and a single deployment binary.
+
+**Why this is useful for GR00T-WholeBodyControl users:**
+- One config swap to switch between GEAR-SONIC, Decoupled WBC, HOVER, and WBC-AGILE
+- ONNX Runtime backend with TensorRT execution provider (same as NVIDIA's own stack)
+- Rust binary with no Python dependency at inference time
+- Zenoh transport bridges DDS, ZMQ, and ROS2 without reconfiguring the robot
+
+**What I tested:** GEAR-SONIC inference on [hardware/sim TBD] with matching latency benchmarks
+vs the reference C++ runtime.
+```
+
+---
+
+## Content: `docs/robowbc-integration.md`
+
+The file below is what the PR would add to `NVlabs/GR00T-WholeBodyControl`.
+
+---
+
+```markdown
+# RoboWBC Integration Guide
+
+[robowbc](https://github.com/MiaoDX/robowbc) is a community-contributed Rust inference runtime
+that runs GEAR-SONIC, Decoupled WBC, HOVER, and WBC-AGILE through one unified interface.
+It is not an NVIDIA product.
+
+## Why use robowbc with GR00T-WholeBodyControl models
+
+| Feature | NVIDIA C++ runtime | robowbc |
+|---------|-------------------|---------|
+| Language | C++ | Rust (+ Python bindings) |
+| Model support | Single model per binary | Config-driven multi-model switching |
+| Backend | ONNX Runtime | ONNX Runtime + TensorRT (same) |
+| Communication | ZMQ | Zenoh (bridges DDS, ZMQ, ROS2) |
+| Python API | No | Yes — `pip install robowbc` |
+
+## Supported models
+
+| Model | robowbc wrapper | Status |
+|-------|----------------|--------|
+| GEAR-SONIC | `GearSonicPolicy` | Supported |
+| Decoupled WBC | `DecoupledWbcPolicy` | Supported |
+| HOVER | `HoverPolicy` | Supported |
+| WBC-AGILE | `WbcAgilePolicy` | Supported |
+
+## Quick start
+
+### Prerequisites
+
+- Rust 1.75+ (`rustup update stable`)
+- ONNX Runtime 1.19 libraries
+- GEAR-SONIC ONNX checkpoints (see below)
+
+### Download GEAR-SONIC checkpoints
+
+```bash
+git clone https://github.com/MiaoDX/robowbc
+cd robowbc
+bash scripts/download_gear_sonic_models.sh
+# Downloads model_encoder.onnx, model_decoder.onnx, planner_sonic.onnx
+# into models/gear-sonic/
+```
+
+### Run GEAR-SONIC inference
+
+```bash
+cargo run --release --bin robowbc -- run --config configs/sonic_g1.toml
+```
+
+The control loop runs at 50 Hz and prints joint position targets for the G1's 29 DOF.
+
+### Switch to Decoupled WBC (no config code change)
+
+```bash
+cargo run --release --bin robowbc -- run --config configs/decoupled_g1.toml
+```
+
+### Python API
+
+```python
+import robowbc
+
+policy = robowbc.load("gear_sonic", config_path="configs/sonic_g1.toml")
+
+observation = robowbc.Observation(
+    joint_positions=[0.0] * 29,
+    joint_velocities=[0.0] * 29,
+    base_linear_velocity=[0.0, 0.0, 0.0],
+    base_angular_velocity=[0.0, 0.0, 0.0],
+    projected_gravity=[0.0, 0.0, -1.0],
+    command=[0.0, 0.0, 0.0],
+)
+
+targets = policy.predict(observation)
+print(targets.positions)   # 29 joint position targets at 50 Hz
+```
+
+## Architecture
+
+robowbc wraps GEAR-SONIC's three-model pipeline (encoder → planner → decoder) inside a
+single `WbcPolicy::predict()` call. The ONNX Runtime backend is used identically to the
+reference C++ runtime — same model files, same execution providers.
+
+```
+Observation → GearSonicPolicy::predict()
+                ├─ model_encoder.onnx  (proprioception → latent)
+                ├─ planner_sonic.onnx  (latent + command → plan)
+                └─ model_decoder.onnx  (plan → joint targets)
+             → JointPositionTargets (29 DOF, 50 Hz)
+```
+
+## Benchmarks
+
+Run the robowbc benchmark suite:
+
+```bash
+cargo bench --bench inference_latency
+```
+
+See [robowbc benchmarks](https://github.com/MiaoDX/robowbc/tree/main/docs/benchmarks) for
+end-to-end latency comparisons.
+
+## Configuration reference
+
+`configs/sonic_g1.toml`:
+
+```toml
+[policy]
+name = "gear_sonic"
+
+[policy.model]
+encoder = "models/gear-sonic/model_encoder.onnx"
+decoder = "models/gear-sonic/model_decoder.onnx"
+planner  = "models/gear-sonic/planner_sonic.onnx"
+
+[robot]
+name = "unitree_g1"
+dof  = 29
+
+[runtime]
+frequency_hz = 50
+```
+
+## More information
+
+- Repository: https://github.com/MiaoDX/robowbc
+- Getting Started: https://github.com/MiaoDX/robowbc/blob/main/docs/getting-started.md
+- Architecture: https://github.com/MiaoDX/robowbc/blob/main/docs/architecture.md
+- Issues / questions: https://github.com/MiaoDX/robowbc/issues
+```
+
+---
+
+## When to submit
+
+Submit the PR after GEAR-SONIC real model inference is confirmed working end-to-end
+(issue #37). Include benchmark numbers in the PR body — NVIDIA engineers respond to
+working code and concrete numbers.

--- a/docs/community/lerobot-rfc.md
+++ b/docs/community/lerobot-rfc.md
@@ -1,0 +1,174 @@
+# LeRobot WBC Backend Integration — RFC
+
+_Tracks issue [#17](https://github.com/MiaoDX/robowbc/issues/17). RFC/proposal ready to submit to [huggingface/lerobot](https://github.com/huggingface/lerobot)._
+
+---
+
+## Status
+
+| Item | Status | Link / Notes |
+|------|--------|--------------|
+| `pip install robowbc` confirmed working | [ ] | Requires #15 |
+| LeRobot v0.5+ interface verified | [ ] | `HolosomaLocomotionController`, `GrootLocomotionController` |
+| Adapter prototype built | [ ] | See interface mapping below |
+| RFC issue opened in LeRobot | [ ] | — |
+| PR or plugin submitted | [ ] | — |
+
+Update this table with issue/PR URLs once submitted.
+
+---
+
+## What to submit
+
+Open a GitHub issue in `huggingface/lerobot` proposing robowbc as a WBC execution backend.
+Frame it as an RFC asking for feedback on the interface mapping, not a feature request that
+LeRobot must implement. A discussion issue is lower friction than a PR for first contact.
+
+**If a PR is preferred:** the PR would add a `robowbc_backend.py` adapter in LeRobot's
+existing WBC controller directory, converting LeRobot's controller interface to robowbc's
+Python API.
+
+---
+
+## Issue title
+
+```
+RFC: robowbc as a unified WBC inference backend for HolosomaLocomotionController / GrootLocomotionController
+```
+
+## Issue body
+
+```markdown
+## Motivation
+
+LeRobot v0.5+ ships `HolosomaLocomotionController` and `GrootLocomotionController`, both of
+which output joint position PD targets at 50 Hz. Today each controller bundles its own
+inference code (Python + PyTorch).
+
+[robowbc](https://github.com/MiaoDX/robowbc) is an open-source Rust inference runtime that
+runs GEAR-SONIC, HOVER, BFM-Zero, WholeBodyVLA, and WBC-AGILE through one unified `WbcPolicy`
+trait. Its Python API (`pip install robowbc`) already matches the calling convention of LeRobot's
+WBC controllers.
+
+## The interface mapping
+
+LeRobot `GrootLocomotionController.step(obs_dict) → action_dict` maps directly to
+robowbc `Policy.predict(Observation) → JointPositionTargets`:
+
+| LeRobot | robowbc |
+|---------|---------|
+| `obs_dict["observation.state"]` (joint positions) | `Observation.joint_positions` |
+| `obs_dict["observation.velocity"]` (joint velocities) | `Observation.joint_velocities` |
+| `obs_dict["observation.imu"]` (gravity, angular vel) | `Observation.{projected_gravity, base_angular_velocity}` |
+| `obs_dict["observation.task_cmd"]` (velocity command) | `Observation.command` |
+| `action_dict["action"]` (joint position targets) | `JointPositionTargets.positions` |
+
+## Proposed adapter
+
+```python
+# lerobot/common/robot_devices/controllers/robowbc_backend.py
+import robowbc
+from lerobot.common.robot_devices.controllers.base import BaseLocomotionController
+
+class RobowbcController(BaseLocomotionController):
+    """Dispatch WBC inference to robowbc (Rust, ONNX Runtime, 50 Hz)."""
+
+    def __init__(self, config_path: str):
+        self._policy = robowbc.load_from_config(config_path)
+
+    def step(self, obs_dict: dict) -> dict:
+        obs = robowbc.Observation(
+            joint_positions=obs_dict["observation.state"].tolist(),
+            joint_velocities=obs_dict["observation.velocity"].tolist(),
+            projected_gravity=obs_dict["observation.imu"][:3].tolist(),
+            base_angular_velocity=obs_dict["observation.imu"][3:6].tolist(),
+            base_linear_velocity=[0.0, 0.0, 0.0],
+            command=obs_dict["observation.task_cmd"].tolist(),
+        )
+        targets = self._policy.predict(obs)
+        return {"action": targets.positions}
+```
+
+## Why this benefits LeRobot users
+
+1. **Multi-model switching:** swap between GEAR-SONIC, HOVER, BFM-Zero via one TOML config,
+   no code changes
+2. **Lower latency:** Rust ONNX Runtime backend vs pure Python; no GIL overhead at 50 Hz
+3. **G1 out of the box:** `configs/sonic_g1.toml` targets the Unitree G1 — the same
+   hardware as LeRobot's own G1 tutorials
+4. **Maintained separately:** robowbc tracks NVIDIA model releases independently, so
+   LeRobot doesn't need to keep up with each NVIDIA checkpoint format change
+
+## Questions for LeRobot maintainers
+
+1. Is an adapter in `lerobot/common/robot_devices/controllers/` the right location?
+2. Does LeRobot prefer an optional dependency (`pip install lerobot[robowbc]`) or a
+   separate package (`pip install lerobot-robowbc`)?
+3. Are there API stability guarantees on `GrootLocomotionController` that an adapter
+   should track?
+
+## References
+
+- robowbc repo: https://github.com/MiaoDX/robowbc
+- robowbc Python API docs: https://github.com/MiaoDX/robowbc/blob/main/docs/python-sdk.md
+- LeRobot G1 docs: https://huggingface.co/docs/lerobot/unitree_g1
+```
+
+---
+
+## When to submit
+
+Submit after `pip install robowbc` works end-to-end (issue #15). A working Python package
+is the minimum bar — the LeRobot team needs to be able to `pip install robowbc` and
+run the adapter prototype to evaluate the proposal.
+
+---
+
+## Adapter prototype (local development)
+
+For local testing before submission, place the adapter at
+`crates/robowbc-py/examples/lerobot_adapter.py`:
+
+```python
+"""
+Prototype: robowbc as a WBC backend for LeRobot.
+
+Usage:
+    pip install robowbc
+    python lerobot_adapter.py --config configs/sonic_g1.toml
+"""
+import argparse
+import numpy as np
+import robowbc
+
+def run(config_path: str, steps: int = 100) -> None:
+    policy = robowbc.load_from_config(config_path)
+    dof = 29  # Unitree G1
+
+    for step in range(steps):
+        # Simulate obs_dict as LeRobot would provide it
+        obs_dict = {
+            "observation.state":    np.zeros(dof, dtype=np.float32),
+            "observation.velocity": np.zeros(dof, dtype=np.float32),
+            "observation.imu":      np.array([0.0, 0.0, -1.0, 0.0, 0.0, 0.0], dtype=np.float32),
+            "observation.task_cmd": np.array([0.3, 0.0, 0.0], dtype=np.float32),
+        }
+        obs = robowbc.Observation(
+            joint_positions=obs_dict["observation.state"].tolist(),
+            joint_velocities=obs_dict["observation.velocity"].tolist(),
+            projected_gravity=obs_dict["observation.imu"][:3].tolist(),
+            base_angular_velocity=obs_dict["observation.imu"][3:6].tolist(),
+            base_linear_velocity=[0.0, 0.0, 0.0],
+            command=obs_dict["observation.task_cmd"].tolist(),
+        )
+        targets = policy.predict(obs)
+        if step % 10 == 0:
+            print(f"step {step:3d}: targets[0:3] = {targets.positions[:3]}")
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config", default="configs/sonic_g1.toml")
+    parser.add_argument("--steps", type=int, default=100)
+    args = parser.parse_args()
+    run(args.config, args.steps)
+```


### PR DESCRIPTION
Closes #17

## Summary

- **`docs/community/groot-wbc-integration.md`** — ready-to-submit PR content for `NVlabs/GR00T-WholeBodyControl`. Includes a PR title + body template and the full `docs/robowbc-integration.md` file that would be added to their repo, covering supported models, quick-start commands, Python API example, architecture diagram, and TOML config reference.

- **`docs/community/lerobot-rfc.md`** — RFC issue body for `huggingface/lerobot` proposing robowbc as a WBC inference backend. Includes explicit interface mapping from LeRobot's `HolosomaLocomotionController` / `GrootLocomotionController` to robowbc's `Observation` / `JointPositionTargets`, a self-contained `RobowbcController` adapter class, questions for LeRobot maintainers, and a local prototype script.

- **`docs/community/blog-posts.md`** — complete English and Chinese drafts of "Why Every Humanoid Team Rebuilds WBC Deployment from Scratch", with data table, abstraction explanation, benchmark placeholder tables, and a publishing checklist for Medium, HuggingFace blog, Hacker News, ROS Discourse, Zhihu, and WeChat.

- **`docs/SUMMARY.md`** — adds a Community section linking all six community docs (new + existing).

## What remains before submitting upstream

- [ ] GEAR-SONIC real model inference confirmed working (issue #37) — needed for benchmarks
- [ ] `pip install robowbc` working (issue #15) — needed before LeRobot RFC
- [ ] Fill benchmark tables in `blog-posts.md` with real numbers
- [ ] Manually submit the GR00T-WBC PR and LeRobot RFC issue (external repos, requires human action)

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] No Rust code changed; docs only

https://claude.ai/code/session_014UeW8xktH8ddHxNDmZR93u