### PR TITLE
docs: restore RoboWBC README from accidental GEAR-SONIC overwrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,242 +1,176 @@
----
-license: other
-license_name: nvidia-open-model-license
-license_link: LICENSE
-tags:
-- robotics
-- humanoid
-- whole-body-control
-- reinforcement-learning
-- motion-tracking
-- teleoperation
-- pytorch
-- isaac-lab
-pipeline_tag: reinforcement-learning
----
+# RoboWBC
 
-# GEAR-SONIC: Supersizing Motion Tracking for Natural Humanoid Whole-Body Control
+Unified inference runtime for humanoid whole-body control policies.
 
-<div align="center">
-  <img src="sonic-preview-gif-480P.gif" width="800">
-</div>
+<p>
+  <a href="https://miaodx.com/robowbc/"><strong>Open Live Policy Reports</strong></a>
+  ·
+  <a href="docs/getting-started.md"><strong>Getting Started</strong></a>
+  ·
+  <a href="docs/architecture.md"><strong>Architecture</strong></a>
+  ·
+  <a href="docs/python-sdk.md"><strong>Python SDK</strong></a>
+  ·
+  <a href="docs/founding-document.md"><strong>Founding Document</strong></a>
+</p>
 
-## Model Description
+RoboWBC gives you one config-driven runtime for loading multiple WBC policies,
+running them through the same Rust CLI, and exporting the same JSON + Rerun
+report pipeline across smoke tests, MuJoCo runs, and hardware-oriented
+transports.
 
-**SONIC** (Supersizing Motion Tracking) is a humanoid behavior foundation model developed by NVIDIA that gives robots a core set of motor skills learned from large-scale human motion data. Rather than building separate controllers for predefined motions, SONIC uses motion tracking as a scalable training task, enabling a single unified policy to produce natural, whole-body movement and support a wide range of behaviors.
+![RoboWBC architecture](docs/assets/architecture.svg)
 
-### Key Features
+## What ships today
 
-- 🤖 **Unified Whole-Body Control**: Single policy handles walking, running, crawling, jumping, manipulation, and more
-- 🎯 **Motion Tracking**: Trained on large-scale human motion data for natural movements
-- 🎮 **Real-Time Teleoperation**: VR-based whole-body teleoperation via PICO headset
-- 🚀 **Hardware Deployment**: C++ inference stack for real-time control on humanoid robots
-- 🎨 **Kinematic Planner**: Real-time locomotion generation with multiple movement styles
-- 🔄 **Multi-Modal Control**: Supports keyboard, gamepad, VR, and high-level planning
+| Area | Status |
+|------|--------|
+| Runtime | Rust workspace with registry-driven policy loading, ONNX Runtime and PyO3 backends, MuJoCo and communication transports, plus JSON and Rerun reporting |
+| Live public-policy paths | `gear_sonic`, `decoupled_wbc`, `wbc_agile`, `bfm_zero` |
+| Honest blocked wrappers | `hover` needs a user-exported checkpoint, `wholebody_vla` still lacks a runnable public upstream release |
+| Published visual report | The `main` workflow is wired to build the same HTML report in CI and publish it to the live report link above |
 
-## VR Whole-Body Teleoperation
+## Policy status
 
-SONIC supports real-time whole-body teleoperation via PICO VR headset, enabling natural human-to-robot motion transfer for data collection and interactive control.
+| Policy | Status | Public assets | Example config | Notes |
+|--------|--------|---------------|----------------|-------|
+| `gear_sonic` | Live | Yes | [configs/sonic_g1.toml](configs/sonic_g1.toml) | Uses the published `planner_sonic.onnx` path today; the encoder and decoder tracking contract is still pending |
+| `decoupled_wbc` | Live | Yes | [configs/decoupled_g1.toml](configs/decoupled_g1.toml) | Public G1 balance and walk checkpoints; [configs/decoupled_smoke.toml](configs/decoupled_smoke.toml) stays as the no-download smoke path |
+| `wbc_agile` | Live | Yes | [configs/wbc_agile_g1.toml](configs/wbc_agile_g1.toml) | Published G1 recurrent checkpoint is wired; the T1 path still expects a user export |
+| `bfm_zero` | Live | Yes | [configs/bfm_zero_g1.toml](configs/bfm_zero_g1.toml) | Public ONNX plus tracking context bundle is normalized by `scripts/download_bfm_zero_models.sh` |
+| `hover` | Blocked | No | [configs/hover_h1.toml](configs/hover_h1.toml) | Wrapper exists, but the public upstream repo does not ship a pretrained checkpoint |
+| `wholebody_vla` | Experimental | No | [configs/wholebody_vla_x2.toml](configs/wholebody_vla_x2.toml) | Contract wrapper only; the public upstream repo does not yet expose a runnable inference release |
+| `py_model` | User supplied | N/A | user TOML | Loads Python modules or PyTorch checkpoints through `robowbc-pyo3` |
 
