### PR TITLE
fix: restore workspace verification on linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,11 +122,11 @@ jobs:
       - name: Build manylinux wheel
         uses: PyO3/maturin-action@v1
         with:
-          args: --release --out /tmp/robowbc-dist
+          args: --release --out dist -i python3.12
           manylinux: auto
 
       - name: Install robowbc wheel
-        run: pip install /tmp/robowbc-dist/*.whl
+        run: pip install dist/*.whl
 
       - name: Python smoke test
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Build manylinux wheels
         uses: PyO3/maturin-action@v1
         with:
-          args: --release --out dist
+          args: --release --out dist -i python3.12
           manylinux: auto
 
       - name: Upload wheels

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -552,7 +552,7 @@ version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 dependencies = [
- "libloading",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -2729,7 +2729,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -3293,6 +3293,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3754,7 +3765,7 @@ dependencies = [
  "glutin_egl_sys",
  "glutin_glx_sys",
  "glutin_wgl_sys",
- "libloading",
+ "libloading 0.8.9",
  "objc2 0.6.4",
  "objc2-app-kit 0.3.2",
  "objc2-core-foundation",
@@ -4708,7 +4719,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
 dependencies = [
  "libc",
- "libloading",
+ "libloading 0.8.9",
  "pkg-config",
 ]
 
@@ -4843,6 +4854,16 @@ name = "libloading"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
  "cfg-if",
  "windows-link",
@@ -6146,6 +6167,7 @@ version = "2.0.0-rc.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
 dependencies = [
+ "libloading 0.9.0",
  "ndarray 0.17.2",
  "ort-sys",
  "smallvec",
@@ -9585,14 +9607,17 @@ name = "robowbc-ort"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "flate2",
  "inventory",
  "ndarray 0.16.1",
  "ort",
  "robowbc-core",
  "robowbc-registry",
  "serde",
+ "tar",
  "thiserror 2.0.18",
  "toml",
+ "ureq",
 ]
 
 [[package]]
@@ -10722,6 +10747,17 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
 
 [[package]]
 name = "target-lexicon"
@@ -12218,7 +12254,7 @@ dependencies = [
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading",
+ "libloading 0.8.9",
  "log",
  "naga",
  "ndk-sys",
@@ -12846,7 +12882,7 @@ dependencies = [
  "as-raw-xcb-connection",
  "gethostname",
  "libc",
- "libloading",
+ "libloading 0.8.9",
  "once_cell",
  "rustix 1.1.4",
  "x11rb-protocol",
@@ -12873,6 +12909,16 @@ dependencies = [
  "rusticata-macros",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix 1.1.4",
 ]
 
 [[package]]
@@ -13415,7 +13461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f54cb62ce3d7b8c2261f091f7f0ba855780f70690e7e8238e2deb490cdf8260"
 dependencies = [
  "git-version",
- "libloading",
+ "libloading 0.8.9",
  "serde",
  "stabby",
  "tracing",
@@ -13542,7 +13588,7 @@ dependencies = [
  "humantime",
  "lazy_static",
  "libc",
- "libloading",
+ "libloading 0.8.9",
  "pnet_datalink",
  "schemars 1.2.1",
  "serde",

--- a/crates/robowbc-ort/Cargo.toml
+++ b/crates/robowbc-ort/Cargo.toml
@@ -5,6 +5,7 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 description = "ONNX Runtime inference backend for RoboWBC"
+build = "build.rs"
 
 [lib]
 path = "src/lib.rs"
@@ -12,12 +13,22 @@ path = "src/lib.rs"
 [dependencies]
 inventory = "0.3"
 ndarray = "0.16"
-ort = { version = "2.0.0-rc.12", default-features = true }
 robowbc-core = { path = "../robowbc-core" }
 robowbc-registry = { path = "../robowbc-registry" }
 serde = { workspace = true }
 thiserror = "2"
 toml = { workspace = true }
+
+[target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
+ort = { version = "2.0.0-rc.12", default-features = false, features = ["api-24", "load-dynamic", "ndarray", "std", "tls-native", "tracing"] }
+
+[target.'cfg(not(all(target_os = "linux", target_arch = "x86_64")))'.dependencies]
+ort = { version = "2.0.0-rc.12", default-features = true }
+
+[target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.build-dependencies]
+flate2 = "1"
+tar = "0.4"
+ureq = { version = "3", features = ["native-tls"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/robowbc-ort/Cargo.toml
+++ b/crates/robowbc-ort/Cargo.toml
@@ -20,7 +20,7 @@ thiserror = "2"
 toml = { workspace = true }
 
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.dependencies]
-ort = { version = "2.0.0-rc.12", default-features = false, features = ["api-24", "load-dynamic", "ndarray", "std", "tls-native", "tracing"] }
+ort = { version = "2.0.0-rc.12", default-features = false, features = ["api-24", "load-dynamic", "ndarray", "std", "tls-rustls", "tracing"] }
 
 [target.'cfg(not(all(target_os = "linux", target_arch = "x86_64")))'.dependencies]
 ort = { version = "2.0.0-rc.12", default-features = true }
@@ -28,7 +28,7 @@ ort = { version = "2.0.0-rc.12", default-features = true }
 [target.'cfg(all(target_os = "linux", target_arch = "x86_64"))'.build-dependencies]
 flate2 = "1"
 tar = "0.4"
-ureq = { version = "3", features = ["native-tls"] }
+ureq = { version = "3", default-features = false, features = ["rustls"] }
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/crates/robowbc-ort/build.rs
+++ b/crates/robowbc-ort/build.rs
@@ -1,0 +1,82 @@
+use std::{
+    env,
+    error::Error,
+    fs::File,
+    io::{self, BufWriter, Write},
+    path::{Path, PathBuf},
+};
+
+const ENV_DYLIB_PATH: &str = "ROBOWBC_ORT_DYLIB_PATH";
+const DIST_NAME: &str = "onnxruntime-linux-x64-1.24.2";
+const DIST_URL: &str =
+    "https://github.com/microsoft/onnxruntime/releases/download/v1.24.2/onnxruntime-linux-x64-1.24.2.tgz";
+const DYLIB_RELATIVE_PATH: &str = "lib/libonnxruntime.so.1.24.2";
+
+fn main() {
+    println!("cargo:rerun-if-env-changed={ENV_DYLIB_PATH}");
+
+    if let Some(path) = env::var_os(ENV_DYLIB_PATH) {
+        println!(
+            "cargo:rustc-env={ENV_DYLIB_PATH}={}",
+            PathBuf::from(path).display()
+        );
+        return;
+    }
+
+    if !matches_target("linux", "x86_64") {
+        return;
+    }
+
+    match ensure_official_runtime() {
+        Ok(path) => println!("cargo:rustc-env={ENV_DYLIB_PATH}={}", path.display()),
+        Err(err) => println!("cargo:warning=failed to prepare ONNX Runtime shared library: {err}"),
+    }
+}
+
+fn matches_target(target_os: &str, target_arch: &str) -> bool {
+    env::var("CARGO_CFG_TARGET_OS").as_deref() == Ok(target_os)
+        && env::var("CARGO_CFG_TARGET_ARCH").as_deref() == Ok(target_arch)
+}
+
+fn ensure_official_runtime() -> Result<PathBuf, Box<dyn Error>> {
+    let out_dir = PathBuf::from(env::var("OUT_DIR")?);
+    let dist_dir = out_dir.join(DIST_NAME);
+    let dylib_path = dist_dir.join(DYLIB_RELATIVE_PATH);
+    if dylib_path.is_file() {
+        return Ok(dylib_path);
+    }
+
+    let archive_path = out_dir.join(format!("{DIST_NAME}.tgz"));
+    if !archive_path.is_file() {
+        download_archive(&archive_path)?;
+    }
+
+    extract_archive(&archive_path, &out_dir)?;
+
+    if dylib_path.is_file() {
+        Ok(dylib_path)
+    } else {
+        Err(format!(
+            "expected ONNX Runtime shared library at {} after extraction",
+            dylib_path.display()
+        )
+        .into())
+    }
+}
+
+fn download_archive(archive_path: &Path) -> Result<(), Box<dyn Error>> {
+    let response = ureq::get(DIST_URL).call()?;
+    let mut reader = response.into_body().into_reader();
+    let mut writer = BufWriter::new(File::create(archive_path)?);
+    io::copy(&mut reader, &mut writer)?;
+    writer.flush()?;
+    Ok(())
+}
+
+fn extract_archive(archive_path: &Path, out_dir: &Path) -> Result<(), Box<dyn Error>> {
+    let archive = File::open(archive_path)?;
+    let decoder = flate2::read::GzDecoder::new(archive);
+    let mut archive = tar::Archive::new(decoder);
+    archive.unpack(out_dir)?;
+    Ok(())
+}

--- a/crates/robowbc-ort/src/lib.rs
+++ b/crates/robowbc-ort/src/lib.rs
@@ -41,6 +41,8 @@ use robowbc_registry::{RegistryPolicy, WbcRegistration};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+use std::sync::OnceLock;
 
 /// Errors produced by the ONNX Runtime backend.
 #[derive(Debug, thiserror::Error)]
@@ -145,6 +147,45 @@ impl From<&OptimizationLevel> for GraphOptimizationLevel {
 
 fn default_num_threads() -> usize {
     1
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+const ROBOWBC_ORT_DYLIB_ENV: &str = "ROBOWBC_ORT_DYLIB_PATH";
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+static ORT_RUNTIME_INIT: OnceLock<Result<(), String>> = OnceLock::new();
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn ensure_onnxruntime_loaded() -> Result<(), OrtError> {
+    ORT_RUNTIME_INIT
+        .get_or_init(|| {
+            let builder = match resolved_onnxruntime_dylib_path() {
+                Some(path) => ort::init_from(path).map_err(|e| e.to_string())?,
+                None => ort::init(),
+            };
+            let _ = builder.commit();
+            Ok(())
+        })
+        .clone()
+        .map_err(|reason| OrtError::SessionCreation { reason })
+}
+
+#[cfg(not(all(target_os = "linux", target_arch = "x86_64")))]
+fn ensure_onnxruntime_loaded() -> Result<(), OrtError> {
+    Ok(())
+}
+
+#[cfg(all(target_os = "linux", target_arch = "x86_64"))]
+fn resolved_onnxruntime_dylib_path() -> Option<PathBuf> {
+    std::env::var_os("ORT_DYLIB_PATH")
+        .or_else(|| std::env::var_os(ROBOWBC_ORT_DYLIB_ENV))
+        .map(PathBuf::from)
+        .filter(|path| path.is_file())
+        .or_else(|| {
+            option_env!("ROBOWBC_ORT_DYLIB_PATH")
+                .map(PathBuf::from)
+                .filter(|path| path.is_file())
+        })
 }
 
 /// Configuration for constructing an [`OrtBackend`].
@@ -276,6 +317,8 @@ impl OrtBackend {
     }
 
     fn build_session(config: &OrtConfig) -> Result<Session, OrtError> {
+        ensure_onnxruntime_loaded()?;
+
         let builder = Session::builder().map_err(|e| OrtError::SessionCreation {
             reason: e.to_string(),
         })?;

--- a/crates/robowbc-pyo3/Cargo.toml
+++ b/crates/robowbc-pyo3/Cargo.toml
@@ -5,9 +5,11 @@ edition.workspace = true
 license.workspace = true
 authors.workspace = true
 description = "PyO3 Python inference backend for RoboWBC"
+build = "build.rs"
 
 [lib]
 path = "src/lib.rs"
+doc = false
 
 [dependencies]
 inventory = "0.3"

--- a/crates/robowbc-pyo3/build.rs
+++ b/crates/robowbc-pyo3/build.rs
@@ -1,0 +1,36 @@
+use std::{env, process::Command};
+
+fn main() {
+    println!("cargo:rerun-if-env-changed=PYO3_PYTHON");
+
+    if env::var("CARGO_CFG_TARGET_OS").as_deref() != Ok("linux") {
+        return;
+    }
+
+    if let Some(libdir) = python_libdir() {
+        println!("cargo:rustc-link-arg=-Wl,-rpath,{libdir}");
+    }
+}
+
+fn python_libdir() -> Option<String> {
+    let python = env::var("PYO3_PYTHON").unwrap_or_else(|_| String::from("python3"));
+    let output = Command::new(python)
+        .args([
+            "-c",
+            "import sysconfig; print(sysconfig.get_config_var('LIBDIR') or '')",
+        ])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let libdir = String::from_utf8(output.stdout).ok()?;
+    let libdir = libdir.trim();
+    if libdir.is_empty() {
+        None
+    } else {
+        Some(libdir.to_owned())
+    }
+}

--- a/crates/robowbc-sim/src/lib.rs
+++ b/crates/robowbc-sim/src/lib.rs
@@ -1,6 +1,6 @@
 //! `MuJoCo` simulation transport for `RoboWBC`.
 //!
-//! Provides [`MujocoTransport`], an implementation of
+//! Provides `MujocoTransport`, an implementation of
 //! [`RobotTransport`](robowbc_comm::RobotTransport) that runs physics
 //! simulation using `MuJoCo`. This enables closed-loop policy testing without
 //! real hardware.

--- a/crates/robowbc-vis/src/lib.rs
+++ b/crates/robowbc-vis/src/lib.rs
@@ -1,6 +1,6 @@
 //! Rerun visualization for `RoboWBC`.
 //!
-//! Provides [`RerunVisualizer`], a logging frontend that streams robot state,
+//! Provides `RerunVisualizer`, a logging frontend that streams robot state,
 //! policy targets, and runtime metrics to a [Rerun](https://rerun.io/) viewer.
 //!
 //! # Feature flags
@@ -65,16 +65,6 @@ fn default_app_id() -> String {
 
 const fn default_spawn_viewer() -> bool {
     true
-}
-
-impl Default for RerunConfig {
-    fn default() -> Self {
-        Self {
-            app_id: default_app_id(),
-            spawn_viewer: default_spawn_viewer(),
-            save_path: None,
-        }
-    }
 }
 
 /// Errors produced by the visualization layer.


### PR DESCRIPTION
Switch Linux x86_64 ONNX Runtime loading to a compatible shared runtime path, add a PyO3 rpath fix for test binaries, remove the duplicate RerunConfig Default impl, and clean up doc build regressions. Mark robowbc-pyo3 lib docs off as a temporary workaround for the current rustdoc+numpy ICE on rustc 1.94.