### PR TITLE
feat(vis): wire per-tick Rerun logging + fix rerun 0.31 API + Blueprint layout

### DIFF
--- a/crates/robowbc-cli/src/main.rs
+++ b/crates/robowbc-cli/src/main.rs
@@ -316,6 +316,7 @@ fn run_control_loop_inner<T: RobotTransport>(
     comm: &CommConfig,
     runtime: &RuntimeConfig,
     running: &AtomicBool,
+    #[cfg(feature = "vis")] visualizer: &mut Option<RerunVisualizer>,
 ) -> Result<(usize, usize, Duration), String> {
     let command = if let Some([vx, vy, yaw]) = runtime.velocity {
         WbcCommand::Velocity(Twist {
@@ -342,27 +343,70 @@ fn run_control_loop_inner<T: RobotTransport>(
         }
 
         let cycle_start = Instant::now();
+
+        // Capture per-tick data for vis logging; populated inside the closure.
+        #[cfg(feature = "vis")]
+        let mut tick_vis: Option<(Vec<f32>, Vec<f32>, Vec<f32>, f64)> = None;
+
         run_control_tick(transport, command.clone(), |obs| {
             let infer_start = Instant::now();
             let output = policy.predict(&obs);
-            inference_total += infer_start.elapsed();
+            let elapsed = infer_start.elapsed();
+            inference_total += elapsed;
+
+            #[cfg(feature = "vis")]
+            {
+                let positions = obs.joint_positions.clone();
+                let velocities = obs.joint_velocities.clone();
+                let targets = output
+                    .as_ref()
+                    .map(|t| t.positions.clone())
+                    .unwrap_or_default();
+                tick_vis = Some((positions, velocities, targets, elapsed.as_secs_f64() * 1e3));
+            }
+
             output
         })
         .map_err(|e| format!("control loop tick failed: {e}"))?;
 
+        let cycle_elapsed = cycle_start.elapsed();
+
+        // Log joint state, targets, and metrics to Rerun (no-op when vis disabled).
+        #[cfg(feature = "vis")]
+        if let (Some(vis), Some((positions, velocities, targets, latency_ms))) =
+            (visualizer.as_mut(), tick_vis)
+        {
+            vis.advance_frame();
+            let _ = vis.log_joint_state(&positions, &velocities);
+            let _ = vis.log_joint_targets(&targets);
+            let _ = vis.log_inference_latency(latency_ms);
+            #[allow(clippy::cast_precision_loss)]
+            let freq = 1.0_f64 / cycle_elapsed.as_secs_f64().max(f64::EPSILON);
+            let _ = vis.log_control_frequency(freq);
+            match &command {
+                WbcCommand::Velocity(t) => {
+                    let _ = vis.log_velocity_command(t.linear[0], t.linear[1], t.angular[2]);
+                }
+                WbcCommand::MotionTokens(tokens) => {
+                    let _ = vis.log_motion_tokens(tokens);
+                }
+                _ => {}
+            }
+        }
+
         ticks = ticks.saturating_add(1);
 
-        let elapsed = cycle_start.elapsed();
-        if elapsed > period {
+        if cycle_elapsed > period {
             dropped_frames = dropped_frames.saturating_add(1);
         } else {
-            thread::sleep(period.saturating_sub(elapsed));
+            thread::sleep(period.saturating_sub(cycle_elapsed));
         }
     }
 
     Ok((ticks, dropped_frames, inference_total))
 }
 
+#[allow(clippy::too_many_lines)]
 fn run_control_loop(
     policy: &dyn WbcPolicy,
     robot: &RobotConfig,
@@ -386,7 +430,7 @@ fn run_control_loop(
 
     // Optionally initialise Rerun visualizer.
     #[cfg(feature = "vis")]
-    let _visualizer: Option<RerunVisualizer> = match vis_config {
+    let mut visualizer: Option<RerunVisualizer> = match vis_config {
         Some(ref cfg) => {
             let vis = RerunVisualizer::new(cfg, &robot.joint_names)
                 .map_err(|e| format!("failed to start Rerun visualizer: {e}"))?;
@@ -406,20 +450,41 @@ fn run_control_loop(
                 UnitreeG1Transport::connect(hw_cfg, robot.clone(), comm.frequency_hz)
                     .map_err(|e| format!("hardware transport connect failed: {e}"))?;
             println!("unitree g1 hardware transport active");
-            let (ticks, dropped, inf) =
-                run_control_loop_inner(&mut transport, policy, comm, runtime, running)?;
+            let (ticks, dropped, inf) = run_control_loop_inner(
+                &mut transport,
+                policy,
+                comm,
+                runtime,
+                running,
+                #[cfg(feature = "vis")]
+                &mut visualizer,
+            )?;
             (ticks, dropped, inf, ticks)
         } else if let Some(sim_cfg) = sim_config {
             let mut transport = MujocoTransport::new(sim_cfg, robot.clone())
                 .map_err(|e| format!("mujoco init failed: {e}"))?;
             println!("mujoco simulation transport active");
-            let (ticks, dropped, inf) =
-                run_control_loop_inner(&mut transport, policy, comm, runtime, running)?;
+            let (ticks, dropped, inf) = run_control_loop_inner(
+                &mut transport,
+                policy,
+                comm,
+                runtime,
+                running,
+                #[cfg(feature = "vis")]
+                &mut visualizer,
+            )?;
             (ticks, dropped, inf, ticks)
         } else {
             let mut transport = SyntheticTransport::new(robot.joint_count);
-            let (ticks, dropped, inf) =
-                run_control_loop_inner(&mut transport, policy, comm, runtime, running)?;
+            let (ticks, dropped, inf) = run_control_loop_inner(
+                &mut transport,
+                policy,
+                comm,
+                runtime,
+                running,
+                #[cfg(feature = "vis")]
+                &mut visualizer,
+            )?;
             (ticks, dropped, inf, transport.sent_commands())
         }
     };
@@ -431,13 +496,27 @@ fn run_control_loop(
                 UnitreeG1Transport::connect(hw_cfg, robot.clone(), comm.frequency_hz)
                     .map_err(|e| format!("hardware transport connect failed: {e}"))?;
             println!("unitree g1 hardware transport active");
-            let (ticks, dropped, inf) =
-                run_control_loop_inner(&mut transport, policy, comm, runtime, running)?;
+            let (ticks, dropped, inf) = run_control_loop_inner(
+                &mut transport,
+                policy,
+                comm,
+                runtime,
+                running,
+                #[cfg(feature = "vis")]
+                &mut visualizer,
+            )?;
             (ticks, dropped, inf, ticks)
         } else {
             let mut transport = SyntheticTransport::new(robot.joint_count);
-            let (ticks, dropped, inf) =
-                run_control_loop_inner(&mut transport, policy, comm, runtime, running)?;
+            let (ticks, dropped, inf) = run_control_loop_inner(
+                &mut transport,
+                policy,
+                comm,
+                runtime,
+                running,
+                #[cfg(feature = "vis")]
+                &mut visualizer,
+            )?;
             (ticks, dropped, inf, transport.sent_commands())
         }
     };

--- a/crates/robowbc-vis/src/lib.rs
+++ b/crates/robowbc-vis/src/lib.rs
@@ -32,7 +32,7 @@ use std::path::PathBuf;
 use serde::{Deserialize, Serialize};
 
 /// Configuration for the Rerun visualizer.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RerunConfig {
     /// Rerun application identifier shown in the viewer title bar.
     #[serde(default = "default_app_id")]
@@ -55,6 +55,16 @@ fn default_app_id() -> String {
 
 const fn default_spawn_viewer() -> bool {
     true
+}
+
+impl Default for RerunConfig {
+    fn default() -> Self {
+        Self {
+            app_id: default_app_id(),
+            spawn_viewer: default_spawn_viewer(),
+            save_path: None,
+        }
+    }
 }
 
 /// Errors produced by the visualization layer.

--- a/crates/robowbc-vis/src/visualizer.rs
+++ b/crates/robowbc-vis/src/visualizer.rs
@@ -131,6 +131,40 @@ impl RerunVisualizer {
             })
     }
 
+    /// Logs a velocity command `[vx, vy, yaw_rate]` for the current frame.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VisError`] if a log call fails.
+    pub fn log_velocity_command(&self, vx: f32, vy: f32, yaw_rate: f32) -> Result<(), VisError> {
+        for (channel, value) in [("vx", vx), ("vy", vy), ("yaw_rate", yaw_rate)] {
+            self.rec
+                .log(format!("command/{channel}"), &Scalar::new(f64::from(value)))
+                .map_err(|e| VisError::LogFailed {
+                    reason: format!("{e}"),
+                })?;
+        }
+        Ok(())
+    }
+
+    /// Logs motion token values for the current frame.
+    ///
+    /// Each token is logged as `command/token_<index>`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VisError`] if a log call fails.
+    pub fn log_motion_tokens(&self, tokens: &[f32]) -> Result<(), VisError> {
+        for (i, &v) in tokens.iter().enumerate() {
+            self.rec
+                .log(format!("command/token_{i}"), &Scalar::new(f64::from(v)))
+                .map_err(|e| VisError::LogFailed {
+                    reason: format!("{e}"),
+                })?;
+        }
+        Ok(())
+    }
+
     /// Advances the timeline to the next frame.
     ///
     /// Call this once per control tick, before logging data for that tick.

--- a/crates/robowbc-vis/src/visualizer.rs
+++ b/crates/robowbc-vis/src/visualizer.rs
@@ -1,7 +1,10 @@
 //! Rerun-backed robot state visualizer.
 
 use crate::{RerunConfig, VisError};
-use rerun::{RecordingStream, RecordingStreamBuilder, Scalar};
+use rerun::{
+    blueprint::{Blueprint, BlueprintActivation, TimeSeriesView, Vertical},
+    RecordingStream, RecordingStreamBuilder, Scalars,
+};
 
 /// Streams robot joint state, policy targets, and runtime metrics to Rerun.
 ///
@@ -24,13 +27,16 @@ impl RerunVisualizer {
     ///    (headless, no display required — suitable for CI).
     /// 2. Else if [`RerunConfig::spawn_viewer`] is `true` → spawns a local
     ///    Rerun viewer process.
-    /// 3. Otherwise → connects to an already-running viewer via TCP.
+    /// 3. Otherwise → connects to an already-running viewer via gRPC.
+    ///
+    /// A default [`Blueprint`] is sent immediately after connecting so the
+    /// viewer opens with a useful panel layout without manual configuration.
     ///
     /// # Errors
     ///
     /// Returns [`VisError`] if the recording stream cannot be created.
     pub fn new(config: &RerunConfig, joint_names: &[String]) -> Result<Self, VisError> {
-        let builder = RecordingStreamBuilder::new(&config.app_id);
+        let builder = RecordingStreamBuilder::new(config.app_id.as_str());
 
         let rec = if let Some(ref path) = config.save_path {
             builder.save(path).map_err(|e| VisError::InitFailed {
@@ -41,16 +47,55 @@ impl RerunVisualizer {
                 reason: format!("failed to spawn viewer: {e}"),
             })?
         } else {
-            builder.connect_tcp().map_err(|e| VisError::InitFailed {
+            builder.connect_grpc().map_err(|e| VisError::InitFailed {
                 reason: format!("failed to connect to viewer: {e}"),
             })?
         };
 
-        Ok(Self {
+        let vis = Self {
             rec,
             joint_names: joint_names.to_vec(),
             frame: 0,
-        })
+        };
+
+        // Send a default blueprint so the viewer opens with a structured layout.
+        vis.send_default_blueprint()?;
+
+        Ok(vis)
+    }
+
+    /// Sends a default [`Blueprint`] that pre-configures two time-series panels:
+    ///
+    /// - **Joint Trajectories** — `joints/actual/*` and `joints/target/*`
+    /// - **Runtime Metrics** — `metrics/*` (latency, frequency)
+    ///
+    /// Called automatically from [`new`](Self::new). Can be re-sent at any
+    /// time to reset the viewer layout.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VisError`] if the blueprint cannot be serialised or sent.
+    pub fn send_default_blueprint(&self) -> Result<(), VisError> {
+        let blueprint = Blueprint::new(Vertical::new([
+            TimeSeriesView::new("Joint Trajectories")
+                .with_origin("joints")
+                .into(),
+            TimeSeriesView::new("Runtime Metrics")
+                .with_origin("metrics")
+                .into(),
+        ]));
+
+        blueprint
+            .send(
+                &self.rec,
+                BlueprintActivation {
+                    make_active: true,
+                    make_default: true,
+                },
+            )
+            .map_err(|e| VisError::InitFailed {
+                reason: format!("failed to send blueprint: {e}"),
+            })
     }
 
     /// Logs actual joint positions and velocities for the current frame.
@@ -64,7 +109,7 @@ impl RerunVisualizer {
                 self.rec
                     .log(
                         format!("joints/actual/{name}"),
-                        &Scalar::new(f64::from(pos)),
+                        &Scalars::new([f64::from(pos)]),
                     )
                     .map_err(|e| VisError::LogFailed {
                         reason: format!("{e}"),
@@ -74,7 +119,7 @@ impl RerunVisualizer {
                 self.rec
                     .log(
                         format!("joints/velocity/{name}"),
-                        &Scalar::new(f64::from(vel)),
+                        &Scalars::new([f64::from(vel)]),
                     )
                     .map_err(|e| VisError::LogFailed {
                         reason: format!("{e}"),
@@ -95,7 +140,7 @@ impl RerunVisualizer {
                 self.rec
                     .log(
                         format!("joints/target/{name}"),
-                        &Scalar::new(f64::from(target)),
+                        &Scalars::new([f64::from(target)]),
                     )
                     .map_err(|e| VisError::LogFailed {
                         reason: format!("{e}"),
@@ -112,7 +157,7 @@ impl RerunVisualizer {
     /// Returns [`VisError`] if the log call fails.
     pub fn log_inference_latency(&self, latency_ms: f64) -> Result<(), VisError> {
         self.rec
-            .log("metrics/inference_latency_ms", &Scalar::new(latency_ms))
+            .log("metrics/inference_latency_ms", &Scalars::new([latency_ms]))
             .map_err(|e| VisError::LogFailed {
                 reason: format!("{e}"),
             })
@@ -125,7 +170,10 @@ impl RerunVisualizer {
     /// Returns [`VisError`] if the log call fails.
     pub fn log_control_frequency(&self, frequency_hz: f64) -> Result<(), VisError> {
         self.rec
-            .log("metrics/control_frequency_hz", &Scalar::new(frequency_hz))
+            .log(
+                "metrics/control_frequency_hz",
+                &Scalars::new([frequency_hz]),
+            )
             .map_err(|e| VisError::LogFailed {
                 reason: format!("{e}"),
             })
@@ -139,7 +187,10 @@ impl RerunVisualizer {
     pub fn log_velocity_command(&self, vx: f32, vy: f32, yaw_rate: f32) -> Result<(), VisError> {
         for (channel, value) in [("vx", vx), ("vy", vy), ("yaw_rate", yaw_rate)] {
             self.rec
-                .log(format!("command/{channel}"), &Scalar::new(f64::from(value)))
+                .log(
+                    format!("command/{channel}"),
+                    &Scalars::new([f64::from(value)]),
+                )
                 .map_err(|e| VisError::LogFailed {
                     reason: format!("{e}"),
                 })?;
@@ -157,7 +208,7 @@ impl RerunVisualizer {
     pub fn log_motion_tokens(&self, tokens: &[f32]) -> Result<(), VisError> {
         for (i, &v) in tokens.iter().enumerate() {
             self.rec
-                .log(format!("command/token_{i}"), &Scalar::new(f64::from(v)))
+                .log(format!("command/token_{i}"), &Scalars::new([f64::from(v)]))
                 .map_err(|e| VisError::LogFailed {
                     reason: format!("{e}"),
                 })?;


### PR DESCRIPTION
## Summary

This PR builds on the headless Rerun snapshot CI (already merged) to make the visualization actually useful end-to-end.

- **Fix: visualizer was dead code** — `_visualizer` was created but never called; zero data was being logged to Rerun per tick
- **Fix: rerun 0.31.2 API mismatches** — the `rerun` feature never compiled against the pinned version
- **New: per-tick logging wired into control loop**
- **New: Blueprint default layout** — viewer opens with structured panels, no manual drag-and-drop

## Changes

### `robowbc-vis`: per-tick logging API
New methods on `RerunVisualizer`:
- `log_velocity_command(vx, vy, yaw_rate)` — logs `command/{vx,vy,yaw_rate}`
- `log_motion_tokens(tokens)` — logs `command/token_<n>`
- `send_default_blueprint()` — sends a Blueprint that pre-configures two panels:
  - **Joint Trajectories** (`joints/` subtree: actual + target overlay)
  - **Runtime Metrics** (`metrics/` subtree: latency + frequency)

### `robowbc-vis`: rerun 0.31.2 API fixes
| Old (broken) | New (0.31.2) |
|---|---|
| `rerun::Scalar` | `rerun::Scalars` |
| `RecordingStreamBuilder::new(&String)` | `new(str)` |
| `.connect_tcp()` | `.connect_grpc()` |

### `robowbc-cli`: wire visualizer into control loop
`run_control_loop_inner` now accepts `&mut Option<RerunVisualizer>` (zero overhead when `vis` feature is off). Each tick:
1. `advance_frame()`
2. `log_joint_state(positions, velocities)`
3. `log_joint_targets(targets)`
4. `log_inference_latency(ms)`
5. `log_control_frequency(hz)`
6. `log_velocity_command` or `log_motion_tokens` depending on command type

## Test plan

- [ ] `cargo check --workspace --all-targets` passes
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo test --workspace --all-targets` — all tests green
- [ ] `cargo check -p robowbc-vis --features rerun` — rerun feature compiles
- [ ] CI snapshot artifact (`policy-snapshots`) contains a non-empty `.rrd` with real time-series channels

https://claude.ai/code/session_01HdgdZuTLg2auk9TGYtgFEz