-<div align="center">
-<table>
-<tr>
-<td align="center"><b>Walking</b></td>
-<td align="center"><b>Running</b></td>
-</tr>
-<tr>
-<td align="center"><img src="media/teleop_walking.gif" width="400"></td>
-<td align="center"><img src="media/teleop_running.gif" width="400"></td>
-</tr>
-<tr>
-<td align="center"><b>Sideways Movement</b></td>
-<td align="center"><b>Kneeling</b></td>
-</tr>
-<tr>
-<td align="center"><img src="media/teleop_sideways.gif" width="400"></td>
-<td align="center"><img src="media/teleop_kneeling.gif" width="400"></td>
-</tr>
-<tr>
-<td align="center"><b>Getting Up</b></td>
-<td align="center"><b>Jumping</b></td>
-</tr>
-<tr>
-<td align="center"><img src="media/teleop_getup.gif" width="400"></td>
-<td align="center"><img src="media/teleop_jumping.gif" width="400"></td>
-</tr>
-<tr>
-<td align="center"><b>Bimanual Manipulation</b></td>
-<td align="center"><b>Object Hand-off</b></td>
-</tr>
-<tr>
-<td align="center"><img src="media/teleop_bimanual.gif" width="400"></td>
-<td align="center"><img src="media/teleop_switch_hands.gif" width="400"></td>
-</tr>
-</table>
-</div>
+The generated HTML report includes every currently working public-asset policy:
+`gear_sonic`, `decoupled_wbc`, `wbc_agile`, and `bfm_zero`.
 
