### PR TITLE
fix: CI — bench compile error and clippy failures under --all-targets

### DIFF
--- a/crates/robowbc-ort/benches/inference.rs
+++ b/crates/robowbc-ort/benches/inference.rs
@@ -16,7 +16,8 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
 use robowbc_core::{JointLimit, Observation, PdGains, RobotConfig, WbcCommand, WbcPolicy};
 use robowbc_ort::{
-    DecoupledWbcConfig, DecoupledWbcPolicy, GearSonicConfig, GearSonicPolicy, OrtBackend, OrtConfig,
+    DecoupledObservationContract, DecoupledWbcConfig, DecoupledWbcPolicy, GearSonicConfig,
+    GearSonicPolicy, OrtBackend, OrtConfig,
 };
 use std::path::PathBuf;
 use std::time::Instant;
@@ -222,9 +223,11 @@ fn bench_decoupled_wbc_predict(c: &mut Criterion) {
 
     let config = DecoupledWbcConfig {
         rl_model: test_ort_config(model_path),
+        stand_model: None,
         robot: test_robot_config(4),
         lower_body_joints: vec![0, 1],
         upper_body_joints: vec![2, 3],
+        contract: DecoupledObservationContract::Flat,
         control_frequency_hz: 50,
     };
     let policy = DecoupledWbcPolicy::new(config).expect("policy should build");

--- a/crates/robowbc-ort/src/bfm_zero.rs
+++ b/crates/robowbc-ort/src/bfm_zero.rs
@@ -949,6 +949,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::float_cmp)]
     fn g1_tracking_builds_expected_input_layout() {
         let dof_pos_minus_default = vec![1.0; BFM_G1_ACTION_DIM];
         let dof_vel = vec![2.0; BFM_G1_ACTION_DIM];

--- a/crates/robowbc-ort/src/decoupled.rs
+++ b/crates/robowbc-ort/src/decoupled.rs
@@ -798,9 +798,8 @@ mod tests {
             }),
             timestamp: Instant::now(),
         };
-        let twist = match &obs.command {
-            WbcCommand::Velocity(twist) => twist,
-            _ => unreachable!("constructed as velocity"),
+        let WbcCommand::Velocity(twist) = &obs.command else {
+            unreachable!("constructed as velocity")
         };
 
         let single_obs = build_groot_g1_single_observation(
@@ -821,7 +820,7 @@ mod tests {
         assert!((single_obs[12] + 1.0).abs() < 1e-6);
     }
 
-    /// Integration test requiring the published GR00T WholeBodyControl ONNX checkpoints.
+    /// Integration test requiring the published GR00T `WholeBodyControl` ONNX checkpoints.
     ///
     /// To run once weights are available:
     /// ```bash

--- a/crates/robowbc-ort/src/lib.rs
+++ b/crates/robowbc-ort/src/lib.rs
@@ -22,7 +22,7 @@ pub mod bfm_zero;
 pub mod decoupled;
 pub mod wholebody_vla;
 pub use bfm_zero::{BfmZeroConfig, BfmZeroPolicy};
-pub use decoupled::{DecoupledWbcConfig, DecoupledWbcPolicy};
+pub use decoupled::{DecoupledObservationContract, DecoupledWbcConfig, DecoupledWbcPolicy};
 pub use wholebody_vla::{WholeBodyVlaConfig, WholeBodyVlaPolicy};
 
 pub mod wbc_agile;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Daily health check (2026-04-16) found that `cargo clippy --workspace --all-targets -- -D warnings` and `cargo test --workspace --all-targets` fail on `main` due to issues that were not caught by the library-only check paths.

- **Bench compile error**: `DecoupledWbcConfig` in `benches/inference.rs` was missing the `contract` and `stand_model` fields added in a recent commit. The bench target was not compiled by the pre-existing `cargo check` / `cargo clippy` (no `--all-targets`), so the breakage slipped through.
- **`DecoupledObservationContract` not re-exported**: `lib.rs` only re-exported `DecoupledWbcConfig` and `DecoupledWbcPolicy`; callers who need to construct a config with a non-default contract had to use the private `decoupled::` module path.
- **`clippy::float_cmp`** (9 errors in `bfm_zero.rs`): `assert_eq!` on `f32` values in `g1_tracking_builds_expected_input_layout`. Added a scoped `#[allow(clippy::float_cmp)]`; the values being compared are whole-number constants that are exactly representable as `f32`.
- **`clippy::manual_let_else`** (1 error in `decoupled.rs`): match-on-enum-then-unreachable rewritten as `let…else`.
- **`clippy::doc_markdown`** (1 error in `decoupled.rs`): `WholeBodyControl` in a doc comment now wrapped in backticks.

## Test plan

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] `cargo fmt --all -- --check` passes
- [ ] `cargo build --bench inference -p robowbc-ort` succeeds
- [ ] `cargo test --workspace` passes (ORT-gated test passes in CI where network is available)

https://claude.ai/code/session_011PMN9abmxr1SYBpoUsa8RC
EOF
)