### PR TITLE
ci: add headless Rerun snapshot job and visualization docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,67 @@ jobs:
       - name: Build docs
         run: mdbook build
 
+  snapshot:
+    name: Policy snapshots (Rerun .rrd)
+    runs-on: ubuntu-latest
+    # Requires the Rust job to pass first so we know the code compiles.
+    needs: rust
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Build robowbc with vis feature
+        run: cargo build --bin robowbc --features robowbc-cli/vis
+
+      - name: Write snapshot config (decoupled_wbc, 200 ticks, headless .rrd)
+        run: |
+          cat > /tmp/snapshot_decoupled.toml << 'EOF'
+          [policy]
+          name = "decoupled_wbc"
+
+          [policy.config.rl_model]
+          model_path = "crates/robowbc-ort/tests/fixtures/test_dynamic_identity.onnx"
+          execution_provider = { type = "cpu" }
+          optimization_level = "extended"
+          num_threads = 1
+
+          [policy.config]
+          lower_body_joints = [0, 1]
+          upper_body_joints = [2, 3]
+          control_frequency_hz = 50
+
+          [robot]
+          config_path = "configs/robots/unitree_g1_mock.toml"
+
+          [comm]
+          frequency_hz = 50
+
+          [runtime]
+          velocity = [0.2, 0.0, 0.1]
+          max_ticks = 200
+
+          [vis]
+          app_id = "robowbc-ci-decoupled_wbc"
+          spawn_viewer = false
+          save_path = "/tmp/decoupled_wbc.rrd"
+          EOF
+
+      - name: Record decoupled_wbc snapshot
+        run: cargo run --bin robowbc --features robowbc-cli/vis -- run --config /tmp/snapshot_decoupled.toml
+
+      - name: Upload .rrd artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: policy-snapshots
+          path: /tmp/*.rrd
+          retention-days: 30
+
   python-sdk:
     runs-on: ubuntu-latest
     # ORT binary download can be flaky on cold CI caches; mark non-blocking

--- a/README.md
+++ b/README.md
@@ -58,6 +58,67 @@ This uniformity makes a thin abstraction layer both possible and natural.
 | [HumanPlus](https://github.com/MarkFzp/humanplus) | Stanford | PyTorch | ❌ | Custom H1 | Planned |
 | [ExBody](https://github.com/chengxuxin/expressive-humanoid) | Unitree collab | PyTorch | ❌ | H1 | Planned |
 
+## Visualization
+
+RoboWBC ships a [Rerun](https://rerun.io)-backed visualizer (`robowbc-vis`) that streams per-tick data for any running policy:
+
+| Channel | Path in Rerun |
+|---------|---------------|
+| Actual joint positions | `joints/actual/<name>` |
+| Actual joint velocities | `joints/velocity/<name>` |
+| Policy joint targets | `joints/target/<name>` |
+| Inference latency | `metrics/inference_latency_ms` |
+| Control loop frequency | `metrics/control_frequency_hz` |
+
+### Quick start
+
+Add a `[vis]` section to any config file and rebuild with the `vis` feature:
+
+```bash
+cargo run --bin robowbc --features robowbc-cli/vis -- run --config configs/decoupled_g1.toml
+```
+
+**Live viewer** — spawns a Rerun window automatically:
+
+```toml
+[vis]
+app_id  = "robowbc"
+spawn_viewer = true
+```
+
+**Headless / save to file** — no display required, works in CI or SSH sessions:
+
+```toml
+[vis]
+app_id       = "robowbc"
+spawn_viewer = false
+save_path    = "recording.rrd"
+```
+
+Open the saved file:
+
+```bash
+rerun recording.rrd          # local Rerun install
+# or paste the file URL into https://app.rerun.io
+```
+
+### CI-generated snapshots
+
+Every CI run on this repository records a headless `.rrd` snapshot of the `decoupled_wbc` policy (200 ticks, no model downloads required). Download the artifact named **`policy-snapshots`** from any [GitHub Actions run](../../actions/workflows/ci.yml) and open it with Rerun to see joint position targets, velocities, and inference latency over time.
+
+### Comparing policies
+
+Run each policy config with a shared `save_path` prefix, then open the files together:
+
+```bash
+# record two policies
+cargo run --bin robowbc --features robowbc-cli/vis -- run --config configs/decoupled_g1.toml
+# edit [vis] save_path between runs, then:
+rerun decoupled_wbc.rrd gear_sonic.rrd
+```
+
+Rerun's timeline lets you scrub both recordings side-by-side to compare target trajectories and latency characteristics.
+
 ## Related Work (WBC Literature)
 
 RoboWBC is grounded in recent whole-body control research and is designed to provide a common deployment interface across these lines of work:

--- a/crates/robowbc-vis/src/lib.rs
+++ b/crates/robowbc-vis/src/lib.rs
@@ -9,24 +9,44 @@
 //!
 //! # Example
 //!
+//! **Live viewer (spawns a local Rerun window):**
 //! ```toml
 //! [vis]
 //! app_id = "robowbc"
 //! spawn_viewer = true
 //! ```
+//!
+//! **Headless / CI (saves a `.rrd` recording file):**
+//! ```toml
+//! [vis]
+//! app_id = "robowbc"
+//! spawn_viewer = false
+//! save_path = "snapshot.rrd"
+//! ```
+//!
+//! Open a saved recording with `rerun snapshot.rrd` or via
+//! <https://app.rerun.io> (paste the file URL in the viewer).
+
+use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
 
 /// Configuration for the Rerun visualizer.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct RerunConfig {
     /// Rerun application identifier shown in the viewer title bar.
     #[serde(default = "default_app_id")]
     pub app_id: String,
     /// When `true`, spawns a new Rerun viewer process on startup.
-    /// When `false`, connects to an already-running viewer.
+    /// When `false` and [`save_path`](Self::save_path) is `None`,
+    /// connects to an already-running viewer via TCP.
     #[serde(default = "default_spawn_viewer")]
     pub spawn_viewer: bool,
+    /// Write the recording to this `.rrd` file instead of streaming to a
+    /// viewer.  Enables headless operation — useful for CI and offline review.
+    /// When set, [`spawn_viewer`](Self::spawn_viewer) is ignored.
+    #[serde(default)]
+    pub save_path: Option<PathBuf>,
 }
 
 fn default_app_id() -> String {
@@ -35,15 +55,6 @@ fn default_app_id() -> String {
 
 const fn default_spawn_viewer() -> bool {
     true
-}
-
-impl Default for RerunConfig {
-    fn default() -> Self {
-        Self {
-            app_id: default_app_id(),
-            spawn_viewer: default_spawn_viewer(),
-        }
-    }
 }
 
 /// Errors produced by the visualization layer.
@@ -82,6 +93,7 @@ mod tests {
         let cfg = RerunConfig::default();
         assert_eq!(cfg.app_id, "robowbc");
         assert!(cfg.spawn_viewer);
+        assert!(cfg.save_path.is_none());
     }
 
     #[test]
@@ -89,10 +101,24 @@ mod tests {
         let cfg = RerunConfig {
             app_id: "test_app".to_owned(),
             spawn_viewer: false,
+            save_path: Some(PathBuf::from("/tmp/snapshot.rrd")),
         };
         let toml_str = toml::to_string(&cfg).expect("serialization should succeed");
         let loaded: RerunConfig =
             toml::from_str(&toml_str).expect("deserialization should succeed");
         assert_eq!(cfg, loaded);
+    }
+
+    #[test]
+    fn headless_config_round_trips() {
+        let toml_str = r#"
+app_id = "ci-run"
+spawn_viewer = false
+save_path = "output.rrd"
+"#;
+        let cfg: RerunConfig = toml::from_str(toml_str).expect("should parse");
+        assert_eq!(cfg.app_id, "ci-run");
+        assert!(!cfg.spawn_viewer);
+        assert_eq!(cfg.save_path, Some(PathBuf::from("output.rrd")));
     }
 }

--- a/crates/robowbc-vis/src/visualizer.rs
+++ b/crates/robowbc-vis/src/visualizer.rs
@@ -17,7 +17,14 @@ pub struct RerunVisualizer {
 }
 
 impl RerunVisualizer {
-    /// Creates a new visualizer and opens the Rerun viewer.
+    /// Creates a new visualizer.
+    ///
+    /// Mode selection (checked in order):
+    /// 1. If [`RerunConfig::save_path`] is set → writes a `.rrd` file
+    ///    (headless, no display required — suitable for CI).
+    /// 2. Else if [`RerunConfig::spawn_viewer`] is `true` → spawns a local
+    ///    Rerun viewer process.
+    /// 3. Otherwise → connects to an already-running viewer via TCP.
     ///
     /// # Errors
     ///
@@ -25,7 +32,11 @@ impl RerunVisualizer {
     pub fn new(config: &RerunConfig, joint_names: &[String]) -> Result<Self, VisError> {
         let builder = RecordingStreamBuilder::new(&config.app_id);
 
-        let rec = if config.spawn_viewer {
+        let rec = if let Some(ref path) = config.save_path {
+            builder.save(path).map_err(|e| VisError::InitFailed {
+                reason: format!("failed to open recording file {}: {e}", path.display()),
+            })?
+        } else if config.spawn_viewer {
             builder.spawn().map_err(|e| VisError::InitFailed {
                 reason: format!("failed to spawn viewer: {e}"),
             })?


### PR DESCRIPTION
- robowbc-vis: add `save_path: Option<PathBuf>` to `RerunConfig`;
  `RerunVisualizer::new()` now uses `RecordingStreamBuilder::save(path)`
  when a path is provided — no display or TCP connection needed.
  This enables headless operation in CI and SSH sessions.
- ci.yml: add `snapshot` job that builds with `--features robowbc-cli/vis`,
  runs decoupled_wbc for 200 ticks using bundled test fixtures (no model
  downloads required), and uploads the resulting `.rrd` file as the
  `policy-snapshots` artifact (retained 30 days).
- README: add Visualization section covering live viewer, headless save,
  how to open recordings locally or via app.rerun.io, and where to find
  CI-generated snapshots.

https://claude.ai/code/session_01HdgdZuTLg2auk9TGYtgFEz