### PR TITLE
feat: #41 — LeRobot WBC backend adapter (RoboWBCController + load_from_config)

### DIFF
--- a/crates/robowbc-py/examples/lerobot_adapter.py
+++ b/crates/robowbc-py/examples/lerobot_adapter.py
@@ -1,0 +1,254 @@
+"""robowbc as a WBC backend for LeRobot.
+
+Implements a ``RoboWBCController`` class that wraps robowbc's ``Policy``
+in a LeRobot-compatible locomotion controller interface::
+
+    controller.step(obs_dict) -> action_dict
+
+LeRobot's ``GrootLocomotionController`` and ``HolosomaLocomotionController``
+share this interface — ``step`` receives a flat observation dict and returns
+an action dict with ``"action"`` (joint position targets).
+
+Interface mapping
+-----------------
+
++-------------------------------------+------------------------------------------+
+| LeRobot ``obs_dict`` key            | robowbc ``Observation`` field            |
++=====================================+==========================================+
+| ``observation.state``               | ``joint_positions``                      |
++-------------------------------------+------------------------------------------+
+| ``observation.velocity``            | ``joint_velocities``                     |
++-------------------------------------+------------------------------------------+
+| ``observation.imu[:3]``             | ``gravity_vector``                       |
++-------------------------------------+------------------------------------------+
+| ``observation.task_cmd``            | ``command_data`` (``command_type="velocity"``) |
++-------------------------------------+------------------------------------------+
+| ``action_dict["action"]``           | ``JointPositionTargets.positions``       |
++-------------------------------------+------------------------------------------+
+
+Velocity command convention
+---------------------------
+LeRobot passes ``observation.task_cmd`` as ``[vx, vy, omega]`` (3 floats).
+robowbc's ``"velocity"`` command type expects ``[vx, vy, vz, wx, wy, wz]``
+(6 floats).  The adapter pads the missing axes with zero:
+``[vx, vy, 0.0, 0.0, 0.0, omega]``.
+
+Usage
+-----
+::
+
+    pip install robowbc
+    python lerobot_adapter.py --config configs/sonic_g1.toml
+
+Without the real GEAR-SONIC ONNX models the policy raises ``RuntimeError``
+at load time.  Use any other registered policy (e.g. ``decoupled_g1.toml``)
+for a quick smoke-test.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any
+
+try:
+    import robowbc
+except ImportError:
+    print("robowbc is not installed.  Run: maturin develop", file=sys.stderr)
+    sys.exit(1)
+
+try:
+    import numpy as np
+    _HAS_NUMPY = True
+except ImportError:
+    _HAS_NUMPY = False
+
+
+class RoboWBCController:
+    """Dispatch WBC inference to robowbc (Rust, ONNX Runtime, 50 Hz).
+
+    Parameters
+    ----------
+    config_path:
+        Path to a robowbc TOML config file.  The file must contain a
+        ``[policy]`` table with a ``name`` field.
+
+    Examples
+    --------
+    Standalone (no LeRobot install required):
+
+    >>> import numpy as np
+    >>> ctrl = RoboWBCController("configs/sonic_g1.toml")
+    >>> obs = {
+    ...     "observation.state":    [0.0] * 29,
+    ...     "observation.velocity": [0.0] * 29,
+    ...     "observation.imu":      [0.0, 0.0, -1.0, 0.0, 0.0, 0.0],
+    ...     "observation.task_cmd": [0.3, 0.0, 0.0],
+    ... }
+    >>> action = ctrl.step(obs)
+    >>> len(action["action"])
+    29
+
+    As a drop-in for LeRobot's ``GrootLocomotionController``:
+
+    >>> # In LeRobot robot code:
+    >>> # from robowbc_lerobot import RoboWBCController
+    >>> # controller = RoboWBCController("configs/sonic_g1.toml")
+    >>> # action = controller.step(obs_dict)
+    """
+
+    def __init__(self, config_path: str) -> None:
+        self._policy = robowbc.load_from_config(config_path)
+
+    # ------------------------------------------------------------------
+    # LeRobot locomotion controller interface
+    # ------------------------------------------------------------------
+
+    def step(self, obs_dict: dict[str, Any]) -> dict[str, list[float]]:
+        """Run one inference step and return joint position targets.
+
+        Parameters
+        ----------
+        obs_dict:
+            Observation dictionary with LeRobot-convention keys.  Expected
+            keys and shapes:
+
+            * ``"observation.state"``    — joint positions  (``[n_joints]``)
+            * ``"observation.velocity"`` — joint velocities (``[n_joints]``)
+            * ``"observation.imu"``      — ``[gx, gy, gz, wx, wy, wz]`` where
+              the first three elements are the projected gravity vector and the
+              last three are base angular velocity.
+            * ``"observation.task_cmd"`` — velocity command ``[vx, vy, omega]``
+              or ``[vx, vy, vz, wx, wy, wz]``.
+
+            Values may be plain Python sequences or numpy arrays.
+
+        Returns
+        -------
+        dict
+            ``{"action": list[float]}`` — per-joint position targets in
+            radians, matching the order in the loaded robot config.
+        """
+        imu = obs_dict["observation.imu"]
+        cmd = obs_dict["observation.task_cmd"]
+
+        # Gravity vector: projected_gravity is imu[:3].
+        gravity = [float(imu[0]), float(imu[1]), float(imu[2])]
+
+        # Velocity command: expand [vx, vy, omega] → [vx, vy, vz, wx, wy, wz].
+        cmd_list = [float(v) for v in cmd]
+        if len(cmd_list) == 3:
+            # LeRobot convention: [forward, lateral, yaw_rate]
+            cmd_6 = [cmd_list[0], cmd_list[1], 0.0, 0.0, 0.0, cmd_list[2]]
+        elif len(cmd_list) == 6:
+            cmd_6 = cmd_list
+        else:
+            raise ValueError(
+                f"observation.task_cmd must have 3 or 6 elements, got {len(cmd_list)}"
+            )
+
+        obs = robowbc.Observation(
+            joint_positions=[float(v) for v in obs_dict["observation.state"]],
+            joint_velocities=[float(v) for v in obs_dict["observation.velocity"]],
+            gravity_vector=(gravity[0], gravity[1], gravity[2]),
+            command_type="velocity",
+            command_data=cmd_6,
+        )
+        targets = self._policy.predict(obs)
+        return {"action": targets.positions}
+
+    def reset(self) -> None:
+        """Reset controller state.
+
+        robowbc policies are stateless between steps — this is a no-op kept
+        for interface compatibility with LeRobot's ``BaseLocomotionController``.
+        """
+
+    # ------------------------------------------------------------------
+    # Informational
+    # ------------------------------------------------------------------
+
+    def control_frequency_hz(self) -> int:
+        """Return the required control loop frequency in Hz (typically 50)."""
+        return self._policy.control_frequency_hz()
+
+    def __repr__(self) -> str:
+        return f"RoboWBCController(control_frequency_hz={self.control_frequency_hz()})"
+
+
+# ---------------------------------------------------------------------------
+# Standalone demo (no LeRobot install required)
+# ---------------------------------------------------------------------------
+
+def _make_synthetic_obs(n_joints: int, step: int = 0) -> dict[str, Any]:
+    """Build a synthetic obs_dict as LeRobot would provide it."""
+    if _HAS_NUMPY:
+        state = np.zeros(n_joints, dtype=np.float32)
+        vel   = np.zeros(n_joints, dtype=np.float32)
+        imu   = np.array([0.0, 0.0, -1.0, 0.0, 0.0, 0.0], dtype=np.float32)
+        cmd   = np.array([0.3 if step < 50 else -0.2, 0.0, 0.0], dtype=np.float32)
+    else:
+        state = [0.0] * n_joints
+        vel   = [0.0] * n_joints
+        imu   = [0.0, 0.0, -1.0, 0.0, 0.0, 0.0]
+        cmd   = [0.3 if step < 50 else -0.2, 0.0, 0.0]
+
+    return {
+        "observation.state":    state,
+        "observation.velocity": vel,
+        "observation.imu":      imu,
+        "observation.task_cmd": cmd,
+    }
+
+
+def run(config_path: str, n_joints: int = 29, steps: int = 100) -> None:
+    """Load a policy and run the demo control loop."""
+    print(f"Loading policy from {config_path!r} …")
+    try:
+        ctrl = RoboWBCController(config_path)
+    except RuntimeError as exc:
+        print(f"Could not load policy: {exc}", file=sys.stderr)
+        print(
+            "Tip: download GEAR-SONIC ONNX models to models/gear-sonic/ "
+            "or point at a config with mock models.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print(f"Loaded: {ctrl!r}")
+    print(f"Running {steps}-step control loop …\n")
+
+    for step in range(steps):
+        obs = _make_synthetic_obs(n_joints, step)
+        action = ctrl.step(obs)
+        if step % 10 == 0:
+            targets = action["action"]
+            preview = ", ".join(f"{v:.4f}" for v in targets[:3])
+            print(f"  step {step:3d}: targets[0:3] = [{preview}]")
+
+    print("\nDone.")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Demonstrate robowbc as a LeRobot WBC backend."
+    )
+    parser.add_argument(
+        "--config",
+        default="configs/sonic_g1.toml",
+        help="Path to a robowbc TOML config file (default: configs/sonic_g1.toml)",
+    )
+    parser.add_argument(
+        "--joints",
+        type=int,
+        default=29,
+        help="Number of joints for the synthetic observation (default: 29 for G1)",
+    )
+    parser.add_argument(
+        "--steps",
+        type=int,
+        default=100,
+        help="Number of control loop steps to run (default: 100)",
+    )
+    args = parser.parse_args()
+    run(args.config, args.joints, args.steps)

--- a/crates/robowbc-py/src/lib.rs
+++ b/crates/robowbc-py/src/lib.rs
@@ -53,6 +53,46 @@ use robowbc_registry::WbcRegistry;
 use std::sync::Arc;
 use std::time::Instant;
 
+/// Load a [`Policy`] from a robowbc TOML config file.
+///
+/// Convenience wrapper around :meth:`Registry.build_from_str` that reads
+/// the config file for you.  The TOML file must contain a ``[policy]`` table
+/// with a ``name`` field and an optional ``[policy.config]`` subsection.
+///
+/// Parameters
+/// ----------
+/// config_path : str
+///     Path to the robowbc TOML config file (e.g. ``"configs/sonic_g1.toml"``).
+///
+/// Returns
+/// -------
+/// Policy
+///     A policy instance ready for inference.
+///
+/// Raises
+/// ------
+/// RuntimeError
+///     If the file cannot be read, parsed, or the policy cannot be built.
+///
+/// Examples
+/// --------
+/// ```python
+/// import robowbc
+/// policy = robowbc.load_from_config("configs/sonic_g1.toml")
+/// print(policy.control_frequency_hz())  # 50
+/// ```
+#[pyfunction]
+fn load_from_config(config_path: &str) -> PyResult<PyPolicy> {
+    let content = std::fs::read_to_string(config_path).map_err(|e| {
+        PyRuntimeError::new_err(format!("cannot read config file {config_path:?}: {e}"))
+    })?;
+    let policy = WbcRegistry::build_from_toml_str(&content)
+        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+    Ok(PyPolicy {
+        inner: Arc::from(policy),
+    })
+}
+
 /// Standardized sensor input for a WBC policy.
 ///
 /// Parameters
@@ -316,5 +356,6 @@ fn robowbc(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<PyJointPositionTargets>()?;
     m.add_class::<PyPolicy>()?;
     m.add_class::<PyRegistry>()?;
+    m.add_function(wrap_pyfunction!(load_from_config, m)?)?;
     Ok(())
 }

--- a/docs/community/lerobot-rfc.md
+++ b/docs/community/lerobot-rfc.md
@@ -8,9 +8,9 @@ _Tracks issue [#17](https://github.com/MiaoDX/robowbc/issues/17). RFC/proposal r
 
 | Item | Status | Link / Notes |
 |------|--------|--------------|
-| `pip install robowbc` confirmed working | [ ] | Requires #15 |
-| LeRobot v0.5+ interface verified | [ ] | `HolosomaLocomotionController`, `GrootLocomotionController` |
-| Adapter prototype built | [ ] | See interface mapping below |
+| `pip install robowbc` confirmed working | [x] | Done in #15 / #39 |
+| LeRobot v0.5+ interface verified | [x] | `HolosomaLocomotionController`, `GrootLocomotionController` — same `step(obs_dict)→action_dict` contract |
+| Adapter prototype built | [x] | `crates/robowbc-py/examples/lerobot_adapter.py` — `RoboWBCController` class |
 | RFC issue opened in LeRobot | [ ] | — |
 | PR or plugin submitted | [ ] | — |
 
@@ -77,13 +77,16 @@ class RobowbcController(BaseLocomotionController):
         self._policy = robowbc.load_from_config(config_path)
 
     def step(self, obs_dict: dict) -> dict:
+        imu = obs_dict["observation.imu"]
+        # LeRobot task_cmd: [vx, vy, omega] → robowbc velocity: [vx, vy, vz, wx, wy, wz]
+        cmd = obs_dict["observation.task_cmd"].tolist()
+        cmd_6 = [cmd[0], cmd[1], 0.0, 0.0, 0.0, cmd[2]] if len(cmd) == 3 else cmd
         obs = robowbc.Observation(
             joint_positions=obs_dict["observation.state"].tolist(),
             joint_velocities=obs_dict["observation.velocity"].tolist(),
-            projected_gravity=obs_dict["observation.imu"][:3].tolist(),
-            base_angular_velocity=obs_dict["observation.imu"][3:6].tolist(),
-            base_linear_velocity=[0.0, 0.0, 0.0],
-            command=obs_dict["observation.task_cmd"].tolist(),
+            gravity_vector=(float(imu[0]), float(imu[1]), float(imu[2])),
+            command_type="velocity",
+            command_data=cmd_6,
         )
         targets = self._policy.predict(obs)
         return {"action": targets.positions}
@@ -118,57 +121,48 @@ class RobowbcController(BaseLocomotionController):
 
 ## When to submit
 
-Submit after `pip install robowbc` works end-to-end (issue #15). A working Python package
-is the minimum bar — the LeRobot team needs to be able to `pip install robowbc` and
-run the adapter prototype to evaluate the proposal.
+`pip install robowbc` works end-to-end (issue #15 / #39 done) and the adapter
+prototype at `crates/robowbc-py/examples/lerobot_adapter.py` is ready.  The
+remaining blocker is **real GEAR-SONIC model inference** (issue A) — the LeRobot
+team needs a working demo they can run, not just a code sketch.  Submit after
+`robowbc run --config configs/sonic_g1.toml` produces real joint targets.
 
 ---
 
 ## Adapter prototype (local development)
 
-For local testing before submission, place the adapter at
-`crates/robowbc-py/examples/lerobot_adapter.py`:
+The adapter prototype is at `crates/robowbc-py/examples/lerobot_adapter.py`.
+It provides a `RoboWBCController` class and a standalone demo loop (no LeRobot
+install required):
+
+```bash
+pip install robowbc        # or: maturin develop
+python crates/robowbc-py/examples/lerobot_adapter.py --config configs/sonic_g1.toml
+```
+
+Abbreviated adapter (see the file for full docstring and numpy/list handling):
 
 ```python
-"""
-Prototype: robowbc as a WBC backend for LeRobot.
-
-Usage:
-    pip install robowbc
-    python lerobot_adapter.py --config configs/sonic_g1.toml
-"""
-import argparse
-import numpy as np
 import robowbc
 
-def run(config_path: str, steps: int = 100) -> None:
-    policy = robowbc.load_from_config(config_path)
-    dof = 29  # Unitree G1
+class RoboWBCController:
+    def __init__(self, config_path: str) -> None:
+        self._policy = robowbc.load_from_config(config_path)
 
-    for step in range(steps):
-        # Simulate obs_dict as LeRobot would provide it
-        obs_dict = {
-            "observation.state":    np.zeros(dof, dtype=np.float32),
-            "observation.velocity": np.zeros(dof, dtype=np.float32),
-            "observation.imu":      np.array([0.0, 0.0, -1.0, 0.0, 0.0, 0.0], dtype=np.float32),
-            "observation.task_cmd": np.array([0.3, 0.0, 0.0], dtype=np.float32),
-        }
+    def step(self, obs_dict: dict) -> dict:
+        imu = obs_dict["observation.imu"]
+        cmd = [float(v) for v in obs_dict["observation.task_cmd"]]
+        # [vx, vy, omega] → [vx, vy, vz, wx, wy, wz]
+        cmd_6 = [cmd[0], cmd[1], 0.0, 0.0, 0.0, cmd[2]] if len(cmd) == 3 else cmd
         obs = robowbc.Observation(
-            joint_positions=obs_dict["observation.state"].tolist(),
-            joint_velocities=obs_dict["observation.velocity"].tolist(),
-            projected_gravity=obs_dict["observation.imu"][:3].tolist(),
-            base_angular_velocity=obs_dict["observation.imu"][3:6].tolist(),
-            base_linear_velocity=[0.0, 0.0, 0.0],
-            command=obs_dict["observation.task_cmd"].tolist(),
+            joint_positions=[float(v) for v in obs_dict["observation.state"]],
+            joint_velocities=[float(v) for v in obs_dict["observation.velocity"]],
+            gravity_vector=(float(imu[0]), float(imu[1]), float(imu[2])),
+            command_type="velocity",
+            command_data=cmd_6,
         )
-        targets = policy.predict(obs)
-        if step % 10 == 0:
-            print(f"step {step:3d}: targets[0:3] = {targets.positions[:3]}")
+        return {"action": self._policy.predict(obs).positions}
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--config", default="configs/sonic_g1.toml")
-    parser.add_argument("--steps", type=int, default=100)
-    args = parser.parse_args()
-    run(args.config, args.steps)
+    def reset(self) -> None:
+        pass  # stateless policy — no-op
 ```

--- a/docs/python-sdk.md
+++ b/docs/python-sdk.md
@@ -142,6 +142,43 @@ for _ in range(100):                        # 2 seconds at 50 Hz
 
 A full runnable example is at `examples/python/gear_sonic_inference.py`.
 
+## LeRobot integration
+
+robowbc can act as a drop-in WBC inference backend for LeRobot's
+`GrootLocomotionController` and `HolosomaLocomotionController`.  Both
+controllers share a `step(obs_dict) → action_dict` interface that maps
+directly to robowbc's `Policy.predict`.
+
+A standalone `RoboWBCController` adapter is provided in
+`crates/robowbc-py/examples/lerobot_adapter.py`:
+
+```python
+from lerobot_adapter import RoboWBCController
+
+# Load any robowbc policy via TOML config — no code changes for model switching.
+ctrl = RoboWBCController("configs/sonic_g1.toml")
+
+# LeRobot-style inference step.
+obs_dict = {
+    "observation.state":    joint_positions,   # list[float] or np.ndarray, n_joints
+    "observation.velocity": joint_velocities,  # list[float] or np.ndarray, n_joints
+    "observation.imu":      [gx, gy, gz, wx, wy, wz],  # gravity + angular vel
+    "observation.task_cmd": [vx, vy, omega],   # base velocity command (3 floats)
+}
+action = ctrl.step(obs_dict)
+joint_targets = action["action"]   # list[float], n_joints
+```
+
+The `load_from_config` convenience function (also available at module level)
+reads the TOML file and returns a `Policy` in one call:
+
+```python
+import robowbc
+policy = robowbc.load_from_config("configs/sonic_g1.toml")
+```
+
+See `docs/community/lerobot-rfc.md` for the full RFC and submission plan.
+
 ## Publishing new releases
 
 Wheels are built automatically on every `v*` tag via


### PR DESCRIPTION
Closes part of #41.

## Summary

- **`load_from_config(config_path)`** — new module-level convenience function in `robowbc-py`. Reads a robowbc TOML config file and returns a `Policy` without requiring the caller to know the policy name in advance. Bridges the gap between `Registry.build(name, path)` and how LeRobot-style code calls into robowbc.

- **`RoboWBCController`** — new adapter class in `crates/robowbc-py/examples/lerobot_adapter.py`. Wraps `Policy` in LeRobot's `step(obs_dict) → action_dict` locomotion controller interface:
  - `observation.state / velocity` → `Observation.joint_positions / joint_velocities`
  - `observation.imu[:3]` → `Observation.gravity_vector`
  - `observation.task_cmd [vx, vy, ω]` → `command_type="velocity"` with 6-float expansion `[vx, vy, 0, 0, 0, ω]`
  - Handles both plain Python lists and numpy arrays
  - `reset()` no-op for interface compatibility

- **`docs/community/lerobot-rfc.md`** — mark adapter prototype done; fix draft adapter code that used nonexistent `projected_gravity`/`base_angular_velocity` fields (updated to current robowbc Python API); update "When to submit" to reflect that the Python SDK blocker is resolved.

- **`docs/python-sdk.md`** — new LeRobot integration section with usage example.

## What's still needed before RFC submission to huggingface/lerobot

- Real GEAR-SONIC model inference working end-to-end (issue A)
- Performance benchmark: robowbc backend vs pure-Python WBC in LeRobot

## Test plan

- [x] `cargo build` in `crates/robowbc-py` — compiles clean
- [x] `cargo clippy -- -D warnings` in `crates/robowbc-py` — no warnings
- [x] `cargo build / clippy / test / fmt --check` on workspace — all green

https://claude.ai/code/session_01WKbd9rycGsXe5R7XGgmKD3