### PR TITLE
Improve hosted policy showcase and README UX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: ["**"]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   rust:
     runs-on: ubuntu-latest
@@ -113,6 +116,32 @@ jobs:
           name: policy-showcase
           path: /tmp/policy-showcase
           retention-days: 30
+
+      - name: Configure GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/configure-pages@v5
+
+      - name: Upload GitHub Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v4
+        with:
+          path: /tmp/policy-showcase
+
+  deploy-showcase:
+    name: Deploy showcase to GitHub Pages
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: [rust, docs, showcase]
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy GitHub Pages site
+        id: deployment
+        uses: actions/deploy-pages@v4
 
   python-sdk:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ control loops, latency, and target trajectories with the same data pipeline.
 - Rust workspace with core abstractions, policy registry, ONNX Runtime
   backends, Python-backed policy loading, CLI, communication, MuJoCo transport,
   and Rerun visualization.
-- Registered policies on `main`: `gear_sonic`, `decoupled_wbc`, `hover`,
+- Registered policies in the current codebase: `gear_sonic`, `decoupled_wbc`, `hover`,
   `wbc_agile`, `bfm_zero`, `wholebody_vla`, and `py_model`.
 - Real public asset-backed runs are wired today for `gear_sonic`
   (`configs/sonic_g1.toml`), `decoupled_wbc` on G1
@@ -34,6 +34,11 @@ control loops, latency, and target trajectories with the same data pipeline.
 - No-download smoke paths remain available through
   `configs/decoupled_smoke.toml` and `configs/decoupled_h1.toml`, both backed
   by the checked-in dynamic identity ONNX fixture.
+- Honest runtime state today: live public-policy paths are `gear_sonic`,
+  `decoupled_wbc`, `wbc_agile`, and `bfm_zero`; `hover` remains blocked until
+  you provide your own exported checkpoint; `wholebody_vla` remains an
+  experimental blocked contract wrapper; `py_model` remains user-supplied by
+  design.
 - `configs/hover_h1.toml`, `configs/wbc_agile_t1.toml`, and
   `configs/wholebody_vla_x2.toml` remain honest blocked configs today:
   `hover` needs a user-trained/exported checkpoint because the public upstream
@@ -44,8 +49,9 @@ control loops, latency, and target trajectories with the same data pipeline.
 - CI runs Rust build/test/lint/format checks, Rust API docs, `mdBook`, Python
   wheel smoke tests, and a mixed-source policy showcase artifact with real CPU
   `gear_sonic`, `decoupled_wbc`, `wbc_agile`, and `bfm_zero` cards plus honest
-  blocked cards for the remaining asset-gated policies, all exported as
-  `index.html`, JSON summaries, logs, and Rerun recordings.
+  blocked cards for `hover` plus an experimental blocked card for
+  `wholebody_vla`, all exported as `index.html`, JSON summaries, logs, and
+  Rerun recordings.
 
 ## Repo layout
 
@@ -161,6 +167,44 @@ without copying an existing example by hand.
 | `wholebody_vla` | `configs/wholebody_vla_x2.toml` | `robowbc-ort` | Experimental X2 `KinematicPose` contract wrapper; the public upstream repo does not yet provide runnable code or ONNX checkpoints |
 | `py_model` | user-supplied TOML | `robowbc-pyo3` | Loads Python scripts or PyTorch checkpoints through PyO3 |
 
+## Manual real-model verification
+
+The repo also exposes ignored integration tests for the real-model paths. Use
+these when you want to validate the wrappers directly inside `robowbc-ort`
+instead of running the CLI configs.
+
+Public-download paths:
+
+```bash
+bash scripts/download_gear_sonic_models.sh
+cargo test -p robowbc-ort -- --ignored gear_sonic_real_model_inference
+
+bash scripts/download_decoupled_wbc_models.sh
+cargo test -p robowbc-ort -- --ignored decoupled_wbc_real_model_inference
+
+bash scripts/download_wbc_agile_models.sh
+cargo test -p robowbc-ort -- --ignored wbc_agile_real_model_inference
+
+bash scripts/download_bfm_zero_models.sh
+BFM_ZERO_MODEL_PATH=models/bfm_zero/bfm_zero_g1.onnx \
+BFM_ZERO_CONTEXT_PATH=models/bfm_zero/zs_walking.npy \
+cargo test -p robowbc-ort bfm_zero_real_model_inference -- --ignored --nocapture
+```
+
+Local/private-model paths:
+
+```bash
+HOVER_MODEL_PATH=models/hover/hover_h1.onnx \
+cargo test -p robowbc-ort hover_real_model_inference -- --ignored --nocapture
+
+WHOLEBODY_VLA_MODEL_PATH=models/wholebody_vla/wholebody_vla_x2.onnx \
+cargo test -p robowbc-ort wholebody_vla_real_model_inference -- --ignored --nocapture
+```
+
+`hover` still requires a user-trained/exported ONNX checkpoint. `wholebody_vla`
+still requires a compatible local/private checkpoint because the public
+upstream repo does not yet expose a runnable inference release.
+
 ## Visualization and reports
 
 RoboWBC records per-tick joint state, policy targets, command inputs, and
@@ -240,8 +284,9 @@ The CI workflow warms cached `models/gear-sonic/`, `models/decoupled-wbc/`,
 mixed-source showcase, and uploads it as the `policy-showcase` artifact. Each
 run contains an auto-generated `index.html` plus per-policy `.json`, `.rrd`,
 `.log`, and embedded Rerun viewer assets for the real CPU `gear_sonic`,
-`decoupled_wbc`, `wbc_agile`, and `bfm_zero` cards, plus honest blocked cards
-for `hover` and `wholebody_vla` whenever their assets are unavailable.
+`decoupled_wbc`, `wbc_agile`, and `bfm_zero` cards, plus an honest blocked
+`hover` card and an experimental blocked `wholebody_vla` card whenever those
+local assets are unavailable.
 
 ## Python SDK
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,13 @@ control loops, latency, and target trajectories with the same data pipeline.
 - No-download smoke paths remain available through
   `configs/decoupled_smoke.toml` and `configs/decoupled_h1.toml`, both backed
   by the checked-in dynamic identity ONNX fixture.
-- `configs/wholebody_vla_x2.toml`, `configs/hover_h1.toml`, and
-  `configs/wbc_agile_t1.toml` are honest blocked configs today: the wrappers
-  load, but they still need public or user-exported model assets.
+- `configs/hover_h1.toml`, `configs/wbc_agile_t1.toml`, and
+  `configs/wholebody_vla_x2.toml` remain honest blocked configs today:
+  `hover` needs a user-trained/exported checkpoint because the public upstream
+  repo ships deployment code but no pretrained model, `wbc_agile_t1` still
+  needs a matching user export, and `wholebody_vla` is an experimental
+  contract wrapper because the public upstream repo does not yet ship runnable
+  code or ONNX weights.
 - CI runs Rust build/test/lint/format checks, Rust API docs, `mdBook`, Python
   wheel smoke tests, and a mixed-source policy showcase artifact with real CPU
   `gear_sonic`, `decoupled_wbc`, `wbc_agile`, and `bfm_zero` cards plus honest
@@ -151,10 +155,10 @@ without copying an existing example by hand.
 |--------|-------------------|---------|-------|
 | `gear_sonic` | `configs/sonic_g1.toml` | `robowbc-ort` | Real `planner_sonic.onnx` velocity path today; encoder/decoder tracking contract still pending |
 | `decoupled_wbc` | `configs/decoupled_smoke.toml`, `configs/decoupled_g1.toml`, `configs/decoupled_h1.toml` | `robowbc-ort` | Real public G1 history contract plus fixture-backed smoke paths |
-| `hover` | `configs/hover_h1.toml` | `robowbc-ort` | Real H1 wrapper is wired, but upstream does not ship public pretrained ONNX weights; provide a user-exported checkpoint |
+| `hover` | `configs/hover_h1.toml` | `robowbc-ort` | Real H1 wrapper is wired, but the public repo/releases do not include pretrained checkpoints; provide a user-trained/exported ONNX model |
 | `wbc_agile` | `configs/wbc_agile_g1.toml`, `configs/wbc_agile_t1.toml` | `robowbc-ort` | Real public G1 checkpoint; the T1 config still expects a user-exported ONNX model |
 | `bfm_zero` | `configs/bfm_zero_g1.toml` | `robowbc-ort` | Real public G1 tracking contract is wired; `scripts/download_bfm_zero_models.sh` fetches and normalizes the upstream ONNX + tracking context automatically |
-| `wholebody_vla` | `configs/wholebody_vla_x2.toml` | `robowbc-ort` | Real `KinematicPose` wrapper is wired, but no public X2 ONNX checkpoint is available yet |
+| `wholebody_vla` | `configs/wholebody_vla_x2.toml` | `robowbc-ort` | Experimental X2 `KinematicPose` contract wrapper; the public upstream repo does not yet provide runnable code or ONNX checkpoints |
 | `py_model` | user-supplied TOML | `robowbc-pyo3` | Loads Python scripts or PyTorch checkpoints through PyO3 |
 
 ## Visualization and reports

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ control loops, latency, and target trajectories with the same data pipeline.
   blocked cards for `hover` plus an experimental blocked card for
   `wholebody_vla`, all exported as `index.html`, JSON summaries, logs, and
   Rerun recordings.
+- The current visual harness compares RoboWBC runs against themselves across
+  policies and surfaces blocked integrations honestly; it does not yet execute
+  or overlay the upstream official C++/Python runtimes as parity baselines.
 
 ## Repo layout
 