-## Kinematic Planner
-
-SONIC includes a kinematic planner for real-time locomotion generation — choose a movement style, steer with keyboard/gamepad, and adjust speed and height on the fly.
-
-<div align="center">
-<table>
-<tr>
-<td align="center" colspan="2"><b>In-the-Wild Navigation</b></td>
-</tr>
-<tr>
-<td align="center" colspan="2"><img src="media/planner/planner_in_the_wild_navigation.gif" width="800"></td>
-</tr>
-<tr>
-<td align="center"><b>Run</b></td>
-<td align="center"><b>Happy</b></td>
-</tr>
-<tr>
-<td align="center"><img src="media/planner/planner_run.gif" width="400"></td>
-<td align="center"><img src="media/planner/planner_happy.gif" width="400"></td>
-</tr>
-<tr>
-<td align="center"><b>Stealth</b></td>
-<td align="center"><b>Injured</b></td>
-</tr>
-<tr>
-<td align="center"><img src="media/planner/planner_stealth.gif" width="400"></td>
-<td align="center"><img src="media/planner/planner_injured.gif" width="400"></td>
-</tr>
-<tr>
-<td align="center"><b>Kneeling</b></td>
-<td align="center"><b>Hand Crawling</b></td>
-</tr>
-<tr>
-<td align="center"><img src="media/planner/planner_kneeling.gif" width="400"></td>
-<td align="center"><img src="media/planner/planner_hand_crawling.gif" width="400"></td>
-</tr>
-<tr>
-<td align="center"><b>Elbow Crawling</b></td>
-<td align="center"><b>Boxing</b></td>
-</tr>
-<tr>
-<td align="center"><img src="media/planner/planner_elbow_crawling.gif" width="400"></td>
-<td align="center"><img src="media/planner/planner_boxing.gif" width="400"></td>
-</tr>
-</table>
-</div>
-
-## Quick Start
-
-📚 **See the [Quick Start Guide](https://nvlabs.github.io/GR00T-WholeBodyControl/getting_started/quickstart.html)** for step-by-step instructions on:
-- Installation and setup
-- Running SONIC with different control modes (keyboard, gamepad, VR)
-- Deploying on real hardware
-- Using the kinematic planner
-
-**Key Resources:**
-- [Installation Guide](https://nvlabs.github.io/GR00T-WholeBodyControl/getting_started/installation_deploy.html) - Complete setup instructions
-- [Keyboard Control Tutorial](https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/keyboard.html) - Get started with keyboard control
-- [Gamepad Control Tutorial](https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/gamepad.html) - Set up gamepad control
-- [VR Teleoperation Setup](https://nvlabs.github.io/GR00T-WholeBodyControl/getting_started/vr_teleop_setup.html) - Full-body VR control
-
-## Model Checkpoints
-
-All checkpoints (ONNX format) are available directly in this repository. Inference is powered by TensorRT and runs on both desktop and Jetson hardware.
-
-| Checkpoint | File | Description |
-|---|---|---|
-| Policy encoder | `model_encoder.onnx` | Encodes motion reference into latent |
-| Policy decoder | `model_decoder.onnx` | Decodes latent into joint actions |
-| Kinematic planner | `planner_sonic.onnx` | Real-time locomotion style planner |
-
-**Quick download** (requires `pip install huggingface_hub`):
-
-```python
-from huggingface_hub import snapshot_download
-snapshot_download(repo_id="nvidia/GEAR-SONIC", local_dir="gear_sonic_deploy")
-```
-
-Or use the download script from the GitHub repo:
+## Quick start
 
 ```bash
-python download_from_hf.py             # policy + planner (default)
-python download_from_hf.py --no-planner # policy only
+rustc --version
+cargo --version
+cargo build
+cargo run --bin robowbc -- run --config configs/decoupled_smoke.toml
 ```
 
-See the [Download Models guide](https://nvlabs.github.io/GR00T-WholeBodyControl/getting_started/download_models.html) for full instructions.
+`configs/decoupled_smoke.toml` uses the checked-in dynamic identity ONNX
+fixture, so it is the intended no-download local smoke path.
+
+<details>
+<summary><strong>Run the live public policies</strong></summary>
+
+```bash
+bash scripts/download_gear_sonic_models.sh
+cargo run --release --bin robowbc -- run --config configs/sonic_g1.toml
+
+bash scripts/download_decoupled_wbc_models.sh
+cargo run --release --bin robowbc -- run --config configs/decoupled_g1.toml
+
+bash scripts/download_wbc_agile_models.sh
+cargo run --release --bin robowbc -- run --config configs/wbc_agile_g1.toml
+
+bash scripts/download_bfm_zero_models.sh
+cargo run --release --bin robowbc -- run --config configs/bfm_zero_g1.toml
+```
+
+`gear_sonic` currently exercises the published `planner_sonic.onnx` velocity
+path. `bfm_zero` fetches the public ONNX plus tracking bundle and converts the
+context into the runtime layout used by both the CLI and CI.
+</details>
+
+<details>
+<summary><strong>Open or generate the visual report</strong></summary>
+
+The same report generator powers both the local HTML bundle and the published
+GitHub Pages site.
+
+```bash
+cargo build --bin robowbc --features robowbc-cli/vis
+python scripts/generate_policy_showcase.py \
+  --repo-root . \
+  --robowbc-binary ./target/debug/robowbc \
+  --output-dir ./artifacts/policy-showcase
+
+cd ./artifacts/policy-showcase
+python -m http.server 8000
+```
+
+The output folder contains `index.html`, `manifest.json`, per-policy `*.json`
+run summaries, raw `*.rrd` recordings, logs, and the embedded Rerun web viewer
+runtime. Pull requests keep the downloadable `policy-showcase` artifact, and
+`main` publishes the generated site to the live report link above.
+</details>
+
+<details>
+<summary><strong>Manual real-model verification</strong></summary>
+
+```bash
+bash scripts/download_gear_sonic_models.sh
+cargo test -p robowbc-ort -- --ignored gear_sonic_real_model_inference
+
+bash scripts/download_decoupled_wbc_models.sh
+cargo test -p robowbc-ort -- --ignored decoupled_wbc_real_model_inference
+
+bash scripts/download_wbc_agile_models.sh
+cargo test -p robowbc-ort -- --ignored wbc_agile_real_model_inference
+
+bash scripts/download_bfm_zero_models.sh
+BFM_ZERO_MODEL_PATH=models/bfm_zero/bfm_zero_g1.onnx \
+BFM_ZERO_CONTEXT_PATH=models/bfm_zero/zs_walking.npy \
+cargo test -p robowbc-ort bfm_zero_real_model_inference -- --ignored --nocapture
+```
+
+`hover` still requires a user-trained exported checkpoint, and `wholebody_vla`
+still requires a compatible private or local model because no runnable public
+release exists upstream today.
+</details>
+
+<details>
+<summary><strong>Python SDK</strong></summary>
+
+```bash
+pip install "maturin>=1.4,<2.0"
+maturin develop
+python -c "from robowbc import Registry; print(Registry.list_policies())"
+```
+
+The standalone Python package lives in `crates/robowbc-py`, while
+`robowbc-pyo3` provides the runtime backend for user-supplied Python or
+PyTorch policies.
+</details>
+
+<details>
+<summary><strong>Workspace layout</strong></summary>
+
+| Path | Purpose |
+|------|---------|
+| `crates/robowbc-core` | `WbcPolicy`, `Observation`, `WbcCommand`, `JointPositionTargets`, `RobotConfig` |
+| `crates/robowbc-registry` | `inventory`-based policy registration and factory |
+| `crates/robowbc-ort` | ONNX Runtime backends and policy wrappers |
+| `crates/robowbc-pyo3` | Python-backed runtime policy loading |
+| `crates/robowbc-comm` | Control-loop plumbing and robot transports |
+| `crates/robowbc-sim` | MuJoCo transport for hardware-free execution |
+| `crates/robowbc-vis` | Rerun visualization and `.rrd` recording |
+| `crates/robowbc-cli` | `robowbc` CLI binary |
+| `crates/robowbc-py` | Standalone `maturin` package for the Python SDK |
+</details>
 
 ## Documentation
 
-📚 **[Full Documentation](https://nvlabs.github.io/GR00T-WholeBodyControl/)**
+- [Getting Started](docs/getting-started.md)
+- [Configuration Reference](docs/configuration.md)
+- [Adding a New Policy](docs/adding-a-model.md)
+- [Adding a New Robot](docs/adding-a-robot.md)
+- [Architecture](docs/architecture.md)
+- [Founding document](docs/founding-document.md)
+- [Q2 2026 roadmap](docs/roadmap-2026-q2.md)
 
-### Guides
-- [Installation (Deployment)](https://nvlabs.github.io/GR00T-WholeBodyControl/getting_started/installation_deploy.html)
-- [Installation (Training)](https://nvlabs.github.io/GR00T-WholeBodyControl/getting_started/installation_training.html)
-- [Quick Start](https://nvlabs.github.io/GR00T-WholeBodyControl/getting_started/quickstart.html)
-- [VR Teleoperation Setup](https://nvlabs.github.io/GR00T-WholeBodyControl/getting_started/vr_teleop_setup.html)
+## Related projects
 
-### Tutorials
-- [Keyboard Control](https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/keyboard.html)
-- [Gamepad Control](https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/gamepad.html)
-- [VR Whole-Body Teleoperation](https://nvlabs.github.io/GR00T-WholeBodyControl/tutorials/vr_wholebody_teleop.html)
-
-## Repository Structure
-
-```
-GR00T-WholeBodyControl/
-├── gear_sonic_deploy/     # C++ inference stack for deployment
-├── gear_sonic/            # Teleoperation and data collection tools
-├── decoupled_wbc/         # Decoupled WBC (GR00T N1.5/N1.6)
-├── docs/                  # Documentation source
-└── media/                 # Videos and images
-```
-
-## Related Projects
-
-This repository is part of NVIDIA's GR00T (Generalist Robot 00 Technology) initiative:
-- **[GR00T N1.5](https://research.nvidia.com/labs/gear/gr00t-n1_5/)**: Previous generation decoupled controller
-- **[GR00T N1.6](https://research.nvidia.com/labs/gear/gr00t-n1_6/)**: Improved decoupled WBC approach
-- **[GEAR-SONIC Website](https://nvlabs.github.io/GEAR-SONIC/)**: Project page with videos and details
-
-## Citation
-
-If you use GEAR-SONIC in your research, please cite:
-
-```bibtex
-@article{luo2025sonic,
-    title={SONIC: Supersizing Motion Tracking for Natural Humanoid Whole-Body Control},
-    author={Luo, Zhengyi and Yuan, Ye and Wang, Tingwu and Li, Chenran and Chen, Sirui and Casta\~neda, Fernando and Cao, Zi-Ang and Li, Jiefeng and Minor, David and Ben, Qingwei and Da, Xingye and Ding, Runyu and Hogg, Cyrus and Song, Lina and Lim, Edy and Jeong, Eugene and He, Tairan and Xue, Haoru and Xiao, Wenli and Wang, Zi and Yuen, Simon and Kautz, Jan and Chang, Yan and Iqbal, Umar and Fan, Linxi and Zhu, Yuke},
-    journal={arXiv preprint arXiv:2511.07820},
-    year={2025}
-}
-```
+- [roboharness](https://github.com/MiaoDX/roboharness), companion visual testing and browser-report project
+- [LeRobot](https://github.com/huggingface/lerobot), upstream robotics stack that can consume a WBC backend
 
 ## License
 
-This project uses **dual licensing**:
-
-- **Source Code**: Apache License 2.0 - applies to all code, scripts, and software components
-- **Model Weights**: NVIDIA Open Model License - applies to all trained model checkpoints
-
-**Key points of the NVIDIA Open Model License:**
-- ✅ Commercial use permitted with attribution
-- ✅ Modification and distribution allowed
-- ⚠️ Must comply with NVIDIA's Trustworthy AI terms
-- ⚠️ Model outputs subject to responsible use guidelines
-
-See [LICENSE](https://github.com/NVlabs/GR00T-WholeBodyControl/blob/main/LICENSE) for complete terms.
-
-## Support & Contact
-
-- 📧 **Email**: [gear-wbc@nvidia.com](mailto:gear-wbc@nvidia.com)
-- 🐛 **Issues**: [GitHub Issues](https://github.com/NVlabs/GR00T-WholeBodyControl/issues)
-- 📖 **Documentation**: [https://nvlabs.github.io/GR00T-WholeBodyControl/](https://nvlabs.github.io/GR00T-WholeBodyControl/)
-- 🌐 **Website**: [https://nvlabs.github.io/GEAR-SONIC/](https://nvlabs.github.io/GEAR-SONIC/)
-
-## Acknowledgments
-
-This work builds upon and acknowledges:
-- [Beyond Mimic](https://github.com/HybridRobotics/whole_body_tracking) - Whole-body tracking foundation
-- [Isaac Lab](https://github.com/isaac-sim/IsaacLab) - Robot learning framework
-- NVIDIA Research GEAR Lab team
-- All contributors and collaborators
-
-## Model Card Contact
-
-For questions about this model card or responsible AI considerations, contact: [gear-wbc@nvidia.com](mailto:gear-wbc@nvidia.com)
+MIT


### PR DESCRIPTION
## Summary

Commit `04563af` accidentally replaced the RoboWBC project README with the upstream NVIDIA GEAR-SONIC model card. This PR restores the original README that describes the unified inference runtime.

## What changed
- Restored `README.md` from `51ab107` (the last commit with the correct RoboWBC README)
- Removed the GEAR-SONIC model card content that overwrote it

## Test plan
- [x] Verified the restored README matches `51ab107:README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)