### PR TITLE
ci: install pyyaml for official benchmarks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
           key: live-policy-models-${{ runner.os }}-v3
 
       - name: Install showcase and benchmark Python dependencies
-        run: pip install numpy joblib onnxruntime==1.24.4
+        run: pip install numpy joblib onnxruntime==1.24.4 pyyaml
 
       - name: Warm live policy checkpoint cache
         run: |


### PR DESCRIPTION
## Summary
- add PyYAML to the showcase benchmark dependency install step
- unblock the official Decoupled WBC benchmark path used in the NVIDIA comparison HTML job

## Verification
- imported the upstream Decoupled WBC policy in a clean virtualenv using the same torch-shim path as scripts/bench_nvidia_decoupled_official.py after installing the CI package set plus PyYAML