@@ -275,7 +278,9 @@ python -m http.server 8000
 ```
 
 Then open `http://127.0.0.1:8000`. The page still keeps the raw `.rrd` links
-for downloading or opening in the desktop Rerun app.
+for downloading or opening in the desktop Rerun app. Today this report reflects
+RoboWBC-native runs only; official-runtime parity overlays are tracked
+separately.
 
 ### CI policy showcase
 

--- a/README.md
+++ b/README.md
@@ -92,14 +92,25 @@ python scripts/generate_policy_showcase.py \
   --robowbc-binary ./target/debug/robowbc \
   --output-dir ./artifacts/policy-showcase
 
-cd ./artifacts/policy-showcase
-python -m http.server 8000
+python scripts/serve_showcase.py \
+  --dir ./artifacts/policy-showcase \
+  --port 8000 \
+  --open
 ```
 
 The output folder contains `index.html`, `manifest.json`, per-policy `*.json`
-run summaries, raw `*.rrd` recordings, logs, and the embedded Rerun web viewer
-runtime. Pull requests keep the downloadable `policy-showcase` artifact, and
-`main` publishes the generated site to the live report link above.
+run summaries, raw `*.rrd` recordings, logs, and the vendored Rerun web viewer
+runtime. The HTML now lazy-loads each `.rrd` file when its card becomes
+visible, so the bundle stays static-site-friendly for both local debug and
+GitHub Pages. Do not open `index.html` directly via `file://`; serve the
+folder over HTTP with `python scripts/serve_showcase.py --dir ...` instead.
+The local helper accepts `--dir`, `--bind`, `--port`, and `--open` so the same
+bundle can be previewed from any generated folder.
+Pull requests keep the downloadable `policy-showcase` artifact, and `main`
+publishes the generated site to the live report link above. If we later need
+preview deploys, custom headers, or to offload larger recordings into object
+storage, Vercel or Cloudflare Pages would be the next step, but GitHub Pages
+remains the default project-site path.
 </details>
 
 <details>

--- a/README.md
+++ b/README.md
@@ -2,77 +2,50 @@
 
 Unified inference runtime for humanoid whole-body control policies.
 
-RoboWBC gives you one runtime for loading multiple WBC policies, switching them
-by TOML config, and running them through synthetic, simulation, or hardware
-transports from the same codebase.
+<p>
+  <a href="https://miaodx.com/robowbc/"><strong>Open Live Policy Reports</strong></a>
+  ·
+  <a href="docs/getting-started.md"><strong>Getting Started</strong></a>
+  ·
+  <a href="docs/architecture.md"><strong>Architecture</strong></a>
+  ·
+  <a href="docs/python-sdk.md"><strong>Python SDK</strong></a>
+  ·
+  <a href="docs/founding-document.md"><strong>Founding Document</strong></a>
+</p>
 
-### **[View Interactive Visual Reports →](https://miaodx.com/roboharness/)**
+RoboWBC gives you one config-driven runtime for loading multiple WBC policies,
+running them through the same Rust CLI, and exporting the same JSON + Rerun
+report pipeline across smoke tests, MuJoCo runs, and hardware-oriented
+transports.
 
-Browser-native visual reports live in the companion `roboharness` project.
-RoboWBC itself records Rerun `.rrd` traces locally and in CI, so you can inspect
-control loops, latency, and target trajectories with the same data pipeline.
+![RoboWBC architecture](docs/assets/architecture.svg)
 
-## Current status
+## What ships today
 
-- Rust workspace with core abstractions, policy registry, ONNX Runtime
-  backends, Python-backed policy loading, CLI, communication, MuJoCo transport,
-  and Rerun visualization.
-- Registered policies in the current codebase: `gear_sonic`, `decoupled_wbc`, `hover`,
-  `wbc_agile`, `bfm_zero`, `wholebody_vla`, and `py_model`.
-- Real public asset-backed runs are wired today for `gear_sonic`
-  (`configs/sonic_g1.toml`), `decoupled_wbc` on G1
-  (`configs/decoupled_g1.toml`), `wbc_agile` on G1
-  (`configs/wbc_agile_g1.toml`), and `bfm_zero` on G1
-  (`configs/bfm_zero_g1.toml`).
-- `bfm_zero` now has an automated public download path through
-  `scripts/download_bfm_zero_models.sh`, which fetches the upstream ONNX
-  checkpoint and tracking context, then normalizes them into the RoboWBC model
-  layout used by the runtime and CI showcase.
-- The repo-owned simulation + zenoh wire paths now carry IMU angular velocity;
-  legacy gravity-only low-state payloads still decode with zero gyro for
-  backward compatibility.
-- No-download smoke paths remain available through
-  `configs/decoupled_smoke.toml` and `configs/decoupled_h1.toml`, both backed
-  by the checked-in dynamic identity ONNX fixture.
-- Honest runtime state today: live public-policy paths are `gear_sonic`,
-  `decoupled_wbc`, `wbc_agile`, and `bfm_zero`; `hover` remains blocked until
-  you provide your own exported checkpoint; `wholebody_vla` remains an
-  experimental blocked contract wrapper; `py_model` remains user-supplied by
-  design.
-- `configs/hover_h1.toml`, `configs/wbc_agile_t1.toml`, and
-  `configs/wholebody_vla_x2.toml` remain honest blocked configs today:
-  `hover` needs a user-trained/exported checkpoint because the public upstream
-  repo ships deployment code but no pretrained model, `wbc_agile_t1` still
-  needs a matching user export, and `wholebody_vla` is an experimental
-  contract wrapper because the public upstream repo does not yet ship runnable
-  code or ONNX weights.
-- CI runs Rust build/test/lint/format checks, Rust API docs, `mdBook`, Python
-  wheel smoke tests, and a mixed-source policy showcase artifact with real CPU
-  `gear_sonic`, `decoupled_wbc`, `wbc_agile`, and `bfm_zero` cards plus honest
-  blocked cards for `hover` plus an experimental blocked card for
-  `wholebody_vla`, all exported as `index.html`, JSON summaries, logs, and
-  Rerun recordings.
-- The current visual harness compares RoboWBC runs against themselves across
-  policies and surfaces blocked integrations honestly; it does not yet execute
-  or overlay the upstream official C++/Python runtimes as parity baselines.
+| Area | Status |
+|------|--------|
+| Runtime | Rust workspace with registry-driven policy loading, ONNX Runtime and PyO3 backends, MuJoCo and communication transports, plus JSON and Rerun reporting |
+| Live public-policy paths | `gear_sonic`, `decoupled_wbc`, `wbc_agile`, `bfm_zero` |
+| Honest blocked wrappers | `hover` needs a user-exported checkpoint, `wholebody_vla` still lacks a runnable public upstream release |
+| Published visual report | The `main` workflow is wired to build the same HTML report in CI and publish it to the live report link above |
 
-## Repo layout
+## Policy status
 
-| Path | Purpose |
-|------|---------|
-| `crates/robowbc-core` | `WbcPolicy`, `Observation`, `WbcCommand`, `JointPositionTargets`, `RobotConfig` |
-| `crates/robowbc-registry` | `inventory`-based policy registration and factory |
-| `crates/robowbc-ort` | ONNX Runtime backends and policy wrappers |
-| `crates/robowbc-pyo3` | Python-backed runtime policy (`py_model`) for `.py`, `.pt`, and `.pth` models |
-| `crates/robowbc-comm` | Control-loop plumbing and robot transports |
-| `crates/robowbc-sim` | MuJoCo transport for hardware-free execution |
-| `crates/robowbc-vis` | Rerun visualization and `.rrd` recording |
-| `crates/robowbc-cli` | `robowbc` CLI binary |
-| `crates/robowbc-py` | Standalone `maturin` package for the Python SDK |
+| Policy | Status | Public assets | Example config | Notes |
+|--------|--------|---------------|----------------|-------|
+| `gear_sonic` | Live | Yes | [configs/sonic_g1.toml](configs/sonic_g1.toml) | Uses the published `planner_sonic.onnx` path today; the encoder and decoder tracking contract is still pending |
+| `decoupled_wbc` | Live | Yes | [configs/decoupled_g1.toml](configs/decoupled_g1.toml) | Public G1 balance and walk checkpoints; [configs/decoupled_smoke.toml](configs/decoupled_smoke.toml) stays as the no-download smoke path |
+| `wbc_agile` | Live | Yes | [configs/wbc_agile_g1.toml](configs/wbc_agile_g1.toml) | Published G1 recurrent checkpoint is wired; the T1 path still expects a user export |
+| `bfm_zero` | Live | Yes | [configs/bfm_zero_g1.toml](configs/bfm_zero_g1.toml) | Public ONNX plus tracking context bundle is normalized by `scripts/download_bfm_zero_models.sh` |
+| `hover` | Blocked | No | [configs/hover_h1.toml](configs/hover_h1.toml) | Wrapper exists, but the public upstream repo does not ship a pretrained checkpoint |
+| `wholebody_vla` | Experimental | No | [configs/wholebody_vla_x2.toml](configs/wholebody_vla_x2.toml) | Contract wrapper only; the public upstream repo does not yet expose a runnable inference release |
+| `py_model` | User supplied | N/A | user TOML | Loads Python modules or PyTorch checkpoints through `robowbc-pyo3` |
+
+The generated HTML report includes every currently working public-asset policy:
+`gear_sonic`, `decoupled_wbc`, `wbc_agile`, and `bfm_zero`.
 
 ## Quick start
