### PR TITLE
fix: CI — repair bench compile error and clippy failures in robowbc-ort

### DIFF
--- a/crates/robowbc-ort/benches/inference.rs
+++ b/crates/robowbc-ort/benches/inference.rs
@@ -16,7 +16,8 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use robowbc_core::{JointLimit, Observation, PdGains, RobotConfig, WbcCommand, WbcPolicy};
 use robowbc_ort::{
-    DecoupledWbcConfig, DecoupledWbcPolicy, GearSonicConfig, GearSonicPolicy, OrtBackend, OrtConfig,
+    DecoupledObservationContract, DecoupledWbcConfig, DecoupledWbcPolicy, GearSonicConfig,
+    GearSonicPolicy, OrtBackend, OrtConfig,
 };
 use std::path::PathBuf;
 use std::time::Instant;
@@ -222,9 +223,11 @@ fn bench_decoupled_wbc_predict(c: &mut Criterion) {
 
     let config = DecoupledWbcConfig {
         rl_model: test_ort_config(model_path),
+        stand_model: None,
         robot: test_robot_config(4),
         lower_body_joints: vec![0, 1],
         upper_body_joints: vec![2, 3],
+        contract: DecoupledObservationContract::Flat,
         control_frequency_hz: 50,
     };
     let policy = DecoupledWbcPolicy::new(config).expect("policy should build");

--- a/crates/robowbc-ort/src/bfm_zero.rs
+++ b/crates/robowbc-ort/src/bfm_zero.rs
@@ -949,6 +949,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn g1_tracking_builds_expected_input_layout() {
         let dof_pos_minus_default = vec![1.0; BFM_G1_ACTION_DIM];
         let dof_vel = vec![2.0; BFM_G1_ACTION_DIM];

--- a/crates/robowbc-ort/src/decoupled.rs
+++ b/crates/robowbc-ort/src/decoupled.rs
@@ -798,9 +798,8 @@ mod tests {
             }),
             timestamp: Instant::now(),
         };
-        let twist = match &obs.command {
-            WbcCommand::Velocity(twist) => twist,
-            _ => unreachable!("constructed as velocity"),
+        let WbcCommand::Velocity(twist) = &obs.command else {
+            unreachable!("constructed as velocity")
         };
 
         let single_obs = build_groot_g1_single_observation(
@@ -821,7 +820,7 @@ mod tests {
         assert!((single_obs[12] + 1.0).abs() < 1e-6);
     }
 
-    /// Integration test requiring the published GR00T WholeBodyControl ONNX checkpoints.
+    /// Integration test requiring the published GR00T `WholeBodyControl` ONNX checkpoints.
     ///
     /// To run once weights are available:
     /// ```bash

--- a/crates/robowbc-ort/src/lib.rs
+++ b/crates/robowbc-ort/src/lib.rs
@@ -22,7 +22,7 @@ pub mod bfm_zero;
 pub mod decoupled;
 pub mod wholebody_vla;
 pub use bfm_zero::{BfmZeroConfig, BfmZeroPolicy};
-pub use decoupled::{DecoupledWbcConfig, DecoupledWbcPolicy};
+pub use decoupled::{DecoupledObservationContract, DecoupledWbcConfig, DecoupledWbcPolicy};
 pub use wholebody_vla::{WholeBodyVlaConfig, WholeBodyVlaPolicy};
 
 pub mod wbc_agile;


### PR DESCRIPTION
## Summary

- **Compile fix**: `benches/inference.rs` was constructing `DecoupledWbcConfig` as a struct literal but missing the two fields added in a recent commit (`contract`, `stand_model`). This broke `cargo check --workspace --all-targets`, the first step of the `rust` CI job.
  - Re-export `DecoupledObservationContract` from `robowbc_ort` lib
  - Import it in the bench and add `stand_model: None` + `contract: Flat`
- **Clippy fixes** (three `-D warnings` failures in `robowbc-ort`):
  - `bfm_zero.rs`: `#[allow(clippy::float_cmp)]` on the exact-integer layout test
  - `decoupled.rs`: rewrite `match`-as-early-return to `let…else`
  - `decoupled.rs`: backtick `WholeBodyControl` in doc comment (`doc_markdown` lint)

## Test plan

- [ ] `cargo check --workspace --all-targets` — no errors
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] `cargo fmt --all -- --check` — clean
- [ ] CI `rust` job passes green

https://claude.ai/code/session_01FhDFR1hFwiYFR73ErExDSn