### PR TITLE
fix: CI — RerunConfig::default() returns empty app_id

### DIFF
--- a/crates/robowbc-vis/src/lib.rs
+++ b/crates/robowbc-vis/src/lib.rs
@@ -32,7 +32,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 /// Configuration for the Rerun visualizer.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RerunConfig {
     /// Rerun application identifier shown in the viewer title bar.
     #[serde(default = "default_app_id")]
@@ -47,6 +47,16 @@ pub struct RerunConfig {
     /// When set, [`spawn_viewer`](Self::spawn_viewer) is ignored.
     #[serde(default)]
     pub save_path: Option<PathBuf>,
+}
+
+impl Default for RerunConfig {
+    fn default() -> Self {
+        Self {
+            app_id: default_app_id(),
+            spawn_viewer: default_spawn_viewer(),
+            save_path: None,
+        }
+    }
 }
 
 fn default_app_id() -> String {


### PR DESCRIPTION
## Summary

- `RerunConfig` had `#[derive(Default)]` but `app_id` uses `#[serde(default = "default_app_id")]`. Serde defaults only apply during deserialization — `Default::default()` for `String` returns `""`, not `"robowbc"`, so `RerunConfig::default()` produced a silent wrong value.
- Replace the derived `Default` with an explicit `impl Default` that calls the same `default_app_id()` / `default_spawn_viewer()` helper functions used by serde. This makes both paths consistent.
- The `tests::default_config_has_sane_values` test was already catching this correctly and was failing in `cargo test`.

## Test plan

- [x] `cargo test -p robowbc-vis --lib` — 3/3 tests pass (including the previously failing `default_config_has_sane_values`)
- [x] `cargo test --workspace --all-targets` — all 118 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — no warnings
- [x] `cargo fmt --all -- --check` — no formatting issues

https://claude.ai/code/session_01MMaoiVt1ujyjupDB6rGoQh