-
-### Rust CLI smoke test
 
 ```bash
 rustc --version
@@ -81,102 +54,56 @@ cargo build
 cargo run --bin robowbc -- run --config configs/decoupled_smoke.toml
 ```
 
-`configs/decoupled_smoke.toml` uses
-`crates/robowbc-ort/tests/fixtures/test_dynamic_identity.onnx`, so it is the
-intended no-download local smoke path.
+`configs/decoupled_smoke.toml` uses the checked-in dynamic identity ONNX
+fixture, so it is the intended no-download local smoke path.
 
-If an ONNX-backed run stalls before the first tick on Linux/x86_64, point
-`ROBOWBC_ORT_DYLIB_PATH` at a fully extracted `libonnxruntime.so.1.24.2` under
-`target/debug/build/robowbc-ort-*/out/onnxruntime-linux-x64-1.24.2/lib/`.
-
-### Run real GEAR-SONIC checkpoints
+<details>
+<summary><strong>Run the live public policies</strong></summary>
 
 ```bash
 bash scripts/download_gear_sonic_models.sh
 cargo run --release --bin robowbc -- run --config configs/sonic_g1.toml
-```
 
-`configs/sonic_g1.toml` downloads NVIDIA's three public GEAR-SONIC checkpoints,
-then runs the published `planner_sonic.onnx` velocity path by default. The
-real encoder/decoder tracking contract is not integrated into the Rust runtime
-yet, so the CLI config keeps `motion_tokens` as a documented fixture-only /
-experimental path for now.
-
-### Run real Decoupled WBC G1 checkpoints
-
-```bash
 bash scripts/download_decoupled_wbc_models.sh
 cargo run --release --bin robowbc -- run --config configs/decoupled_g1.toml
-```
 
-`configs/decoupled_g1.toml` uses NVIDIA's public balance + walk checkpoints and
-the official 516D history contract for the Unitree G1 lower body.
-
-### Run real WBC-AGILE G1 checkpoint
-
-```bash
 bash scripts/download_wbc_agile_models.sh
 cargo run --release --bin robowbc -- run --config configs/wbc_agile_g1.toml
-```
 
-`configs/wbc_agile_g1.toml` uses NVIDIA's public recurrent G1 checkpoint. The
-published model commands 14 lower-body joints; RoboWBC maps those outputs back
-into the 35-DOF robot ordering and holds the remaining joints at their current
-positions.
-
-### Run real BFM-Zero G1 assets
-
-```bash
 bash scripts/download_bfm_zero_models.sh
-# Downloads the public ONNX + tracking context bundle into models/bfm_zero/
-# and converts zs_walking.pkl into zs_walking.npy for the Rust runtime.
 cargo run --release --bin robowbc -- run --config configs/bfm_zero_g1.toml
 ```
 
-`configs/bfm_zero_g1.toml` targets the public G1 tracking contract. The helper
-script fetches `FBcprAuxModel.onnx` and `zs_walking.pkl` from the public
-upstream BFM-Zero release, then normalizes them into
-`models/bfm_zero/bfm_zero_g1.onnx` and `models/bfm_zero/zs_walking.npy` for
-the runtime and CI showcase.
+`gear_sonic` currently exercises the published `planner_sonic.onnx` velocity
+path. `bfm_zero` fetches the public ONNX plus tracking bundle and converts the
+context into the runtime layout used by both the CLI and CI.
+</details>
 
-If you already have an upstream checkout or want to prepare the assets
-manually, the lower-level conversion step is still available:
+<details>
+<summary><strong>Open or generate the visual report</strong></summary>
 
-```bash
-python scripts/prepare_bfm_zero_assets.py \
-  --source /path/to/BFM-Zero/model \
-  --output models/bfm_zero
-cargo run --release --bin robowbc -- run --config configs/bfm_zero_g1.toml
-```
-
-### Generate a new config template
+The same report generator powers both the local HTML bundle and the published
+GitHub Pages site.
 
 ```bash
-cargo run --bin robowbc -- init --output robowbc.template.toml
+cargo build --bin robowbc --features robowbc-cli/vis
+python scripts/generate_policy_showcase.py \
+  --repo-root . \
+  --robowbc-binary ./target/debug/robowbc \
+  --output-dir ./artifacts/policy-showcase
+
+cd ./artifacts/policy-showcase
+python -m http.server 8000
 ```
 
-The generated file is the fastest way to start a new policy or robot config
-without copying an existing example by hand.
+The output folder contains `index.html`, `manifest.json`, per-policy `*.json`
+run summaries, raw `*.rrd` recordings, logs, and the embedded Rerun web viewer
+runtime. Pull requests keep the downloadable `policy-showcase` artifact, and
+`main` publishes the generated site to the live report link above.
+</details>
 
-## Registered policies
-
-| Policy | Example config(s) | Backend | Notes |
-|--------|-------------------|---------|-------|
-| `gear_sonic` | `configs/sonic_g1.toml` | `robowbc-ort` | Real `planner_sonic.onnx` velocity path today; encoder/decoder tracking contract still pending |
-| `decoupled_wbc` | `configs/decoupled_smoke.toml`, `configs/decoupled_g1.toml`, `configs/decoupled_h1.toml` | `robowbc-ort` | Real public G1 history contract plus fixture-backed smoke paths |
-| `hover` | `configs/hover_h1.toml` | `robowbc-ort` | Real H1 wrapper is wired, but the public repo/releases do not include pretrained checkpoints; provide a user-trained/exported ONNX model |
-| `wbc_agile` | `configs/wbc_agile_g1.toml`, `configs/wbc_agile_t1.toml` | `robowbc-ort` | Real public G1 checkpoint; the T1 config still expects a user-exported ONNX model |
-| `bfm_zero` | `configs/bfm_zero_g1.toml` | `robowbc-ort` | Real public G1 tracking contract is wired; `scripts/download_bfm_zero_models.sh` fetches and normalizes the upstream ONNX + tracking context automatically |
-| `wholebody_vla` | `configs/wholebody_vla_x2.toml` | `robowbc-ort` | Experimental X2 `KinematicPose` contract wrapper; the public upstream repo does not yet provide runnable code or ONNX checkpoints |
-| `py_model` | user-supplied TOML | `robowbc-pyo3` | Loads Python scripts or PyTorch checkpoints through PyO3 |
-
-## Manual real-model verification
-
-The repo also exposes ignored integration tests for the real-model paths. Use
-these when you want to validate the wrappers directly inside `robowbc-ort`
-instead of running the CLI configs.
-
-Public-download paths:
+<details>
+<summary><strong>Manual real-model verification</strong></summary>
 
 ```bash
 bash scripts/download_gear_sonic_models.sh
@@ -194,111 +121,13 @@ BFM_ZERO_CONTEXT_PATH=models/bfm_zero/zs_walking.npy \
 cargo test -p robowbc-ort bfm_zero_real_model_inference -- --ignored --nocapture
 ```
 
-Local/private-model paths:
+`hover` still requires a user-trained exported checkpoint, and `wholebody_vla`
+still requires a compatible private or local model because no runnable public
+release exists upstream today.
+</details>
 
-```bash
-HOVER_MODEL_PATH=models/hover/hover_h1.onnx \
-cargo test -p robowbc-ort hover_real_model_inference -- --ignored --nocapture
-
-WHOLEBODY_VLA_MODEL_PATH=models/wholebody_vla/wholebody_vla_x2.onnx \
-cargo test -p robowbc-ort wholebody_vla_real_model_inference -- --ignored --nocapture
-```
-
-`hover` still requires a user-trained/exported ONNX checkpoint. `wholebody_vla`
-still requires a compatible local/private checkpoint because the public
-upstream repo does not yet expose a runnable inference release.
-
-## Visualization and reports
-
-RoboWBC records per-tick joint state, policy targets, command inputs, and
-timing data through `robowbc-vis`, and the CLI can also write a JSON run
-summary for downstream tooling or static report generation.
-
-Build the CLI with visualization enabled:
-
-```bash
-cargo build --bin robowbc --features robowbc-cli/vis
-```
-
-Add a `[vis]` section to any config:
-
-```toml
-[vis]
-app_id = "robowbc"
-spawn_viewer = false
-save_path = "recording.rrd"
-
-[report]
-output_path = "artifacts/run/report.json"
-max_frames = 120
-```
-
-Then run:
-
-```bash
-cargo run --bin robowbc --features robowbc-cli/vis -- run --config configs/decoupled_smoke.toml
-```
-
-Open the saved recording with a local Rerun install:
-
-```bash
-rerun recording.rrd
-```
-
-If you only need the machine-readable summary, `[report]` works on the default
-CLI build too.
-
-### Generate the local policy showcase
-
-Build the CLI with visualization enabled, then run the showcase generator:
-
-```bash
-cargo build --bin robowbc --features robowbc-cli/vis
-# npm is used once to vendor the Rerun web viewer into the output folder.
-python scripts/generate_policy_showcase.py \
-  --repo-root . \
-  --robowbc-binary ./target/debug/robowbc \
-  --output-dir ./artifacts/policy-showcase
-```
-
-That produces:
-
-- `index.html`: mixed-source comparison report with embedded interactive Rerun panes
-- `manifest.json`: machine-readable manifest of all runs
-- `*.json`: per-policy run summaries written by the CLI `[report]` section
-- `*.rrd`: raw downloadable Rerun recordings for each policy
-- `*.log`: raw stdout/stderr from each showcase run
-- `_rerun_web_viewer/`: vendored Rerun web-viewer runtime used by the embedded panes
-
-For the most reliable local viewing path, serve the output directory over HTTP:
-
-```bash
-cd ./artifacts/policy-showcase
-python -m http.server 8000
-```
-
-Then open `http://127.0.0.1:8000`. The page still keeps the raw `.rrd` links
-for downloading or opening in the desktop Rerun app. Today this report reflects
-RoboWBC-native runs only; official-runtime parity overlays are tracked
-separately.
-
-### CI policy showcase
-
-The CI workflow warms cached `models/gear-sonic/`, `models/decoupled-wbc/`,
-`models/wbc-agile/`, and `models/bfm_zero/` directories, builds the same
-mixed-source showcase, and uploads it as the `policy-showcase` artifact. Each
-run contains an auto-generated `index.html` plus per-policy `.json`, `.rrd`,
-`.log`, and embedded Rerun viewer assets for the real CPU `gear_sonic`,
-`decoupled_wbc`, `wbc_agile`, and `bfm_zero` cards, plus an honest blocked
-`hover` card and an experimental blocked `wholebody_vla` card whenever those
-local assets are unavailable.
-
-## Python SDK
-
-The repository ships a standalone Python package in `crates/robowbc-py` and a
-runtime Python-backed policy backend in `crates/robowbc-pyo3`.
-
-Build the SDK locally with `maturin`:
+<details>
+<summary><strong>Python SDK</strong></summary>
 
 ```bash
 pip install "maturin>=1.4,<2.0"
@@ -306,37 +135,41 @@ maturin develop
 python -c "from robowbc import Registry; print(Registry.list_policies())"
 ```
 
