### PR TITLE
feat: make the public showcase honestly MuJoCo-backed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,11 @@ jobs:
         run: mdbook build
 
   showcase:
-    name: Policy showcase (HTML + Rerun)
+    name: Policy showcase (HTML + MuJoCo + Rerun)
     runs-on: ubuntu-latest
     needs: rust
+    env:
+      MUJOCO_DOWNLOAD_DIR: /tmp/mujoco
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -100,8 +102,8 @@ jobs:
           bash scripts/download_wbc_agile_models.sh models/wbc-agile
           bash scripts/download_bfm_zero_models.sh models/bfm_zero
 
-      - name: Build robowbc with vis feature
-        run: cargo build --bin robowbc --features robowbc-cli/vis
+      - name: Build robowbc with sim + vis showcase features
+        run: cargo build --bin robowbc --features robowbc-cli/sim-auto-download,robowbc-cli/vis
 
       - name: Generate mixed-source policy showcase
         run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arboard"
 version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2650,6 +2659,17 @@ checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
  "serde_core",
+]
+
+[[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5225,8 +5245,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82c4e2adc7cf4b96a8b4e53290a206f40304d72c805df3034beae1b3f1f9eff3"
 dependencies = [
  "bytemuck",
+ "flate2",
  "paste",
  "pkg-config",
+ "sha2",
+ "tar",
+ "ureq",
+ "zip 6.0.0",
 ]
 
 [[package]]
@@ -9233,7 +9258,7 @@ dependencies = [
  "re_log",
  "thiserror 2.0.18",
  "tiny_http",
- "zip",
+ "zip 8.5.1",
 ]
 
 [[package]]
@@ -13690,6 +13715,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.13.1",
+ "memchr",
+ "zopfli",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ preview flow in [Open or generate the visual report](#open-or-generate-the-visua
 | Runtime | Rust workspace with registry-driven policy loading, ONNX Runtime and PyO3 backends, MuJoCo and communication transports, plus JSON and Rerun reporting |
 | Live public-policy paths | `gear_sonic`, `decoupled_wbc`, `wbc_agile`, `bfm_zero` |
 | Honest blocked wrappers | `hover` needs a user-exported checkpoint, `wholebody_vla` still lacks a runnable public upstream release |
-| Published visual report | The `main` workflow is wired to build the same HTML report in CI and publish it to the live report link above |
+| Published visual report | The `main` workflow builds the same HTML report in CI, runs the public G1 cards through MuJoCo, and publishes the result to the live report link above |
 
 ## Policy status
 
@@ -75,7 +75,11 @@ Blocked or local-only:
 The hosted showcase keeps the working public-asset policies first and pushes
 blocked or local-only integrations lower on the page. The live public cards are
 `gear_sonic`, `decoupled_wbc`, `wbc_agile`, and `bfm_zero`, each with a stable
-anchor you can link to directly.
+anchor you can link to directly. Their showcase recordings are MuJoCo-backed
+via a meshless public G1 MJCF fallback because this repo does not redistribute
+Unitree's STL mesh bundle; `wbc_agile` currently reuses the public 29-DOF G1
+embodiment, so its extra finger joints stay at their default pose in the
+recorded scene.
 
 ## Quick start
 
@@ -118,7 +122,8 @@ The same report generator powers both the local HTML bundle and the published
 GitHub Pages site.
 
 ```bash
-cargo build --bin robowbc --features robowbc-cli/vis
+export MUJOCO_DOWNLOAD_DIR="$(pwd)/.cache/mujoco"
+cargo build --bin robowbc --features robowbc-cli/sim-auto-download,robowbc-cli/vis
 python scripts/generate_policy_showcase.py \
   --repo-root . \
   --robowbc-binary ./target/debug/robowbc \
@@ -130,12 +135,20 @@ python scripts/serve_showcase.py \
   --open
 ```
 
+On Linux and Windows, the first `sim-auto-download` build unpacks MuJoCo into
+`MUJOCO_DOWNLOAD_DIR`. If you already manage a system MuJoCo install, building
+with `robowbc-cli/sim,robowbc-cli/vis` still works too.
+
 The output folder contains `index.html`, `manifest.json`, per-policy `*.json`
 run summaries, raw `*.rrd` recordings, logs, and the vendored Rerun web viewer
 runtime. The HTML now lazy-loads each `.rrd` file when its card becomes
 visible, so the bundle stays static-site-friendly for both local debug and
-GitHub Pages. Do not open `index.html` directly via `file://`; serve the
-folder over HTTP with `python scripts/serve_showcase.py --dir ...` instead.
+GitHub Pages. Successful public cards are executed through MuJoCo; on the
+public G1 path the loader transparently uses a meshless MJCF fallback unless
+you provide the upstream STL bundle locally, and the generator refuses to
+silently fall back to the synthetic transport. Do not open `index.html`
+directly via `file://`; serve the folder over HTTP with
+`python scripts/serve_showcase.py --dir ...` instead.
 The local helper accepts `--dir`, `--bind`, `--port`, and `--open` so the same
 bundle can be previewed from any generated folder.
 Pull requests keep the downloadable `policy-showcase` artifact, and `main`

--- a/crates/robowbc-cli/Cargo.toml
+++ b/crates/robowbc-cli/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 [features]
 default = []
 sim = ["dep:robowbc-sim", "robowbc-sim/mujoco"]
+sim-auto-download = ["sim", "robowbc-sim/mujoco-auto-download"]
 vis = ["dep:robowbc-vis", "robowbc-vis/rerun"]
 
 [dependencies]

--- a/crates/robowbc-cli/src/main.rs
+++ b/crates/robowbc-cli/src/main.rs
@@ -105,7 +105,7 @@ struct AppConfig {
     /// Optional JSON report written after a run completes.
     #[serde(default)]
     report: Option<ReportConfig>,
-    /// MuJoCo simulation config. When present and the `sim` feature is
+    /// `MuJoCo` simulation config. When present and the `sim` feature is
     /// enabled, the control loop uses [`MujocoTransport`] instead of the
     /// synthetic transport.
     #[cfg(feature = "sim")]
@@ -468,6 +468,7 @@ fn build_policy(app: &AppConfig) -> Result<(Box<dyn WbcPolicy>, RobotConfig), St
     Ok((policy, robot))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn run_control_loop_inner<T: RobotTransport>(
     transport: &mut T,
     policy: &dyn WbcPolicy,
@@ -537,7 +538,6 @@ fn run_control_loop_inner<T: RobotTransport>(
                     WbcCommand::MotionTokens(tokens) => {
                         let _ = vis.log_motion_tokens(tokens);
                     }
-                    WbcCommand::KinematicPose(_) => {}
                     _ => {}
                 }
             }
@@ -572,7 +572,7 @@ fn run_control_loop(
     running: &AtomicBool,
     hardware: Option<UnitreeG1Config>,
     #[cfg(feature = "sim")] sim_config: Option<MujocoConfig>,
-    #[cfg(feature = "vis")] vis_config: Option<RerunConfig>,
+    #[cfg(feature = "vis")] vis_config: Option<&RerunConfig>,
 ) -> Result<Metrics, String> {
     if comm.frequency_hz == 0 {
         return Err("comm.frequency_hz must be > 0".to_owned());
@@ -588,7 +588,7 @@ fn run_control_loop(
     // Optionally initialise Rerun visualizer.
     #[cfg(feature = "vis")]
     let mut visualizer: Option<RerunVisualizer> = match vis_config {
-        Some(ref cfg) => {
+        Some(cfg) => {
             let vis = RerunVisualizer::new(cfg, robot)
                 .map_err(|e| format!("failed to start Rerun visualizer: {e}"))?;
             println!("rerun visualizer started (app_id={})", cfg.app_id);
@@ -624,7 +624,14 @@ fn run_control_loop(
         } else if let Some(sim_cfg) = sim_config {
             let mut transport = MujocoTransport::new(sim_cfg, robot.clone())
                 .map_err(|e| format!("mujoco init failed: {e}"))?;
-            println!("mujoco simulation transport active");
+            println!(
+                "mujoco simulation transport active (mapped_joints={}/{}, model={}, model_variant={}, meshless_public_fallback={})",
+                transport.mapped_joint_count(),
+                robot.joint_count,
+                transport.sim_config().model_path.display(),
+                transport.model_variant(),
+                transport.uses_meshless_public_fallback()
+            );
             let (ticks, dropped, inf) = run_control_loop_inner(
                 &mut transport,
                 policy,
@@ -806,7 +813,7 @@ fn main() {
         #[cfg(feature = "sim")]
         app.sim,
         #[cfg(feature = "vis")]
-        app.vis,
+        app.vis.as_ref(),
     ) {
         Ok(metrics) => {
             println!(

--- a/crates/robowbc-sim/Cargo.toml
+++ b/crates/robowbc-sim/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 [features]
 default = []
 mujoco = ["dep:mujoco-rs"]
+mujoco-auto-download = ["mujoco", "mujoco-rs/auto-download-mujoco"]
 
 [dependencies]
 robowbc-core = { path = "../robowbc-core" }

--- a/crates/robowbc-sim/src/lib.rs
+++ b/crates/robowbc-sim/src/lib.rs
@@ -9,6 +9,9 @@
 //!
 //! - **`mujoco`** — enables the `MuJoCo` backend via the `mujoco-rs` crate.
 //!   Requires the `MuJoCo` C library (v3.0+) to be installed on the host.
+//! - **`mujoco-auto-download`** — Linux/Windows convenience feature that
+//!   enables `mujoco-rs`' automatic runtime download path. Requires
+//!   `MUJOCO_DOWNLOAD_DIR` to point at an absolute extraction directory.
 //!
 //! # Example
 //!

--- a/crates/robowbc-sim/src/transport.rs
+++ b/crates/robowbc-sim/src/transport.rs
@@ -1,71 +1,107 @@
-//! MuJoCo-backed [`RobotTransport`] implementation.
+//! `MuJoCo`-backed [`RobotTransport`] implementation.
 
 use crate::{MujocoConfig, SimError};
-use mujoco_rs::{MjData, MjModel};
+use mujoco_rs::wrappers::{MjData, MjModel, MjtSensor, MjtTrn};
 use robowbc_comm::{CommError, ImuSample, JointState, RobotTransport};
 use robowbc_core::{JointPositionTargets, RobotConfig};
-use std::time::Instant;
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
-/// A [`RobotTransport`] that steps a MuJoCo physics simulation.
+#[derive(Debug, Clone, Copy, Default)]
+struct JointMapping {
+    qpos_adr: Option<usize>,
+    qvel_adr: Option<usize>,
+    actuator_id: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct SensorSpan {
+    start: usize,
+    len: usize,
+}
+
+struct LoadedModel {
+    model: MjModel,
+    model_variant: &'static str,
+}
+
+/// A [`RobotTransport`] that steps a `MuJoCo` physics simulation.
 ///
-/// Joint states are read from MuJoCo sensor data (jointpos / jointvel) and
-/// IMU data from the accelerometer sensor. Targets are written to `ctrl` and
-/// the simulation is advanced by [`MujocoConfig::substeps`] sub-steps on each
+/// Joint states are read from `MuJoCo` `qpos` / `qvel`, IMU data comes from the
+/// model's gyro and accelerometer sensors, and targets are written into the
+/// actuator `ctrl` vector. The simulation is advanced by
+/// [`MujocoConfig::substeps`] on each
 /// [`send_joint_targets`](RobotTransport::send_joint_targets) call.
 pub struct MujocoTransport {
-    model: MjModel,
-    data: MjData,
+    data: MjData<Box<MjModel>>,
     robot_config: RobotConfig,
     config: MujocoConfig,
-    /// Sensor-data index where the 29 jointpos sensors begin.
-    jointpos_offset: usize,
-    /// Sensor-data index where the 29 jointvel sensors begin.
-    jointvel_offset: usize,
-    /// Sensor-data index of the IMU gyro (3 values).
-    gyro_offset: usize,
-    /// Sensor-data index of the IMU accelerometer (3 values).
-    accel_offset: usize,
+    joint_mappings: Vec<JointMapping>,
+    mapped_joint_count: usize,
+    gyro_sensor: SensorSpan,
+    accel_sensor: SensorSpan,
+    model_variant: &'static str,
 }
 
 impl MujocoTransport {
     /// Creates a new simulation transport.
     ///
-    /// Loads the MJCF model, initialises simulation data, and resolves
-    /// sensor-data offsets for the joints described in `robot_config`.
+    /// Loads the MJCF model, initialises simulation data, and resolves the
+    /// configured robot joints against whatever subset exists in the MJCF.
+    /// This allows showcase configs such as the 35-DOF WBC-AGILE robot to run
+    /// against the public 29-DOF G1 embodiment while leaving the extra finger
+    /// joints at their configured default pose.
     ///
     /// # Errors
     ///
     /// Returns [`SimError`] if the model cannot be loaded or the joint mapping
     /// between `robot_config` and the MJCF actuators is inconsistent.
     pub fn new(config: MujocoConfig, robot_config: RobotConfig) -> Result<Self, SimError> {
-        let model =
-            MjModel::from_xml_path(&config.model_path).map_err(|e| SimError::ModelLoadFailed {
-                reason: format!("{e}"),
-            })?;
+        config.validate()?;
 
-        let data = MjData::new(&model).map_err(|e| SimError::ModelLoadFailed {
-            reason: format!("failed to create MjData: {e}"),
-        })?;
+        let LoadedModel {
+            mut model,
+            model_variant,
+        } = load_model_resolving_assets(&config.model_path)?;
+        model.opt_mut().timestep = config.timestep;
 
-        // Resolve sensor offsets.
-        // The G1 MJCF defines sensors in order: 29 jointpos, 29 jointvel,
-        // then IMU sensors (framequat(4), gyro(3), accelerometer(3), ...).
-        let joint_count = robot_config.joint_count;
-        let jointpos_offset = 0;
-        let jointvel_offset = joint_count;
-        let gyro_offset = joint_count * 2 + 4;
-        // framequat(4) + gyro(3) = 7 values between jointvel end and accelerometer
-        let accel_offset = joint_count * 2 + 4 + 3;
+        let joint_mappings = robot_config
+            .joint_names
+            .iter()
+            .map(|joint_name| joint_mapping(&model, joint_name))
+            .collect::<Result<Vec<_>, _>>()?;
+        let mapped_joint_count = joint_mappings
+            .iter()
+            .filter(|mapping| mapping.actuator_id.is_some())
+            .count();
+        if mapped_joint_count == 0 {
+            return Err(SimError::JointMappingError {
+                reason: format!(
+                    "model {} exposes none of the actuated joints from robot config `{}`",
+                    config.model_path.display(),
+                    robot_config.name
+                ),
+            });
+        }
+
+        let gyro_sensor = find_sensor_span(&model, MjtSensor::mjSENS_GYRO, 3, "gyro")?;
+        let accel_sensor =
+            find_sensor_span(&model, MjtSensor::mjSENS_ACCELEROMETER, 3, "accelerometer")?;
+
+        let mut data = MjData::new(Box::new(model));
+        initialize_state(&mut data, &robot_config, &joint_mappings);
 
         Ok(Self {
-            model,
             data,
             robot_config,
             config,
-            jointpos_offset,
-            jointvel_offset,
-            gyro_offset,
-            accel_offset,
+            joint_mappings,
+            mapped_joint_count,
+            gyro_sensor,
+            accel_sensor,
+            model_variant,
         })
     }
 
@@ -80,22 +116,43 @@ impl MujocoTransport {
     pub fn sim_config(&self) -> &MujocoConfig {
         &self.config
     }
+
+    /// Returns how many configured robot joints are actively mapped into the
+    /// loaded `MuJoCo` model.
+    #[must_use]
+    pub fn mapped_joint_count(&self) -> usize {
+        self.mapped_joint_count
+    }
+
+    /// Returns the variant of the MJCF that was actually loaded.
+    #[must_use]
+    pub fn model_variant(&self) -> &'static str {
+        self.model_variant
+    }
+
+    /// Returns whether the transport had to synthesize a meshless public MJCF
+    /// because the upstream STL bundle is not present locally.
+    #[must_use]
+    pub fn uses_meshless_public_fallback(&self) -> bool {
+        self.model_variant == "meshless-public-mjcf"
+    }
 }
 
 impl RobotTransport for MujocoTransport {
     fn recv_joint_state(&mut self) -> Result<JointState, CommError> {
-        let sensor = self.data.sensordata();
-        let n = self.robot_config.joint_count;
+        let qpos = self.data.qpos();
+        let qvel = self.data.qvel();
+        let mut positions = self.robot_config.default_pose.clone();
+        let mut velocities = vec![0.0; self.robot_config.joint_count];
 
-        let positions: Vec<f32> = sensor[self.jointpos_offset..self.jointpos_offset + n]
-            .iter()
-            .map(|&v| v as f32)
-            .collect();
-
-        let velocities: Vec<f32> = sensor[self.jointvel_offset..self.jointvel_offset + n]
-            .iter()
-            .map(|&v| v as f32)
-            .collect();
+        for (joint_index, mapping) in self.joint_mappings.iter().enumerate() {
+            if let Some(qpos_adr) = mapping.qpos_adr {
+                positions[joint_index] = mj_scalar(qpos[qpos_adr]);
+            }
+            if let Some(qvel_adr) = mapping.qvel_adr {
+                velocities[joint_index] = mj_scalar(qvel[qvel_adr]);
+            }
+        }
 
         Ok(JointState {
             positions,
@@ -106,20 +163,19 @@ impl RobotTransport for MujocoTransport {
 
     fn recv_imu(&mut self) -> Result<ImuSample, CommError> {
         let sensor = self.data.sensordata();
+        let gyro = &sensor[self.gyro_sensor.start..self.gyro_sensor.start + self.gyro_sensor.len];
+        let accel =
+            &sensor[self.accel_sensor.start..self.accel_sensor.start + self.accel_sensor.len];
 
-        let angular_velocity = [
-            sensor[self.gyro_offset] as f32,
-            sensor[self.gyro_offset + 1] as f32,
-            sensor[self.gyro_offset + 2] as f32,
-        ];
+        let angular_velocity = [mj_scalar(gyro[0]), mj_scalar(gyro[1]), mj_scalar(gyro[2])];
 
         // Read accelerometer (3 values). When stationary the accelerometer
         // measures the reaction to gravity: roughly [0, 0, +9.81].
         // The policy expects a unit gravity vector in body frame, so we
         // negate and normalise.
-        let ax = sensor[self.accel_offset] as f32;
-        let ay = sensor[self.accel_offset + 1] as f32;
-        let az = sensor[self.accel_offset + 2] as f32;
+        let ax = mj_scalar(accel[0]);
+        let ay = mj_scalar(accel[1]);
+        let az = mj_scalar(accel[2]);
 
         let norm = (ax * ax + ay * ay + az * az).sqrt();
         let gravity_vector = if norm > f32::EPSILON {
@@ -146,17 +202,390 @@ impl RobotTransport for MujocoTransport {
             });
         }
 
-        // Write position targets into MuJoCo ctrl vector.
+        // Write mapped position targets into MuJoCo's ctrl vector.
         let ctrl = self.data.ctrl_mut();
-        for (i, &pos) in targets.positions.iter().enumerate() {
-            ctrl[i] = f64::from(pos);
+        for (joint_index, mapping) in self.joint_mappings.iter().enumerate() {
+            let Some(actuator_id) = mapping.actuator_id else {
+                continue;
+            };
+            ctrl[actuator_id] = f64::from(targets.positions[joint_index]);
         }
 
         // Advance simulation by the configured number of substeps.
         for _ in 0..self.config.substeps {
-            mujoco_rs::mj_step(&self.model, &mut self.data);
+            self.data.step();
         }
 
         Ok(())
+    }
+}
+
+fn load_model_resolving_assets(model_path: &Path) -> Result<LoadedModel, SimError> {
+    let absolute_model_path =
+        fs::canonicalize(model_path).map_err(|e| SimError::ModelLoadFailed {
+            reason: format!(
+                "failed to canonicalize MJCF path {}: {e}",
+                model_path.display()
+            ),
+        })?;
+
+    let missing_mesh_assets = collect_missing_mesh_assets(&absolute_model_path)?;
+    if missing_mesh_assets.is_empty() {
+        return Ok(LoadedModel {
+            model: load_model_from_xml(&absolute_model_path)?,
+            model_variant: "upstream-mjcf",
+        });
+    }
+
+    let meshless_model_path = write_meshless_public_mjcf(&absolute_model_path)?;
+    let model = load_model_from_xml(&meshless_model_path);
+    let _ = fs::remove_file(&meshless_model_path);
+
+    model.map(|model| LoadedModel {
+        model,
+        model_variant: "meshless-public-mjcf",
+    })
+}
+
+fn load_model_from_xml(model_path: &Path) -> Result<MjModel, SimError> {
+    MjModel::from_xml(model_path).map_err(|e| SimError::ModelLoadFailed {
+        reason: format!("{e}"),
+    })
+}
+
+fn collect_missing_mesh_assets(model_path: &Path) -> Result<Vec<PathBuf>, SimError> {
+    let mjcf = fs::read_to_string(model_path).map_err(|e| SimError::ModelLoadFailed {
+        reason: format!("failed to read MJCF model {}: {e}", model_path.display()),
+    })?;
+
+    let model_dir = model_path
+        .parent()
+        .ok_or_else(|| SimError::ModelLoadFailed {
+            reason: format!(
+                "MJCF path has no parent directory: {}",
+                model_path.display()
+            ),
+        })?;
+    let mesh_dir = first_self_closing_tag(&mjcf, "compiler")
+        .and_then(|tag| xml_attribute(tag, "meshdir"))
+        .map_or_else(
+            || model_dir.to_path_buf(),
+            |meshdir| model_dir.join(meshdir),
+        );
+
+    let mut missing = BTreeSet::new();
+    for mesh_tag in self_closing_tags(&mjcf, "mesh") {
+        let Some(file) = xml_attribute(mesh_tag, "file") else {
+            continue;
+        };
+        let candidate = mesh_dir.join(file);
+        if !candidate.exists() {
+            missing.insert(candidate);
+        }
+    }
+
+    Ok(missing.into_iter().collect())
+}
+
+fn write_meshless_public_mjcf(model_path: &Path) -> Result<PathBuf, SimError> {
+    let mjcf = fs::read_to_string(model_path).map_err(|e| SimError::ModelLoadFailed {
+        reason: format!("failed to read MJCF model {}: {e}", model_path.display()),
+    })?;
+    let serialized = strip_mesh_references_from_mjcf(&mjcf);
+    write_temporary_meshless_model(model_path, serialized.as_bytes())
+}
+
+fn first_self_closing_tag<'a>(mjcf: &'a str, tag_name: &str) -> Option<&'a str> {
+    self_closing_tags(mjcf, tag_name).into_iter().next()
+}
+
+fn self_closing_tags<'a>(mjcf: &'a str, tag_name: &str) -> Vec<&'a str> {
+    let mut tags = Vec::new();
+    let start_pattern = format!("<{tag_name}");
+    let mut cursor = 0;
+
+    while let Some(relative_start) = mjcf[cursor..].find(&start_pattern) {
+        let start = cursor + relative_start;
+        let rest = &mjcf[start..];
+        if !tag_starts_with(rest, tag_name) {
+            cursor = start + start_pattern.len();
+            continue;
+        }
+
+        let Some(relative_end) = rest.find("/>") else {
+            break;
+        };
+        let end = start + relative_end + 2;
+        tags.push(&mjcf[start..end]);
+        cursor = end;
+    }
+
+    tags
+}
+
+fn tag_starts_with(tag_source: &str, tag_name: &str) -> bool {
+    let Some(after_name) = tag_source
+        .strip_prefix('<')
+        .and_then(|source| source.strip_prefix(tag_name))
+    else {
+        return false;
+    };
+
+    match after_name.as_bytes().first() {
+        None => true,
+        Some(byte) => byte.is_ascii_whitespace() || matches!(*byte, b'/' | b'>'),
+    }
+}
+
+fn xml_attribute<'a>(tag: &'a str, attribute: &str) -> Option<&'a str> {
+    let start_pattern = format!(r#"{attribute}=""#);
+    let start = tag.find(&start_pattern)? + start_pattern.len();
+    let end = start + tag[start..].find('"')?;
+    Some(&tag[start..end])
+}
+
+fn strip_mesh_references_from_mjcf(mjcf: &str) -> String {
+    let mut sanitized = String::with_capacity(mjcf.len());
+    let mut cursor = 0;
+
+    while let Some(relative_start) = mjcf[cursor..].find('<') {
+        let start = cursor + relative_start;
+        sanitized.push_str(&mjcf[cursor..start]);
+
+        let rest = &mjcf[start..];
+        if let Some(relative_end) = rest.find("/>") {
+            let end = start + relative_end + 2;
+            let tag = &mjcf[start..end];
+            if tag_starts_with(tag, "mesh")
+                || (tag_starts_with(tag, "geom") && xml_attribute(tag, "mesh").is_some())
+            {
+                cursor = end;
+                continue;
+            }
+        }
+
+        sanitized.push('<');
+        cursor = start + 1;
+    }
+
+    sanitized.push_str(&mjcf[cursor..]);
+    sanitized
+}
+
+fn write_temporary_meshless_model(model_path: &Path, contents: &[u8]) -> Result<PathBuf, SimError> {
+    let model_dir = model_path
+        .parent()
+        .ok_or_else(|| SimError::ModelLoadFailed {
+            reason: format!(
+                "MJCF path has no parent directory: {}",
+                model_path.display()
+            ),
+        })?;
+    let stem = model_path
+        .file_stem()
+        .and_then(|stem| stem.to_str())
+        .unwrap_or("model");
+    let unique_suffix = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let file_name = format!(
+        ".robowbc-{stem}-meshless-{}-{unique_suffix}.xml",
+        std::process::id()
+    );
+
+    let primary_path = model_dir.join(&file_name);
+    match fs::write(&primary_path, contents) {
+        Ok(()) => Ok(primary_path),
+        Err(primary_err) => {
+            let fallback_path = std::env::temp_dir().join(file_name);
+            fs::write(&fallback_path, contents).map_err(|fallback_err| SimError::ModelLoadFailed {
+                reason: format!(
+                    "failed to write meshless MJCF fallback next to {}: {primary_err}; temp dir fallback {} also failed: {fallback_err}",
+                    model_path.display(),
+                    fallback_path.display()
+                ),
+            })?;
+            Ok(fallback_path)
+        }
+    }
+}
+
+fn joint_mapping(model: &MjModel, joint_name: &str) -> Result<JointMapping, SimError> {
+    let Some(joint_info) = model.joint(joint_name) else {
+        return Ok(JointMapping::default());
+    };
+    let joint_id = i32::try_from(joint_info.id).map_err(|_| SimError::JointMappingError {
+        reason: format!("joint `{joint_name}` has an id that does not fit MuJoCo actuator lookup"),
+    })?;
+
+    let qpos_adr = usize::try_from(model.jnt_qposadr()[joint_info.id]).map_err(|_| {
+        SimError::JointMappingError {
+            reason: format!("joint `{joint_name}` has a negative qpos address in the MJCF"),
+        }
+    })?;
+    let qvel_adr = usize::try_from(model.jnt_dofadr()[joint_info.id]).map_err(|_| {
+        SimError::JointMappingError {
+            reason: format!("joint `{joint_name}` has a negative dof address in the MJCF"),
+        }
+    })?;
+
+    let actuator_id = model
+        .actuator_trntype()
+        .iter()
+        .zip(model.actuator_trnid().iter())
+        .position(|(transmission, ids)| *transmission == MjtTrn::mjTRN_JOINT && ids[0] == joint_id);
+
+    Ok(JointMapping {
+        qpos_adr: Some(qpos_adr),
+        qvel_adr: Some(qvel_adr),
+        actuator_id,
+    })
+}
+
+#[allow(clippy::cast_possible_truncation)]
+fn mj_scalar(value: f64) -> f32 {
+    value as f32
+}
+
+fn find_sensor_span(
+    model: &MjModel,
+    sensor_type: MjtSensor,
+    expected_len: usize,
+    label: &str,
+) -> Result<SensorSpan, SimError> {
+    let Some(sensor_id) = model
+        .sensor_type()
+        .iter()
+        .position(|candidate| *candidate == sensor_type)
+    else {
+        return Err(SimError::ModelLoadFailed {
+            reason: format!("MJCF model is missing the required {label} sensor"),
+        });
+    };
+
+    let start =
+        usize::try_from(model.sensor_adr()[sensor_id]).map_err(|_| SimError::ModelLoadFailed {
+            reason: format!("MJCF {label} sensor has a negative data address"),
+        })?;
+    let len =
+        usize::try_from(model.sensor_dim()[sensor_id]).map_err(|_| SimError::ModelLoadFailed {
+            reason: format!("MJCF {label} sensor has a negative dimension"),
+        })?;
+
+    if len != expected_len {
+        return Err(SimError::ModelLoadFailed {
+            reason: format!("MJCF {label} sensor dimension {len} != expected {expected_len}"),
+        });
+    }
+
+    Ok(SensorSpan { start, len })
+}
+
+fn initialize_state(
+    data: &mut MjData<Box<MjModel>>,
+    robot_config: &RobotConfig,
+    joint_mappings: &[JointMapping],
+) {
+    for (joint_index, mapping) in joint_mappings.iter().enumerate() {
+        let default_position = f64::from(robot_config.default_pose[joint_index]);
+        if let Some(qpos_adr) = mapping.qpos_adr {
+            data.qpos_mut()[qpos_adr] = default_position;
+        }
+        if let Some(qvel_adr) = mapping.qvel_adr {
+            data.qvel_mut()[qvel_adr] = 0.0;
+        }
+        if let Some(actuator_id) = mapping.actuator_id {
+            data.ctrl_mut()[actuator_id] = default_position;
+        }
+    }
+
+    data.forward();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::time::Instant;
+
+    fn repo_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+    }
+
+    fn load_robot_config(relative_path: &str) -> RobotConfig {
+        let repo_root = repo_root();
+        RobotConfig::from_toml_file(&repo_root.join(relative_path))
+            .expect("robot config should load")
+    }
+
+    fn g1_model_path() -> PathBuf {
+        repo_root().join("assets/robots/unitree_g1/g1_29dof.xml")
+    }
+
+    #[test]
+    fn new_applies_timestep_and_maps_full_g1_robot() {
+        let robot = load_robot_config("configs/robots/unitree_g1.toml");
+        let config = MujocoConfig {
+            model_path: g1_model_path(),
+            timestep: 0.004,
+            substeps: 2,
+        };
+
+        let transport = MujocoTransport::new(config.clone(), robot.clone())
+            .expect("transport should initialize");
+        let missing_mesh_assets =
+            collect_missing_mesh_assets(&config.model_path).expect("mesh assets should inspect");
+
+        assert_eq!(transport.mapped_joint_count(), robot.joint_count);
+        assert_eq!(
+            transport.uses_meshless_public_fallback(),
+            !missing_mesh_assets.is_empty()
+        );
+        assert!((transport.sim_config().timestep - config.timestep).abs() < f64::EPSILON);
+        assert!((transport.data.model().opt().timestep - config.timestep).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn agile_robot_reuses_g1_embodiment_with_unmapped_fingers_left_at_default_pose() {
+        let robot = load_robot_config("configs/robots/unitree_g1_35dof.toml");
+        let transport = MujocoTransport::new(
+            MujocoConfig {
+                model_path: g1_model_path(),
+                timestep: 0.002,
+                substeps: 1,
+            },
+            robot.clone(),
+        )
+        .expect("transport should initialize");
+
+        assert_eq!(transport.mapped_joint_count(), 29);
+        assert_eq!(transport.joint_mappings.len(), 35);
+        assert!(transport.joint_mappings[29..]
+            .iter()
+            .all(|mapping| mapping.actuator_id.is_none()));
+
+        let mut transport = transport;
+        let state = transport
+            .recv_joint_state()
+            .expect("joint state should be readable");
+        assert_eq!(state.positions.len(), 35);
+        assert_eq!(state.velocities.len(), 35);
+        for (actual, expected) in state.positions[29..]
+            .iter()
+            .zip(robot.default_pose[29..].iter())
+        {
+            assert!(
+                (actual - expected).abs() < 1e-6,
+                "unmapped finger joint drifted from default pose"
+            );
+        }
+
+        transport
+            .send_joint_targets(&JointPositionTargets {
+                positions: robot.default_pose.clone(),
+                timestamp: Instant::now(),
+            })
+            .expect("sending 35-dof targets should skip unmapped joints instead of failing");
     }
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,13 +49,18 @@ The repository includes a mixed-source showcase generator that compares the
 currently runnable policy integrations and emits one static HTML report.
 
 ```bash
-cargo build --bin robowbc --features robowbc-cli/vis
+export MUJOCO_DOWNLOAD_DIR="$(pwd)/.cache/mujoco"
+cargo build --bin robowbc --features robowbc-cli/sim-auto-download,robowbc-cli/vis
 # npm is used once to vendor the Rerun web viewer beside the report.
 python scripts/generate_policy_showcase.py \
   --repo-root . \
   --robowbc-binary ./target/debug/robowbc \
   --output-dir ./artifacts/policy-showcase
 ```
+
+On Linux and Windows, the first `sim-auto-download` build unpacks MuJoCo into
+`MUJOCO_DOWNLOAD_DIR`. If you already manage a system MuJoCo install, the base
+`robowbc-cli/sim` feature path still works too.
 
 The output folder contains:
 
@@ -75,13 +80,15 @@ python scripts/serve_showcase.py \
 Then open `http://127.0.0.1:8000`. Do not open the generated `index.html`
 directly via `file://`; the interactive viewer expects an HTTP-served folder.
 The helper script also accepts `--bind` if you want to expose the local preview
-to another machine on the same network. If the public checkpoints are present,
-the report includes real CPU
+to another machine on the same network. If the public checkpoints are present, the report includes MuJoCo-backed
 `gear_sonic`, `decoupled_wbc`, `wbc_agile`, and `bfm_zero` cards; otherwise
 missing integrations are rendered as blocked with explicit missing-path
-reasons. The page lazy-loads each `.rrd` recording when a card becomes visible,
-which keeps the same static bundle usable in CI artifacts and on the
-`main`-branch GitHub Pages site.
+reasons. On the public G1 path the loader uses a meshless MJCF fallback because
+this repo does not ship Unitree's STL mesh bundle. `wbc_agile` currently
+reuses the public 29-DOF G1 embodiment for its scene, so the extra finger
+joints stay at their default pose. The page lazy-loads each `.rrd` recording
+when a card becomes visible, which keeps the same static bundle usable in CI
+artifacts and on the `main`-branch GitHub Pages site.
 
 ## Run GEAR-SONIC with real checkpoints
 

--- a/scripts/generate_policy_showcase.py
+++ b/scripts/generate_policy_showcase.py
@@ -15,6 +15,8 @@ import shutil
 import subprocess
 import tarfile
 import tempfile
+import sys
+import tomllib
 from typing import Iterable
 
 POLICIES = [
@@ -23,7 +25,7 @@ POLICIES = [
         "title": "GEAR-SONIC",
         "config": "configs/showcase/gear_sonic_real.toml",
         "source": "NVIDIA GR00T",
-        "summary": "Real CPU planner_sonic.onnx run using the published multi-input velocity contract and the full Unitree G1 robot config.",
+        "summary": "Real CPU planner_sonic.onnx run inside the MuJoCo-backed G1 showcase using the published multi-input velocity contract and the full Unitree G1 robot config.",
         "coverage": "Planner-only locomotion showcase",
         "execution_kind": "real",
         "checkpoint_source": "Published GEAR-SONIC ONNX checkpoints",
@@ -41,7 +43,7 @@ POLICIES = [
         "title": "Decoupled WBC",
         "config": "configs/showcase/decoupled_wbc_real.toml",
         "source": "NVIDIA GR00T",
-        "summary": "Real public GR00T WholeBodyControl run using the official 516D history contract plus separate balance and walk checkpoints.",
+        "summary": "Real public GR00T WholeBodyControl run inside the MuJoCo-backed G1 showcase using the official 516D history contract plus separate balance and walk checkpoints.",
         "coverage": "Lower body RL + upper body default-pose baseline",
         "execution_kind": "real",
         "checkpoint_source": "Published GR00T WholeBodyControl ONNX checkpoints",
@@ -58,7 +60,7 @@ POLICIES = [
         "title": "BFM-Zero",
         "config": "configs/bfm_zero_g1.toml",
         "source": "CMU",
-        "summary": "Real public G1 tracking contract using a 721D prompt-conditioned observation, IMU gyro/history features, and a 256D latent context.",
+        "summary": "Real public G1 tracking contract running inside the MuJoCo-backed showcase with a 721D prompt-conditioned observation, IMU gyro/history features, and a 256D latent context.",
         "coverage": "Full-body prompt-conditioned G1 controller",
         "execution_kind": "real",
         "checkpoint_source": "Prepared BFM-Zero ONNX checkpoint plus tracking context assets",
@@ -91,8 +93,8 @@ POLICIES = [
         "title": "WBC-AGILE",
         "config": "configs/showcase/wbc_agile_real.toml",
         "source": "NVIDIA Isaac",
-        "summary": "Real public G1 checkpoint using the published recurrent history tensors and lower-body target mapping.",
-        "coverage": "Published G1 locomotion checkpoint",
+        "summary": "Real public G1 checkpoint using the published recurrent history tensors and lower-body target mapping. The showcase reuses the public 29-DOF G1 MuJoCo embodiment, so the extra finger joints remain at their default pose in the recorded scene.",
+        "coverage": "Published G1 locomotion checkpoint on the public 29-DOF embodiment",
         "execution_kind": "real",
         "checkpoint_source": "Published NVIDIA Isaac G1 ONNX checkpoint",
         "command_source": "runtime.velocity",
@@ -174,6 +176,49 @@ def resolve_ort_dylib(repo_root: Path) -> str | None:
     return str(candidates[0]) if candidates else None
 
 
+def resolve_mujoco_runtime_libdir(env: dict[str, str]) -> Path | None:
+    explicit = env.get("MUJOCO_DYNAMIC_LINK_DIR")
+    if explicit:
+        return Path(explicit)
+
+    download_dir = env.get("MUJOCO_DOWNLOAD_DIR")
+    if not download_dir:
+        return None
+
+    if os.name == "nt":
+        library_name = "mujoco.dll"
+    elif sys.platform == "darwin":
+        library_name = "libmujoco.dylib"
+    else:
+        library_name = "libmujoco.so"
+
+    candidates = sorted(
+        Path(download_dir).glob(f"mujoco-*/lib/{library_name}"),
+        key=lambda path: path.stat().st_mtime,
+        reverse=True,
+    )
+    return candidates[0].parent if candidates else None
+
+
+def prepend_env_path(env: dict[str, str], key: str, value: Path) -> None:
+    current = env.get(key)
+    env[key] = f"{value}{os.pathsep}{current}" if current else str(value)
+
+
+def configure_binary_runtime_env(env: dict[str, str]) -> dict[str, str]:
+    libdir = resolve_mujoco_runtime_libdir(env)
+    if libdir is None:
+        return env
+
+    if os.name == "nt":
+        prepend_env_path(env, "PATH", libdir)
+    elif sys.platform == "darwin":
+        prepend_env_path(env, "DYLD_LIBRARY_PATH", libdir)
+    else:
+        prepend_env_path(env, "LD_LIBRARY_PATH", libdir)
+    return env
+
+
 def resolve_rerun_web_viewer_version(repo_root: Path) -> str:
     lock_text = (repo_root / "Cargo.lock").read_text(encoding="utf-8")
     match = re.search(r'name = "rerun"\nversion = "([^"]+)"', lock_text)
@@ -247,11 +292,92 @@ def vendor_rerun_web_viewer(repo_root: Path, output_dir: Path) -> dict[str, str]
     }
 
 
-def append_report_and_vis(base_toml: str, policy_id: str, json_path: Path, rrd_path: Path) -> str:
-    return (
-        base_toml.rstrip()
-        + f"\n\n[vis]\napp_id = \"robowbc-showcase-{policy_id}\"\nspawn_viewer = false\nsave_path = \"{rrd_path.as_posix()}\"\n\n[report]\noutput_path = \"{json_path.as_posix()}\"\nmax_frames = 120\n"
+def resolve_showcase_context(repo_root: Path, policy: dict[str, object]) -> dict[str, object]:
+    config_path = repo_root / str(policy["config"])
+    app_config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    comm_cfg = app_config.get("comm") or app_config.get("communication") or {}
+    frequency_hz = int(comm_cfg.get("frequency_hz", 50) or 50)
+    existing_sim = app_config.get("sim")
+
+    robot_cfg_path = app_config.get("robot", {}).get("config_path")
+    robot_model_path = None
+    if robot_cfg_path:
+        robot_cfg = tomllib.loads((repo_root / str(robot_cfg_path)).read_text(encoding="utf-8"))
+        robot_model_path = robot_cfg.get("model_path")
+
+    if isinstance(existing_sim, dict):
+        model_path = str(existing_sim.get("model_path") or robot_model_path or "")
+        timestep = float(existing_sim.get("timestep", 0.002))
+        substeps = int(existing_sim.get("substeps", 10))
+        return {
+            "transport": "mujoco" if model_path else "synthetic",
+            "model_path": model_path or None,
+            "timestep": timestep,
+            "substeps": substeps,
+            "robot_config_path": str(robot_cfg_path) if robot_cfg_path else None,
+            "config_has_sim_section": True,
+        }
+
+    if robot_model_path is None:
+        return {
+            "transport": "synthetic",
+            "model_path": None,
+            "timestep": None,
+            "substeps": None,
+            "robot_config_path": str(robot_cfg_path) if robot_cfg_path else None,
+            "config_has_sim_section": False,
+        }
+
+    timestep = float(policy.get("showcase_timestep", 0.002))
+    derived_substeps = round(1.0 / (max(frequency_hz, 1) * timestep))
+    substeps = int(policy.get("showcase_substeps", max(derived_substeps, 1)))
+    return {
+        "transport": "mujoco",
+        "model_path": str(robot_model_path),
+        "timestep": timestep,
+        "substeps": substeps,
+        "robot_config_path": str(robot_cfg_path) if robot_cfg_path else None,
+        "config_has_sim_section": False,
+    }
+
+
+def compose_showcase_config(
+    base_toml: str,
+    policy_id: str,
+    json_path: Path,
+    rrd_path: Path,
+    showcase_context: dict[str, object],
+) -> str:
+    sections = [base_toml.rstrip()]
+    if (
+        showcase_context["transport"] == "mujoco"
+        and not showcase_context["config_has_sim_section"]
+    ):
+        sections.append(
+            "\n".join(
+                [
+                    "[sim]",
+                    f'model_path = "{showcase_context["model_path"]}"',
+                    f'timestep = {showcase_context["timestep"]:g}',
+                    f'substeps = {showcase_context["substeps"]}',
+                ]
+            )
+        )
+    sections.append(
+        "\n".join(
+            [
+                "[vis]",
+                f'app_id = "robowbc-showcase-{policy_id}"',
+                "spawn_viewer = false",
+                f'save_path = "{rrd_path.as_posix()}"',
+                "",
+                "[report]",
+                f'output_path = "{json_path.as_posix()}"',
+                "max_frames = 120",
+            ]
+        )
     )
+    return "\n\n".join(sections) + "\n"
 
 
 def missing_required_paths(repo_root: Path, policy: dict[str, object]) -> list[str]:
@@ -265,7 +391,28 @@ def missing_required_paths(repo_root: Path, policy: dict[str, object]) -> list[s
     return missing
 
 
-def policy_meta(policy: dict[str, object], json_path: Path | None = None, rrd_path: Path | None = None, log_path: Path | None = None) -> dict[str, object]:
+def detect_transport(log_text: str) -> str:
+    if "mujoco simulation transport active" in log_text:
+        return "mujoco"
+    if "unitree g1 hardware transport active" in log_text:
+        return "hardware"
+    return "synthetic"
+
+
+def detect_mujoco_model_variant(log_text: str) -> str | None:
+    match = re.search(r"model_variant=([^,\s)]+)", log_text)
+    return match.group(1) if match else None
+
+
+def policy_meta(
+    policy: dict[str, object],
+    showcase_context: dict[str, object],
+    actual_transport: str | None = None,
+    actual_model_variant: str | None = None,
+    json_path: Path | None = None,
+    rrd_path: Path | None = None,
+    log_path: Path | None = None,
+) -> dict[str, object]:
     meta = {
         "title": policy["title"],
         "source": policy["source"],
@@ -278,6 +425,10 @@ def policy_meta(policy: dict[str, object], json_path: Path | None = None, rrd_pa
         "config_path": policy["config"],
         "required_paths": list(policy.get("required_paths", [])),
         "blocked_reason": policy.get("blocked_reason"),
+        "showcase_transport": actual_transport or str(showcase_context["transport"]),
+        "showcase_model_path": showcase_context.get("model_path"),
+        "showcase_model_variant": actual_model_variant,
+        "robot_config_path": showcase_context.get("robot_config_path"),
     }
     if json_path is not None:
         meta["json_file"] = json_path.name
@@ -288,8 +439,10 @@ def policy_meta(policy: dict[str, object], json_path: Path | None = None, rrd_pa
     return meta
 
 
+
 def blocked_entry(repo_root: Path, policy: dict[str, object]) -> dict[str, object]:
     missing = missing_required_paths(repo_root, policy)
+    showcase_context = resolve_showcase_context(repo_root, policy)
     return {
         "policy_name": policy["id"],
         "status": "blocked",
@@ -299,25 +452,39 @@ def blocked_entry(repo_root: Path, policy: dict[str, object]) -> dict[str, objec
         "command_kind": str(policy["command_source"]).removeprefix("runtime."),
         "command_data": [],
         "_meta": {
-            **policy_meta(policy),
+            **policy_meta(policy, showcase_context),
             "missing_paths": missing,
         },
     }
 
 
-def run_policy(repo_root: Path, binary: Path, output_dir: Path, policy: dict[str, object], env: dict[str, str]) -> dict[str, object]:
+
+def run_policy(
+    repo_root: Path,
+    binary: Path,
+    output_dir: Path,
+    policy: dict[str, object],
+    env: dict[str, str],
+) -> dict[str, object]:
     missing = missing_required_paths(repo_root, policy)
     if missing:
         return blocked_entry(repo_root, policy)
 
     policy_id = str(policy["id"])
+    showcase_context = resolve_showcase_context(repo_root, policy)
     base_config = (repo_root / str(policy["config"])).read_text(encoding="utf-8")
     temp_config = output_dir / f"{policy_id}.toml"
     json_path = output_dir / f"{policy_id}.json"
     rrd_path = output_dir / f"{policy_id}.rrd"
     log_path = output_dir / f"{policy_id}.log"
     temp_config.write_text(
-        append_report_and_vis(base_config, policy_id, json_path, rrd_path),
+        compose_showcase_config(
+            base_config,
+            policy_id,
+            json_path,
+            rrd_path,
+            showcase_context,
+        ),
         encoding="utf-8",
     )
 
@@ -329,7 +496,8 @@ def run_policy(repo_root: Path, binary: Path, output_dir: Path, policy: dict[str
         text=True,
         check=False,
     )
-    log_path.write_text(proc.stdout + "\n--- STDERR ---\n" + proc.stderr, encoding="utf-8")
+    log_text = proc.stdout + "\n--- STDERR ---\n" + proc.stderr
+    log_path.write_text(log_text, encoding="utf-8")
     if proc.returncode != 0:
         raise SystemExit(
             f"policy showcase run failed for {policy_id} with exit code {proc.returncode}; see {log_path}"
@@ -341,12 +509,28 @@ def run_policy(repo_root: Path, binary: Path, output_dir: Path, policy: dict[str
     if not rrd_path.exists():
         raise SystemExit(
             f"policy showcase run for {policy_id} did not write the expected Rerun recording at {rrd_path}; "
-            "build robowbc with --features robowbc-cli/vis before running the showcase generator"
+            "build robowbc with --features robowbc-cli/sim,robowbc-cli/vis before running the showcase generator"
+        )
+
+    actual_transport = detect_transport(log_text)
+    actual_model_variant = detect_mujoco_model_variant(log_text)
+    if showcase_context["transport"] == "mujoco" and actual_transport != "mujoco":
+        raise SystemExit(
+            f"policy showcase run for {policy_id} did not activate MuJoCo transport; "
+            f"see {log_path} and build robowbc with sim + vis support before regenerating the showcase"
         )
 
     report = json.loads(json_path.read_text(encoding="utf-8"))
     report["status"] = "ok"
-    report["_meta"] = policy_meta(policy, json_path=json_path, rrd_path=rrd_path, log_path=log_path)
+    report["_meta"] = policy_meta(
+        policy,
+        showcase_context,
+        actual_transport=actual_transport,
+        actual_model_variant=actual_model_variant,
+        json_path=json_path,
+        rrd_path=rrd_path,
+        log_path=log_path,
+    )
     return report
 
 
@@ -419,6 +603,30 @@ def pill(label: str, css_class: str) -> str:
     return f'<span class="pill {css_class}">{html.escape(label)}</span>'
 
 
+def showcase_transport_badge_label(transport: str) -> str:
+    if transport == "mujoco":
+        return "MUJOCO SIM"
+    if transport == "hardware":
+        return "HARDWARE"
+    return transport.upper()
+
+
+def showcase_transport_text(transport: str) -> str:
+    if transport == "mujoco":
+        return "MuJoCo sim"
+    if transport == "hardware":
+        return "Hardware"
+    return "Synthetic fallback"
+
+
+def showcase_model_variant_text(variant: str | None) -> str:
+    if variant == "meshless-public-mjcf":
+        return "Meshless public MJCF"
+    if variant == "upstream-mjcf":
+        return "Upstream MJCF"
+    return variant or "-"
+
+
 def display_sort_key(index: int, entry: dict[str, object]) -> tuple[int, int, int]:
     meta = entry["_meta"]
     status = entry.get("status", "ok")
@@ -457,8 +665,11 @@ def render_html(entries: list[dict[str, object]], output_dir: Path, repo_root: P
         meta = entry["_meta"]
         status = entry.get("status", "ok")
         execution_kind = str(meta["execution_kind"])
+        transport = str(meta.get("showcase_transport", "synthetic"))
+        model_variant = showcase_model_variant_text(meta.get("showcase_model_variant"))
+        transport_html = pill(showcase_transport_badge_label(transport), "transport")
         status_html = pill("OK" if status == "ok" else "BLOCKED", "ok" if status == "ok" else "blocked")
-        provenance_html = pill(execution_kind.upper(), execution_kind)
+        provenance_html = " ".join([pill(execution_kind.upper(), execution_kind), transport_html])
 
         metrics = entry.get("metrics") or {}
         ticks = metrics.get("ticks", "-")
@@ -484,6 +695,7 @@ def render_html(entries: list[dict[str, object]], output_dir: Path, repo_root: P
         badge_row = " ".join(
             [
                 pill(execution_kind.upper(), execution_kind),
+                transport_html,
                 pill(str(entry.get("command_kind", "")).upper(), "command"),
                 pill(str(meta["command_source"]), "meta"),
             ]
@@ -506,6 +718,18 @@ def render_html(entries: list[dict[str, object]], output_dir: Path, repo_root: P
     <div>
       <span>Status</span>
       <strong>Blocked</strong>
+    </div>
+    <div>
+      <span>Showcase transport</span>
+      <strong>{html.escape(showcase_transport_text(transport))}</strong>
+    </div>
+    <div>
+      <span>Embodiment</span>
+      <code>{html.escape(str(meta['showcase_model_path'] or '-'))}</code>
+    </div>
+    <div>
+      <span>MuJoCo model variant</span>
+      <strong>{html.escape(model_variant)}</strong>
     </div>
     <div>
       <span>Checkpoint source</span>
@@ -614,6 +838,18 @@ def render_html(entries: list[dict[str, object]], output_dir: Path, repo_root: P
   </div>
   <div class="details-grid">
     <div>
+      <span>Showcase transport</span>
+      <strong>{html.escape(showcase_transport_text(transport))}</strong>
+    </div>
+    <div>
+      <span>Embodiment</span>
+      <code>{html.escape(str(meta['showcase_model_path'] or '-'))}</code>
+    </div>
+    <div>
+      <span>MuJoCo model variant</span>
+      <strong>{html.escape(model_variant)}</strong>
+    </div>
+    <div>
       <span>Command data</span>
       <code>{html.escape(format_vector(entry.get('command_data', [])))}</code>
     </div>
@@ -676,6 +912,8 @@ def render_html(entries: list[dict[str, object]], output_dir: Path, repo_root: P
       --command-fg: #8a5b00;
       --meta-bg: #edf2f7;
       --meta-fg: #334155;
+      --transport-bg: #e8f1ff;
+      --transport-fg: #1d4ed8;
     }}
     * {{ box-sizing: border-box; }}
     body {{ margin: 0; font-family: "IBM Plex Sans", "Segoe UI", sans-serif; background: radial-gradient(circle at top, #eef7ff, var(--bg) 45%); color: var(--text); }}
@@ -702,6 +940,7 @@ def render_html(entries: list[dict[str, object]], output_dir: Path, repo_root: P
     .pill.ok {{ background: var(--real-bg); color: var(--real-fg); }}
     .pill.command {{ background: var(--command-bg); color: var(--command-fg); }}
     .pill.meta {{ background: var(--meta-bg); color: var(--meta-fg); text-transform: none; }}
+    .pill.transport {{ background: var(--transport-bg); color: var(--transport-fg); }}
     .muted {{ color: var(--muted); }}
     .stats {{ display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 12px; margin: 16px 0 20px; }}
     .stats div, .details-grid div {{ background: #f7f9fc; border: 1px solid var(--border); border-radius: 16px; padding: 12px 14px; }}
@@ -737,7 +976,8 @@ def render_html(entries: list[dict[str, object]], output_dir: Path, repo_root: P
   <main>
     <section class="hero">
       <h1>RoboWBC Policy Showcase</h1>
-      <p>This artifact is generated automatically in CI from the set of real policy integrations that are wired today. When a public checkpoint bundle is cached, the card runs live; when assets are unavailable, the page degrades to a visible blocked card instead of pretending the integration exists.</p>
+      <p>This artifact is generated automatically in CI from the set of real policy integrations that are wired today. Successful cards run real checkpoints through the MuJoCo transport and save the resulting 3D Rerun scene; when assets are unavailable, the page degrades to a visible blocked card instead of pretending the integration exists.</p>
+      <p class="muted">The public G1 cards currently load a meshless MuJoCo MJCF variant because this repository does not redistribute Unitree's upstream STL mesh bundle. The dynamics stay MuJoCo-backed, while the Rerun robot scene is reconstructed from the same open MJCF kinematic tree.</p>
       <p class="muted">Each successful card lazy-loads its saved Rerun recording when visible. The raw <code>.rrd</code> files are still available for download, and serving the folder over HTTP remains the most reliable way to open the interactive viewer locally.</p>
       <div class="meta-row">
         <span>Generated: {html.escape(generated_at)}</span>
@@ -748,10 +988,10 @@ def render_html(entries: list[dict[str, object]], output_dir: Path, repo_root: P
 
     <section class="overview">
       <h2>Compared policies</h2>
-      <p class="muted">Successful cards use real checkpoints or public asset bundles cached by CI. Blocked cards surface the exact missing files or unavailable upstream artifacts instead of falling back to mock output.</p>
+      <p class="muted">Successful cards use real checkpoints or public asset bundles cached by CI and must activate the requested showcase transport. Blocked cards surface the exact missing files or unavailable upstream artifacts instead of falling back to mock output.</p>
       <table>
         <thead>
-          <tr><th>Policy</th><th>Status</th><th>Provenance</th><th>Coverage</th><th>Ticks</th><th>Avg inference</th><th>Achieved rate</th><th>Dropped frames</th></tr>
+          <tr><th>Policy</th><th>Status</th><th>Run path</th><th>Coverage</th><th>Ticks</th><th>Avg inference</th><th>Achieved rate</th><th>Dropped frames</th></tr>
         </thead>
         <tbody>
           {''.join(overview_rows)}
@@ -882,6 +1122,7 @@ def main() -> int:
     dylib = resolve_ort_dylib(repo_root)
     if dylib:
         env.setdefault("ROBOWBC_ORT_DYLIB_PATH", dylib)
+    env = configure_binary_runtime_env(env)
 
     entries = [run_policy(repo_root, binary, output_dir, policy, env) for policy in POLICIES]
     render_html(entries, output_dir, repo_root)


### PR DESCRIPTION
## Summary
- run the showcase on the MuJoCo + vis feature path in CI and local docs using the auto-download workflow
- make the public G1 MJCF loadable without vendored STL meshes by generating a meshless public fallback for MuJoCo while keeping the same kinematic tree for Rerun
- expose the actual MuJoCo model variant in CLI/showcase metadata so the hosted page is explicit about using the meshless public embodiment

## Verification
- cargo build
- cargo check
- cargo test
- cargo clippy -- -D warnings
- cargo doc --no-deps
- cargo build --bin robowbc --features robowbc-cli/sim-auto-download,robowbc-cli/vis
- cargo clippy --bin robowbc --features robowbc-cli/sim-auto-download,robowbc-cli/vis -- -D warnings
- cargo test -p robowbc-sim --features mujoco-auto-download
- python -m py_compile scripts/generate_policy_showcase.py scripts/serve_showcase.py
- python scripts/generate_policy_showcase.py --repo-root . --robowbc-binary ./target/debug/robowbc --output-dir ./artifacts/policy-showcase-simcheck4

Closes #98.