### PR TITLE
fix: ensure_onnxruntime_loaded fails fast when no ORT library path is known

### DIFF
--- a/crates/robowbc-ort/src/lib.rs
+++ b/crates/robowbc-ort/src/lib.rs
@@ -167,11 +167,21 @@ static ORT_RUNTIME_INIT: OnceLock<Result<(), String>> = OnceLock::new();
 fn ensure_onnxruntime_loaded() -> Result<(), OrtError> {
     ORT_RUNTIME_INIT
         .get_or_init(|| {
-            let builder = match resolved_onnxruntime_dylib_path() {
-                Some(path) => ort::init_from(path).map_err(|e| e.to_string())?,
-                None => ort::init(),
-            };
-            let _ = builder.commit();
+            // Fail fast when no library path is known. Falling back to
+            // ort::init() with no path can trigger a runtime HTTPS download
+            // that hangs indefinitely on networks with untrusted TLS certificates.
+            let path = resolved_onnxruntime_dylib_path().ok_or_else(|| {
+                "ONNX Runtime shared library not found. \
+                 Build the crate in a network-accessible environment so the \
+                 build script can download it, or point ROBOWBC_ORT_DYLIB_PATH \
+                 / ORT_DYLIB_PATH at a local libonnxruntime.so file."
+                    .to_owned()
+            })?;
+            if !ort::init_from(path).map_err(|e| e.to_string())?.commit() {
+                return Err(
+                    "OrtEnvironment commit returned false; ORT initialization failed".to_owned(),
+                );
+            }
             Ok(())
         })
         .clone()


### PR DESCRIPTION
## Summary

- **Root cause**: `ensure_onnxruntime_loaded()` fell back to `ort::init()` (no path) when `resolved_onnxruntime_dylib_path()` returned `None`. On Linux x86_64 with the `load-dynamic` + `tls-rustls` feature combination, this silently triggered a runtime HTTPS download attempt **inside** the `OnceLock` initialiser — hanging indefinitely when TLS certificates are untrusted (e.g. sandboxed CI environments, network outages).
- **Cascading failure**: The `OnceLock`'s internal futex kept every subsequent call to `ensure_onnxruntime_loaded()` stuck in `__futex_wait`, effectively deadlocking the entire test binary — no timeout, no error, just an infinite hang.
- **Fix**: Return a clear `SessionCreation` error immediately when no library path is available, instead of attempting a pathless init. Also propagate the `commit()` `bool` return as an error instead of silently ignoring it (`let _ = builder.commit()`).

## Effect

| Scenario | Before | After |
|---|---|---|
| ORT library unavailable (SSL cert issue, no download) | Test binary hangs **forever** | Tests fail in ~0.1 s with a clear error message |
| ORT library available (normal CI) | Tests pass | Tests pass (unchanged) |

## Test plan

- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p robowbc-ort` completes in 0.08 s (was infinite hang) when ORT is unavailable
- [x] `cargo test -p robowbc-cli` completes in 0.12 s (was infinite hang) when ORT is unavailable
- [x] All 56 non-ORT tests (`robowbc-core`, `robowbc-registry`, `robowbc-comm`, `robowbc-sim`, `robowbc-vis`) pass

https://claude.ai/code/session_01Q2tcFg6KgDGPCD9Sca57hH