-That exposes the same registry-driven runtime from Python:
+The standalone Python package lives in `crates/robowbc-py`, while
+`robowbc-pyo3` provides the runtime backend for user-supplied Python or
+PyTorch policies.
+</details>
 
-```python
-from robowbc import Observation, Registry
+<details>
+<summary><strong>Workspace layout</strong></summary>
 
-policy = Registry.build("decoupled_wbc", "configs/decoupled_smoke.toml")
-obs = Observation(
-    joint_positions=[0.0] * 4,
-    joint_velocities=[0.0] * 4,
-    gravity_vector=[0.0, 0.0, -1.0],
-    angular_velocity=[0.0, 0.0, 0.0],
-    command_type="velocity",
-    command_data=[0.2, 0.0, 0.0],
-)
-targets = policy.predict(obs)
-print(targets.positions)
-```
+| Path | Purpose |
+|------|---------|
+| `crates/robowbc-core` | `WbcPolicy`, `Observation`, `WbcCommand`, `JointPositionTargets`, `RobotConfig` |
+| `crates/robowbc-registry` | `inventory`-based policy registration and factory |
+| `crates/robowbc-ort` | ONNX Runtime backends and policy wrappers |
+| `crates/robowbc-pyo3` | Python-backed runtime policy loading |
+| `crates/robowbc-comm` | Control-loop plumbing and robot transports |
+| `crates/robowbc-sim` | MuJoCo transport for hardware-free execution |
+| `crates/robowbc-vis` | Rerun visualization and `.rrd` recording |
+| `crates/robowbc-cli` | `robowbc` CLI binary |
+| `crates/robowbc-py` | Standalone `maturin` package for the Python SDK |
+</details>
 
 ## Documentation
 
 - [Getting Started](docs/getting-started.md)
-- [Python SDK](docs/python-sdk.md)
+- [Configuration Reference](docs/configuration.md)
+- [Adding a New Policy](docs/adding-a-model.md)
+- [Adding a New Robot](docs/adding-a-robot.md)
 - [Architecture](docs/architecture.md)
 - [Founding document](docs/founding-document.md)
+- [Q2 2026 roadmap](docs/roadmap-2026-q2.md)
 
 ## Related projects
 
-- [roboharness](https://github.com/MiaoDX/roboharness): companion visual
-  testing and browser-report project
-- [LeRobot](https://github.com/huggingface/lerobot): upstream robotics stack
-  that can consume a WBC backend
+- [roboharness](https://github.com/MiaoDX/roboharness), companion visual testing and browser-report project
+- [LeRobot](https://github.com/huggingface/lerobot), upstream robotics stack that can consume a WBC backend
 
 ## License
 

--- a/configs/hover_h1.toml
+++ b/configs/hover_h1.toml
@@ -6,10 +6,11 @@
 # This config selects locomotion mode (indices 0–2 active: vx, vy, yaw_rate).
 # Change `mode_mask` to enable body-pose mode (indices 3–5) or other modes.
 #
-# Model download: trained weights are not publicly distributed.
-# To export your own HOVER model from the NVIDIA HOVER codebase:
-#   1. Train in Isaac Lab: python train.py --task HoverH1
-#   2. Export to ONNX: python export_onnx.py --checkpoint <path> --output models/hover/
+# Model availability: the public HOVER repo ships deployment code, but it does
+# not include pretrained H1 checkpoints or ONNX exports.
+# To use this config today you must train or otherwise obtain your own HOVER
+# checkpoint, then export it with your own tooling to
+# `models/hover/hover_h1.onnx`.
 # Expected model I/O shape:
 #   input:  [1, 2*n + 3 + 2*command_dim]  (n = 19 for H1, command_dim = 15)
 #   output: [1, n]  (19 joint position targets)

--- a/configs/wholebody_vla_x2.toml
+++ b/configs/wholebody_vla_x2.toml
@@ -17,15 +17,12 @@
 #
 # ## Obtaining the model
 #
-# WholeBodyVLA does not yet ship a pre-built ONNX checkpoint.
-# After training with the WholeBodyVLA repository:
+# The public WholeBodyVLA repo does not currently ship runnable training or
+# export code, and it does not provide a ready-to-run ONNX checkpoint.
+# This config therefore documents the expected WBC contract if a compatible
+# local/private X2 checkpoint becomes available.
 #
-#   python export_onnx.py \
-#       --checkpoint checkpoints/wholebody_vla_x2.pt \
-#       --output models/wholebody_vla_x2.onnx \
-#       --num_ee_links 4
-#
-# Then update `policy.config.model.model_path` below.
+# Point `policy.config.model.model_path` below at that local ONNX file.
 #
 # ## Running
 #

--- a/crates/robowbc-ort/src/bfm_zero.rs
+++ b/crates/robowbc-ort/src/bfm_zero.rs
@@ -975,17 +975,21 @@ mod tests {
             &latent,
         );
 
+        let assert_close = |actual: f32, expected: f32| {
+            assert!((actual - expected).abs() < f32::EPSILON);
+        };
+
         assert_eq!(input.len(), BFM_G1_INPUT_DIM);
         assert_eq!(&input[..BFM_G1_ACTION_DIM], &vec![1.0; BFM_G1_ACTION_DIM]);
-        assert_eq!(input[58], 3.0);
-        assert_eq!(input[61], 6.0);
-        assert_eq!(input[64], 9.0);
-        assert_eq!(input[93], 10.0);
-        assert_eq!(input[209], 11.0);
-        assert_eq!(input[221], 14.0);
-        assert_eq!(input[337], 15.0);
-        assert_eq!(input[453], 16.0);
-        assert_eq!(*input.last().expect("latent tail should exist"), 19.0);
+        assert_close(input[58], 3.0);
+        assert_close(input[61], 6.0);
+        assert_close(input[64], 9.0);
+        assert_close(input[93], 10.0);
+        assert_close(input[209], 11.0);
+        assert_close(input[221], 14.0);
+        assert_close(input[337], 15.0);
+        assert_close(input[453], 16.0);
+        assert_close(*input.last().expect("latent tail should exist"), 19.0);
     }
 
     #[test]

--- a/crates/robowbc-ort/src/decoupled.rs
+++ b/crates/robowbc-ort/src/decoupled.rs
@@ -799,7 +799,7 @@ mod tests {
             timestamp: Instant::now(),
         };
         let WbcCommand::Velocity(twist) = &obs.command else {
-            unreachable!("constructed as velocity")
+            unreachable!("constructed as velocity");
         };
 
         let single_obs = build_groot_g1_single_observation(

--- a/crates/robowbc-ort/src/hover.rs
+++ b/crates/robowbc-ort/src/hover.rs
@@ -20,8 +20,12 @@
 //!
 //! | Variant | Filled indices | Mode |
 //! |---|---|---|
-//! | `Velocity(twist)` | 0=vx, 1=vy, 2=yaw_rate | Locomotion |
-//! | `KinematicPose(body_pose)` | 3=height, 4=roll, 5=yaw | Body pose |
+//! | `Velocity(twist)` | `0=vx`, `1=vy`, `2=yaw_rate` | Locomotion |
+//! | `KinematicPose(body_pose)` | `3=height`, `4=roll`, `5=yaw` | Body pose |
+//!
+//! The public HOVER repo includes deployment code, but it does not ship a
+//! pretrained H1 checkpoint. Real-model validation therefore requires a
+//! user-provided ONNX export.
 
 use crate::{OrtBackend, OrtConfig};
 use robowbc_core::{
@@ -738,6 +742,42 @@ default_pose = [0.0, 0.0]
             .predict(&obs)
             .expect_err("missing pelvis link should fail");
         assert!(matches!(err, WbcError::InvalidObservation(_)));
+    }
+
+    #[test]
+    #[ignore = "requires a user-provided HOVER ONNX checkpoint; public upstream release does not provide one"]
+    fn hover_real_model_inference() {
+        let model_path = std::env::var("HOVER_MODEL_PATH").expect("HOVER_MODEL_PATH not set");
+        let policy = HoverPolicy::new(HoverConfig {
+            model: OrtConfig {
+                model_path: PathBuf::from(&model_path),
+                execution_provider: crate::ExecutionProvider::Cpu,
+                optimization_level: crate::OptimizationLevel::Extended,
+                num_threads: 1,
+            },
+            robot: test_robot_config(19),
+            command_dim: 15,
+            mode_mask: locomotion_mask(15),
+            control_frequency_hz: 50,
+        })
+        .expect("policy should build from real model");
+
+        let obs = Observation {
+            joint_positions: vec![0.0; 19],
+            joint_velocities: vec![0.0; 19],
+            gravity_vector: [0.0, 0.0, -1.0],
+            angular_velocity: [0.0, 0.0, 0.0],
+            command: WbcCommand::Velocity(Twist {
+                linear: [0.3, 0.0, 0.0],
+                angular: [0.0, 0.0, 0.1],
+            }),
+            timestamp: Instant::now(),
+        };
+
+        let targets = policy
+            .predict(&obs)
+            .expect("real model inference should succeed");
+        assert_eq!(targets.positions.len(), 19);
     }
 
     #[test]

--- a/crates/robowbc-ort/src/wholebody_vla.rs
+++ b/crates/robowbc-ort/src/wholebody_vla.rs
@@ -32,16 +32,15 @@
 //! [ joint_position_targets(n) ]
 //! ```
 //!
-//! ## ONNX export
+//! ## ONNX contract
 //!
-//! After training with the `WholeBodyVLA` repository:
-//! ```bash
-//! python export_onnx.py --checkpoint checkpoints/wholebody_vla_x2.pt \
-//!     --output models/wholebody_vla_x2.onnx \
-//!     --num_ee_links 4
-//! ```
-//! The exported model should have one input of shape `[1, 2*n+3+7*L]` and one
-//! output of shape `[1, n]`.
+//! The public `WholeBodyVLA` repository does not currently ship runnable
+//! training/export code or a ready-to-run checkpoint. Treat the layout below as
+//! the expected contract for a compatible local/private ONNX export when one
+//! becomes available.
+//!
+//! The model should have one input of shape `[1, 2*n+3+7*L]` and one output of
+//! shape `[1, n]`.
 
 use crate::{OrtBackend, OrtConfig};
 use robowbc_core::{
@@ -428,9 +427,9 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "requires real WholeBodyVLA ONNX weights; run manually after downloading"]
+    #[ignore = "requires a locally provided WholeBodyVLA ONNX checkpoint; public upstream release does not provide one"]
     fn wholebody_vla_real_model_inference() {
-        // Set WHOLEBODY_VLA_MODEL_PATH env var to point at a real WholeBodyVLA checkpoint.
+        // Set WHOLEBODY_VLA_MODEL_PATH env var to point at a compatible local WholeBodyVLA checkpoint.
         let model_path =
             std::env::var("WHOLEBODY_VLA_MODEL_PATH").expect("WHOLEBODY_VLA_MODEL_PATH not set");
         let policy = WholeBodyVlaPolicy::new(WholeBodyVlaConfig {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,38 +1,46 @@
 # RoboWBC
 
-**RoboWBC** is an open-source inference runtime that lets you run humanoid
-whole-body control (WBC) policies through one unified interface. Swap models
-by changing a single TOML file — no code changes required.
+**RoboWBC** is an open-source inference runtime for humanoid whole-body control
+policies. Swap models by changing a single TOML file, then emit the same JSON
+and Rerun reports across smoke tests, MuJoCo runs, and hardware-oriented
+transports.
 
-## What it does
+[Open Live Policy Reports](https://miaodx.com/robowbc/) ·
+[Getting Started](getting-started.md) ·
+[Architecture](architecture.md) ·
+[Python SDK](python-sdk.md)
 
-```
-VLA model (GR00T, LeRobot, StarVLA)
-       ↓  SE3 poses + velocity commands
-  RoboWBC  ← you are here
-       ↓  joint position PD targets @ 50 Hz
-  Robot PD controllers
-```
+![RoboWBC architecture](assets/architecture.svg)
 
-Every WBC model surveyed (GEAR-SONIC, Decoupled WBC, HOVER, OmniH2O, HumanPlus, ExBody)
-shares the same output contract: joint position PD targets at 50 Hz. RoboWBC
-exploits this uniformity to provide a single runtime for all of them.
+## Current status
 
-## Quick links
+| Area | State |
+|------|-------|
+| Live public-policy paths | `gear_sonic`, `decoupled_wbc`, `wbc_agile`, `bfm_zero` |
+| Honest blocked wrappers | `hover` needs a user-exported checkpoint, `wholebody_vla` has no runnable public upstream release |
+| User-supplied backend | `py_model` via `robowbc-pyo3` |
+| Published report | `main` is wired to publish the generated policy report to the live report link above |
 
-- [Getting Started](getting-started.md) — build, download models, run first inference
-- [Adding a New Policy](adding-a-model.md) — integrate a new WBC model in ~50 lines
-- [Adding a New Robot](adding-a-robot.md) — add a TOML config for a new hardware target
-- [Configuration Reference](configuration.md) — full TOML schema documentation
-- [Architecture](architecture.md) — trait design, registry pattern, inference backends
+## Policy coverage
 
-## Supported policies
+| Policy | Example config | Status |
+|--------|----------------|--------|
+| `gear_sonic` | `configs/sonic_g1.toml` | Live public planner path |
+| `decoupled_wbc` | `configs/decoupled_g1.toml` | Live public G1 path |
+| `wbc_agile` | `configs/wbc_agile_g1.toml` | Live public G1 path |
+| `bfm_zero` | `configs/bfm_zero_g1.toml` | Live public G1 path |
+| `hover` | `configs/hover_h1.toml` | Wrapper present, blocked on user checkpoint |
+| `wholebody_vla` | `configs/wholebody_vla_x2.toml` | Experimental contract wrapper |
+| `py_model` | user TOML | User supplied |
 
-| Policy | Format | Hardware | Status |
-|--------|--------|----------|--------|
-| GEAR-SONIC | ONNX (3 models) | Unitree G1 | First target |
-| Decoupled WBC | ONNX | Unitree G1 | Implemented |
+## Start here
+
+- [Getting Started](getting-started.md), build the workspace and run the smoke config
+- [Configuration Reference](configuration.md), understand the TOML surface
+- [Adding a New Policy](adding-a-model.md), wire a new model into the registry
+- [Adding a New Robot](adding-a-robot.md), add a new hardware target
+- [Architecture](architecture.md), understand the crate split and runtime flow
 
 ## License
 
-Apache 2.0 — see `LICENSE`.
+MIT

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,6 +2,12 @@
 
 ## Overview
 
+![RoboWBC architecture](assets/architecture.svg)
+
+The diagram below reflects the current crate split, policy backends,
+transport loop, and reporting path used by the CLI and the published HTML
+report.
+
 ```
 ┌─────────────────────────────────────────────────┐
 │  robowbc-cli  — config loading → control loop    │

--- a/docs/assets/architecture.svg
+++ b/docs/assets/architecture.svg
@@ -1,0 +1,171 @@
+<svg width="1400" height="860" viewBox="0 0 1400 860" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="title desc">
+  <title id="title">RoboWBC architecture</title>
+  <desc id="desc">Config-driven CLI and registry route whole-body control policies through ONNX Runtime or PyO3 backends, then into communication, simulation, and visual reporting outputs.</desc>
+  <defs>
+    <linearGradient id="bg" x1="120" y1="60" x2="1260" y2="800" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F7FBFF"/>
+      <stop offset="0.55" stop-color="#EEF6F1"/>
+      <stop offset="1" stop-color="#FFF6EA"/>
+    </linearGradient>
+    <linearGradient id="panel" x1="0" y1="0" x2="1" y2="1">
+      <stop stop-color="#FFFFFF"/>
+      <stop offset="1" stop-color="#F8FBFD"/>
+    </linearGradient>
+    <linearGradient id="core" x1="380" y1="120" x2="1000" y2="680" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#F3F8FF"/>
+      <stop offset="1" stop-color="#FFFFFF"/>
+    </linearGradient>
+    <linearGradient id="blueCard" x1="0" y1="0" x2="1" y2="1">
+      <stop stop-color="#E9F2FF"/>
+      <stop offset="1" stop-color="#F8FBFF"/>
+    </linearGradient>
+    <linearGradient id="greenCard" x1="0" y1="0" x2="1" y2="1">
+      <stop stop-color="#EAF8EF"/>
+      <stop offset="1" stop-color="#F8FDF9"/>
+    </linearGradient>
+    <linearGradient id="orangeCard" x1="0" y1="0" x2="1" y2="1">
+      <stop stop-color="#FFF1E3"/>
+      <stop offset="1" stop-color="#FFF9F2"/>
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="160%" color-interpolation-filters="sRGB">
+      <feDropShadow dx="0" dy="14" stdDeviation="18" flood-color="#0F172A" flood-opacity="0.10"/>
+    </filter>
+    <marker id="arrow" markerWidth="12" markerHeight="12" refX="10" refY="6" orient="auto">
+      <path d="M1 1L11 6L1 11" fill="none" stroke="#5F6F85" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    </marker>
+  </defs>
+
+  <rect x="20" y="20" width="1360" height="820" rx="36" fill="url(#bg)"/>
+
+  <text x="70" y="92" fill="#142033" font-size="42" font-weight="700" font-family="IBM Plex Sans, Segoe UI, sans-serif">RoboWBC</text>
+  <text x="70" y="126" fill="#506176" font-size="20" font-weight="500" font-family="IBM Plex Sans, Segoe UI, sans-serif">One runtime for switching humanoid WBC policies, transports, and reports.</text>
+
+  <rect x="1020" y="62" width="300" height="56" rx="18" fill="#0F172A" opacity="0.92"/>
+  <text x="1046" y="88" fill="#F8FAFC" font-size="14" font-weight="700" font-family="IBM Plex Sans, Segoe UI, sans-serif">LIVE TODAY</text>
+  <text x="1046" y="108" fill="#D5E6FB" font-size="14" font-weight="500" font-family="IBM Plex Sans, Segoe UI, sans-serif">gear_sonic · decoupled_wbc · wbc_agile · bfm_zero</text>
+
+  <g filter="url(#shadow)">
+    <rect x="60" y="160" width="250" height="560" rx="28" fill="url(#panel)" stroke="#D8E1EB"/>
+    <rect x="360" y="140" width="640" height="590" rx="32" fill="url(#core)" stroke="#D8E1EB"/>
+    <rect x="1050" y="160" width="290" height="560" rx="28" fill="url(#panel)" stroke="#D8E1EB"/>
+  </g>
+
+  <text x="92" y="204" fill="#142033" font-size="26" font-weight="700" font-family="IBM Plex Sans, Segoe UI, sans-serif">Inputs</text>
+  <text x="392" y="188" fill="#142033" font-size="28" font-weight="700" font-family="IBM Plex Sans, Segoe UI, sans-serif">Runtime Core</text>
+  <text x="1082" y="204" fill="#142033" font-size="26" font-weight="700" font-family="IBM Plex Sans, Segoe UI, sans-serif">Outputs</text>
+
+  <g filter="url(#shadow)">
+    <rect x="84" y="236" width="202" height="92" rx="20" fill="url(#blueCard)" stroke="#C9D8EA"/>
+    <rect x="84" y="346" width="202" height="92" rx="20" fill="url(#blueCard)" stroke="#C9D8EA"/>
+    <rect x="84" y="456" width="202" height="92" rx="20" fill="url(#blueCard)" stroke="#C9D8EA"/>
+    <rect x="84" y="566" width="202" height="118" rx="20" fill="url(#blueCard)" stroke="#C9D8EA"/>
+  </g>
+
+  <g font-family="IBM Plex Sans, Segoe UI, sans-serif" fill="#142033">
+    <text x="106" y="270" font-size="18" font-weight="700">TOML config</text>
+    <text x="106" y="296" font-size="14" fill="#5F6F85">policy name, model paths,</text>
+    <text x="106" y="316" font-size="14" fill="#5F6F85">robot setup, vis/report opts</text>
+
+    <text x="106" y="380" font-size="18" font-weight="700">Checkpoint assets</text>
+    <text x="106" y="406" font-size="14" fill="#5F6F85">public downloads or</text>
+    <text x="106" y="426" font-size="14" fill="#5F6F85">user-supplied local models</text>
+
+    <text x="106" y="490" font-size="18" font-weight="700">Command streams</text>
+    <text x="106" y="516" font-size="14" fill="#5F6F85">velocity, motion tokens,</text>
+    <text x="106" y="536" font-size="14" fill="#5F6F85">end-effector or body poses</text>
+
+    <text x="106" y="600" font-size="18" font-weight="700">Robot state</text>
+    <text x="106" y="626" font-size="14" fill="#5F6F85">joint positions, velocities,</text>
+    <text x="106" y="646" font-size="14" fill="#5F6F85">gravity vector, IMU gyro,</text>
+    <text x="106" y="666" font-size="14" fill="#5F6F85">transport feedback loop</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="398" y="214" width="564" height="88" rx="22" fill="url(#blueCard)" stroke="#C9D8EA"/>
+    <rect x="398" y="324" width="248" height="110" rx="22" fill="url(#blueCard)" stroke="#C9D8EA"/>
+    <rect x="670" y="324" width="292" height="110" rx="22" fill="#F9FBFD" stroke="#C9D8EA"/>
+    <rect x="398" y="462" width="172" height="118" rx="22" fill="url(#greenCard)" stroke="#C9E0D0"/>
+    <rect x="594" y="462" width="172" height="118" rx="22" fill="url(#greenCard)" stroke="#C9E0D0"/>
+    <rect x="790" y="462" width="172" height="118" rx="22" fill="url(#orangeCard)" stroke="#E7D3BE"/>
+    <rect x="398" y="610" width="266" height="88" rx="22" fill="url(#blueCard)" stroke="#C9D8EA"/>
+    <rect x="692" y="610" width="270" height="88" rx="22" fill="url(#greenCard)" stroke="#C9E0D0"/>
+  </g>
+
+  <g font-family="IBM Plex Sans, Segoe UI, sans-serif">
+    <text x="424" y="248" fill="#142033" font-size="24" font-weight="700">robowbc-cli</text>
+    <text x="424" y="276" fill="#5F6F85" font-size="15">run, init, config loading, policy selection, control-loop orchestration</text>
+
+    <text x="424" y="360" fill="#142033" font-size="22" font-weight="700">robowbc-registry</text>
+    <text x="424" y="388" fill="#5F6F85" font-size="15">inventory-based discovery</text>
+    <text x="424" y="410" fill="#5F6F85" font-size="15">and config-driven builders</text>
+
+    <text x="696" y="360" fill="#142033" font-size="22" font-weight="700">robowbc-core</text>
+    <text x="696" y="388" fill="#5F6F85" font-size="15">WbcPolicy trait</text>
+    <text x="696" y="410" fill="#5F6F85" font-size="15">Observation · WbcCommand</text>
+    <text x="696" y="432" fill="#5F6F85" font-size="15">JointPositionTargets · RobotConfig</text>
+
+    <text x="422" y="498" fill="#142033" font-size="20" font-weight="700">robowbc-ort</text>
+    <text x="422" y="524" fill="#5F6F85" font-size="14">Live ONNX-backed paths</text>
+    <text x="422" y="546" fill="#5F6F85" font-size="14">gear_sonic · decoupled_wbc</text>
+    <text x="422" y="566" fill="#5F6F85" font-size="14">wbc_agile · bfm_zero</text>
+
+    <text x="618" y="498" fill="#142033" font-size="20" font-weight="700">robowbc-pyo3</text>
+    <text x="618" y="524" fill="#5F6F85" font-size="14">Python-backed runtime</text>
+    <text x="618" y="546" fill="#5F6F85" font-size="14">for user-supplied `py_model`</text>
+
+    <text x="814" y="498" fill="#142033" font-size="20" font-weight="700">Blocked / future</text>
+    <text x="814" y="524" fill="#5F6F85" font-size="14">hover needs checkpoint</text>
+    <text x="814" y="546" fill="#5F6F85" font-size="14">wholebody_vla needs runnable upstream</text>
+
+    <text x="424" y="644" fill="#142033" font-size="20" font-weight="700">robowbc-comm + robowbc-sim</text>
+    <text x="424" y="670" fill="#5F6F85" font-size="14">synthetic, MuJoCo, and robot-facing transport loop</text>
+
+    <text x="718" y="644" fill="#142033" font-size="20" font-weight="700">robowbc-vis</text>
+    <text x="718" y="670" fill="#5F6F85" font-size="14">Rerun `.rrd` capture and JSON report export</text>
+  </g>
+
+  <g filter="url(#shadow)">
+    <rect x="1076" y="236" width="238" height="92" rx="20" fill="url(#greenCard)" stroke="#C9E0D0"/>
+    <rect x="1076" y="346" width="238" height="92" rx="20" fill="url(#blueCard)" stroke="#C9D8EA"/>
+    <rect x="1076" y="456" width="238" height="92" rx="20" fill="url(#blueCard)" stroke="#C9D8EA"/>
+    <rect x="1076" y="566" width="238" height="118" rx="20" fill="url(#orangeCard)" stroke="#E7D3BE"/>
+  </g>
+
+  <g font-family="IBM Plex Sans, Segoe UI, sans-serif" fill="#142033">
+    <text x="1098" y="270" font-size="18" font-weight="700">Joint targets @ 50 Hz</text>
+    <text x="1098" y="296" font-size="14" fill="#5F6F85">uniform output contract</text>
+    <text x="1098" y="316" font-size="14" fill="#5F6F85">for policy switching</text>
+
+    <text x="1098" y="380" font-size="18" font-weight="700">Robot or MuJoCo</text>
+    <text x="1098" y="406" font-size="14" fill="#5F6F85">transport applies commands</text>
+    <text x="1098" y="426" font-size="14" fill="#5F6F85">and feeds observations back</text>
+
+    <text x="1098" y="490" font-size="18" font-weight="700">Run artifacts</text>
+    <text x="1098" y="516" font-size="14" fill="#5F6F85">per-policy JSON, logs,</text>
+    <text x="1098" y="536" font-size="14" fill="#5F6F85">and downloadable `.rrd` traces</text>
+
+    <text x="1098" y="600" font-size="18" font-weight="700">Published HTML report</text>
+    <text x="1098" y="626" font-size="14" fill="#5F6F85">embedded Rerun viewer,</text>
+    <text x="1098" y="646" font-size="14" fill="#5F6F85">current live policies, honest</text>
+    <text x="1098" y="666" font-size="14" fill="#5F6F85">blocked cards on Pages</text>
+  </g>
+
+  <g stroke="#5F6F85" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" marker-end="url(#arrow)">
+    <line x1="286" y1="282" x2="398" y2="258"/>
+    <line x1="286" y1="392" x2="398" y2="258"/>
+    <line x1="286" y1="502" x2="398" y2="258"/>
+    <line x1="286" y1="626" x2="398" y2="378"/>
+    <line x1="680" y1="302" x2="520" y2="324"/>
+    <line x1="720" y1="302" x2="814" y2="462"/>
+    <line x1="780" y1="434" x2="780" y2="462"/>
+    <line x1="484" y1="580" x2="484" y2="610"/>
+    <line x1="680" y1="580" x2="826" y2="610"/>
+    <line x1="664" y1="654" x2="1076" y2="282"/>
+    <line x1="962" y1="654" x2="1076" y2="502"/>
+  </g>
+
+  <path d="M1188 436C1188 496 1120 520 1008 520C902 520 280 554 206 620" stroke="#94A3B8" stroke-width="3" stroke-linecap="round" stroke-dasharray="8 10" marker-end="url(#arrow)"/>
+  <text x="1048" y="478" fill="#5F6F85" font-size="14" font-weight="600" font-family="IBM Plex Sans, Segoe UI, sans-serif">observation feedback loop</text>
+
+  <text x="394" y="770" fill="#506176" font-size="15" font-family="IBM Plex Sans, Segoe UI, sans-serif">Same crates power the CLI smoke path, live public-policy runs, JSON logs, raw `.rrd` traces, and the published HTML report.</text>
+</svg>

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -59,23 +59,29 @@ python scripts/generate_policy_showcase.py \
 
 The output folder contains:
 
-- `index.html` with embedded interactive Rerun viewers for each successful run
+- `index.html` with lazy-loaded interactive Rerun panes for each successful run
 - raw `*.rrd`, `*.json`, and `*.log` files per policy
-- `_rerun_web_viewer/`, the vendored web runtime used by the embedded panes
+- `_rerun_web_viewer/`, the vendored web runtime used by those panes
 
 For the most reliable local viewing path, serve that folder over HTTP:
 
 ```bash
-cd ./artifacts/policy-showcase
-python -m http.server 8000
+python scripts/serve_showcase.py \
+  --dir ./artifacts/policy-showcase \
+  --port 8000 \
+  --open
 ```
 
-Then open `http://127.0.0.1:8000`. If the public checkpoints are present, the
-report includes real CPU `gear_sonic`, `decoupled_wbc`, `wbc_agile`, and
-`bfm_zero` cards; otherwise missing integrations are rendered as blocked with
-explicit missing-path reasons. The same generator is used in CI for both the
-downloadable `policy-showcase` artifact and the `main`-branch GitHub Pages
-site.
+Then open `http://127.0.0.1:8000`. Do not open the generated `index.html`
+directly via `file://`; the interactive viewer expects an HTTP-served folder.
+The helper script also accepts `--bind` if you want to expose the local preview
+to another machine on the same network. If the public checkpoints are present,
+the report includes real CPU
+`gear_sonic`, `decoupled_wbc`, `wbc_agile`, and `bfm_zero` cards; otherwise
+missing integrations are rendered as blocked with explicit missing-path
+reasons. The page lazy-loads each `.rrd` recording when a card becomes visible,
+which keeps the same static bundle usable in CI artifacts and on the
+`main`-branch GitHub Pages site.
 
 ## Run GEAR-SONIC with real checkpoints
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -73,8 +73,9 @@ python -m http.server 8000
 Then open `http://127.0.0.1:8000`. If the public checkpoints are present, the
 report includes real CPU `gear_sonic`, `decoupled_wbc`, `wbc_agile`, and
 `bfm_zero` cards; otherwise missing integrations are rendered as blocked with
-explicit missing-path reasons. The same generator is used in CI for the
-downloadable `policy-showcase` artifact.
+explicit missing-path reasons. The same generator is used in CI for both the
+downloadable `policy-showcase` artifact and the `main`-branch GitHub Pages
+site.
 
 ## Run GEAR-SONIC with real checkpoints
 

--- a/scripts/generate_policy_showcase.py
+++ b/scripts/generate_policy_showcase.py
@@ -327,6 +327,15 @@ def run_policy(repo_root: Path, binary: Path, output_dir: Path, policy: dict[str
         raise SystemExit(
             f"policy showcase run failed for {policy_id} with exit code {proc.returncode}; see {log_path}"
         )
+    if not json_path.exists():
+        raise SystemExit(
+            f"policy showcase run for {policy_id} did not write the expected report JSON at {json_path}; see {log_path}"
+        )
+    if not rrd_path.exists():
+        raise SystemExit(
+            f"policy showcase run for {policy_id} did not write the expected Rerun recording at {rrd_path}; "
+            "build robowbc with --features robowbc-cli/vis before running the showcase generator"
+        )
 
     report = json.loads(json_path.read_text(encoding="utf-8"))
     report["status"] = "ok"
@@ -854,6 +863,10 @@ def main() -> int:
     repo_root = Path(args.repo_root).resolve()
     output_dir = Path(args.output_dir).resolve()
     output_dir.mkdir(parents=True, exist_ok=True)
+    # GitHub Pages ignores underscore-prefixed asset directories unless the site
+    # root opts out of Jekyll processing. The embedded Rerun viewer lives under
+    # _rerun_web_viewer/, so always emit the marker for deployed reports.
+    (output_dir / ".nojekyll").write_text("", encoding="utf-8")
     binary = Path(args.robowbc_binary).resolve()
     if not binary.exists():
         raise SystemExit(f"robowbc binary not found: {binary}")

--- a/scripts/generate_policy_showcase.py
+++ b/scripts/generate_policy_showcase.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import argparse
-import base64
 import datetime as dt
 import html
 import json
@@ -412,26 +411,6 @@ def pill(label: str, css_class: str) -> str:
     return f'<span class="pill {css_class}">{html.escape(label)}</span>'
 
 
-def inline_recording_payload(entries: list[dict[str, object]], output_dir: Path) -> list[dict[str, str]]:
-    payload: list[dict[str, str]] = []
-    for entry in entries:
-        if entry.get("status") != "ok":
-            continue
-        meta = entry["_meta"]
-        rrd_file = meta.get("rrd_file")
-        if not isinstance(rrd_file, str) or not rrd_file:
-            continue
-        rrd_path = output_dir / rrd_file
-        payload.append(
-            {
-                "policy_id": str(entry["policy_name"]),
-                "title": str(meta["title"]),
-                "rrd_file": rrd_file,
-                "base64": base64.b64encode(rrd_path.read_bytes()).decode("ascii"),
-            }
-        )
-    return payload
-
 
 def render_html(entries: list[dict[str, object]], output_dir: Path, repo_root: Path) -> None:
     generated_at = dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%d %H:%M:%SZ")
@@ -442,7 +421,6 @@ def render_html(entries: list[dict[str, object]], output_dir: Path, repo_root: P
     commit_link = f"{server}/{repo}/commit/{sha}" if sha and repo else ""
     run_link = f"{server}/{repo}/actions/runs/{run_id}" if run_id and repo else ""
     viewer_assets = vendor_rerun_web_viewer(repo_root, output_dir)
-    recordings_json = json.dumps(inline_recording_payload(entries, output_dir), separators=(",", ":"))
 
     overview_rows: list[str] = []
     cards: list[str] = []
@@ -597,12 +575,12 @@ def render_html(entries: list[dict[str, object]], output_dir: Path, repo_root: P
   <div class="rerun-block">
     <div class="rerun-block-header">
       <strong>Embedded Rerun viewer</strong>
-      <span class="muted">Loaded from the saved <code>{html.escape(str(meta['rrd_file']))}</code> recording.</span>
+      <span class="muted">Fetches <code>{html.escape(str(meta['rrd_file']))}</code> lazily when the card enters the viewport.</span>
     </div>
-    <div class="rerun-stage" data-rerun-policy="{html.escape(str(entry['policy_name']))}">
+    <div class="rerun-stage" data-rerun-policy="{html.escape(str(entry['policy_name']))}" data-rrd-file="{html.escape(str(meta['rrd_file']))}">
       <div class="rerun-stage-placeholder">
         <strong>Preparing interactive view</strong>
-        <span>Mounts automatically when this card enters the viewport.</span>
+        <span>Loads the viewer runtime and recording on demand when visible.</span>
       </div>
     </div>
   </div>
@@ -732,7 +710,7 @@ def render_html(entries: list[dict[str, object]], output_dir: Path, repo_root: P
     <section class="hero">
       <h1>RoboWBC Policy Showcase</h1>
       <p>This artifact is generated automatically in CI from the set of real policy integrations that are wired today. When a public checkpoint bundle is cached, the card runs live; when assets are unavailable, the page degrades to a visible blocked card instead of pretending the integration exists.</p>
-      <p class="muted">Each successful card now embeds its saved Rerun recording directly in-page. The raw <code>.rrd</code> files are still available for download, and serving the folder over HTTP remains the most reliable way to open the interactive viewer locally.</p>
+      <p class="muted">Each successful card lazy-loads its saved Rerun recording when visible. The raw <code>.rrd</code> files are still available for download, and serving the folder over HTTP remains the most reliable way to open the interactive viewer locally.</p>
       <div class="meta-row">
         <span>Generated: {html.escape(generated_at)}</span>
         <span>Commit: {commit_html or 'local'}</span>
@@ -762,37 +740,28 @@ def render_html(entries: list[dict[str, object]], output_dir: Path, repo_root: P
       <ul>{excluded}</ul>
     </section>
   </main>
-  <script id="rerun-recordings" type="application/json">{recordings_json}</script>
   <script type="module">
-    import {{ WebViewer }} from "{viewer_assets['module_path']}";
-
-    const recordingData = JSON.parse(document.getElementById("rerun-recordings").textContent);
-    const recordings = new Map(recordingData.map((item) => [item.policy_id, item]));
+    let webViewerCtor = null;
     const viewers = new Map();
 
-    function base64ToUint8Array(base64String) {{
-      const binary = atob(base64String);
-      const bytes = new Uint8Array(binary.length);
-      for (let idx = 0; idx < binary.length; idx += 1) {{
-        bytes[idx] = binary.charCodeAt(idx);
+    async function getWebViewerCtor() {{
+      if (webViewerCtor === null) {{
+        const module = await import("{viewer_assets['module_path']}");
+        webViewerCtor = module.WebViewer;
       }}
-      return bytes;
+      return webViewerCtor;
     }}
 
-    function recordingBlobUrl(policyId) {{
-      const recording = recordings.get(policyId);
-      if (!recording) {{
-        throw new Error(`missing embedded recording for ${{policyId}}`);
+    function recordingUrl(stage) {{
+      const rrdFile = stage.dataset.rrdFile;
+      if (!rrdFile) {{
+        throw new Error("missing data-rrd-file attribute");
       }}
-      if (!recording.blobUrl) {{
-        const bytes = base64ToUint8Array(recording.base64);
-        recording.blobUrl = URL.createObjectURL(new Blob([bytes], {{ type: "application/octet-stream" }}));
-        delete recording.base64;
-      }}
-      return recording.blobUrl;
+      return new URL(rrdFile, window.location.href).toString();
     }}
 
     function showStageError(stage, message) {{
+      stage.dataset.loading = "false";
       stage.replaceChildren();
       const errorNode = document.createElement("div");
       errorNode.className = "rerun-stage-error";
@@ -804,6 +773,13 @@ def render_html(entries: list[dict[str, object]], output_dir: Path, repo_root: P
       stage.append(errorNode);
     }}
 
+    function showFileProtocolMessage(stage) {{
+      showStageError(
+        stage,
+        "This report was opened via file://. Serve the folder over HTTP, for example with `python scripts/serve_showcase.py --dir ./artifacts/policy-showcase`."
+      );
+    }}
+
     async function mountStage(stage) {{
       const policyId = stage.dataset.rerunPolicy;
       if (!policyId || viewers.has(policyId)) {{
@@ -813,8 +789,9 @@ def render_html(entries: list[dict[str, object]], output_dir: Path, repo_root: P
       stage.dataset.loading = "true";
       stage.replaceChildren();
       try {{
+        const WebViewer = await getWebViewerCtor();
         const viewer = new WebViewer();
-        await viewer.start(recordingBlobUrl(policyId), stage, {{
+        await viewer.start(recordingUrl(stage), stage, {{
           width: "100%",
           height: "420px",
           hide_welcome_screen: true,
@@ -840,15 +817,17 @@ def render_html(entries: list[dict[str, object]], output_dir: Path, repo_root: P
     }}, {{ rootMargin: "180px 0px" }});
 
     const stages = [...document.querySelectorAll(".rerun-stage[data-rerun-policy]")];
-    if (stages.length > 0) {{
-      void mountStage(stages[0]);
-    }}
-    for (const stage of stages.slice(1)) {{
-      observer.observe(stage);
-    }}
-
     if (window.location.protocol === "file:") {{
-      console.warn("Embedded Rerun viewers are most reliable when the showcase folder is served over HTTP.");
+      for (const stage of stages) {{
+        showFileProtocolMessage(stage);
+      }}
+    }} else {{
+      if (stages.length > 0) {{
+        void mountStage(stages[0]);
+      }}
+      for (const stage of stages.slice(1)) {{
+        observer.observe(stage);
+      }}
     }}
   </script>
 </body>

--- a/scripts/generate_policy_showcase.py
+++ b/scripts/generate_policy_showcase.py
@@ -85,7 +85,7 @@ POLICIES = [
         "required_paths": [
             "models/hover/hover_h1.onnx",
         ],
-        "blocked_reason": "HOVER does not ship public pretrained ONNX weights. Export your own checkpoint from the upstream training repo to enable this card.",
+        "blocked_reason": "HOVER ships public code and deployment tooling, but the public repo/releases do not include pretrained checkpoints. Provide your own exported ONNX model to enable this card.",
     },
     {
         "id": "wbc_agile",
@@ -108,16 +108,16 @@ POLICIES = [
         "title": "WholeBodyVLA",
         "config": "configs/wholebody_vla_x2.toml",
         "source": "OpenDriveLab",
-        "summary": "Real AGIBOT X2 kinematic-pose wrapper for WholeBodyVLA, ready to run when a user-exported ONNX checkpoint is available.",
-        "coverage": "KinematicPose-driven whole-body VLA handoff",
-        "execution_kind": "real",
-        "checkpoint_source": "User-exported WholeBodyVLA ONNX checkpoint",
+        "summary": "Experimental AGIBOT X2 kinematic-pose contract wrapper for WholeBodyVLA. The public upstream project does not yet expose a runnable inference release, so this card documents the expected handoff shape and stays blocked until a compatible local model exists.",
+        "coverage": "Experimental KinematicPose contract placeholder",
+        "execution_kind": "experimental",
+        "checkpoint_source": "Local/private WholeBodyVLA ONNX checkpoint",
         "command_source": "runtime.kinematic_pose",
         "model_artifact": "models/wholebody_vla/wholebody_vla_x2.onnx",
         "required_paths": [
             "models/wholebody_vla/wholebody_vla_x2.onnx",
         ],
-        "blocked_reason": "WholeBodyVLA does not publish a ready-to-run ONNX checkpoint. Export one from the upstream training repo to enable this card.",
+        "blocked_reason": "The public WholeBodyVLA repo does not currently provide runnable code or ONNX checkpoints. This wrapper remains blocked until a compatible local model is available.",
     },
 ]
 
@@ -651,6 +651,8 @@ def render_html(entries: list[dict[str, object]], output_dir: Path, repo_root: P
       --shadow: 0 18px 50px rgba(20, 32, 51, 0.08);
       --real-bg: #e7f7ef;
       --real-fg: #11643a;
+      --experimental-bg: #fff4e5;
+      --experimental-fg: #9a3412;
       --fixture-bg: #e7f0ff;
       --fixture-fg: #1146a6;
       --blocked-bg: #fff1f2;
@@ -679,6 +681,7 @@ def render_html(entries: list[dict[str, object]], output_dir: Path, repo_root: P
     .badge-row {{ display: flex; flex-wrap: wrap; gap: 8px; justify-content: flex-end; }}
     .pill {{ border-radius: 999px; padding: 8px 12px; font-size: 0.82rem; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; display: inline-flex; align-items: center; }}
     .pill.real {{ background: var(--real-bg); color: var(--real-fg); }}
+    .pill.experimental {{ background: var(--experimental-bg); color: var(--experimental-fg); }}
     .pill.fixture {{ background: var(--fixture-bg); color: var(--fixture-fg); }}
     .pill.blocked {{ background: var(--blocked-bg); color: var(--blocked-fg); }}
     .pill.ok {{ background: var(--real-bg); color: var(--real-fg); }}

--- a/scripts/serve_showcase.py
+++ b/scripts/serve_showcase.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Serve a generated RoboWBC showcase bundle over HTTP for local debugging."""
+
+from __future__ import annotations
+
+import argparse
+import functools
+import http.server
+import socketserver
+import webbrowser
+from pathlib import Path
+
+
+class ShowcaseRequestHandler(http.server.SimpleHTTPRequestHandler):
+    extensions_map = {
+        **http.server.SimpleHTTPRequestHandler.extensions_map,
+        ".wasm": "application/wasm",
+        ".rrd": "application/octet-stream",
+    }
+
+    def end_headers(self) -> None:
+        self.send_header("Cache-Control", "no-store")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        super().end_headers()
+
+
+class ReusableTCPServer(socketserver.TCPServer):
+    allow_reuse_address = True
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--dir",
+        default=".",
+        help="Directory containing the generated showcase bundle and index.html",
+    )
+    parser.add_argument("--bind", default="127.0.0.1", help="Address to bind the local server")
+    parser.add_argument("--port", type=int, default=8000, help="Port to bind the local server")
+    parser.add_argument("--open", action="store_true", help="Open the served page in the default browser")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    root = Path(args.dir).resolve()
+    if not root.is_dir():
+        raise SystemExit(f"showcase directory not found: {root}")
+    if not (root / "index.html").is_file():
+        raise SystemExit(f"expected {root / 'index.html'} to exist")
+
+    handler = functools.partial(ShowcaseRequestHandler, directory=str(root))
+    with ReusableTCPServer((args.bind, args.port), handler) as httpd:
+        url = f"http://{args.bind}:{args.port}/"
+        print(f"Serving RoboWBC showcase from {root}")
+        print(f"Open {url}")
+        print("Press Ctrl-C to stop.")
+        if args.open:
+            webbrowser.open(url)
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            print("\nStopping showcase server.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- clean up the README and architecture overview so the current public-policy status is easier to scan
- publish the policy showcase to GitHub Pages and keep the PR artifact path intact
- serve showcase bundles over HTTP locally and lazy-load Rerun recordings instead of inlining them

## Verification
- cargo build
- cargo check
- cargo test
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check
- cargo doc --workspace --no-deps
- /tmp/robowbc-mdbook/mdbook build
- regenerated local showcase and verified both file:// fallback messaging and HTTP-served viewer asset loading
