### PR TITLE
ci: require real showcase proof-pack renders

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
     needs: rust
     env:
       MUJOCO_DOWNLOAD_DIR: /tmp/mujoco
+      MUJOCO_GL: egl
+      PYOPENGL_PLATFORM: egl
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -81,6 +83,11 @@ jobs:
 
       - name: Cache cargo artifacts
         uses: Swatinem/rust-cache@v2
+
+      - name: Install headless MuJoCo EGL runtime
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libegl1 libegl-mesa0 libgles2 libgl1-mesa-dri libgbm1
 
       - name: Cache live policy checkpoints
         uses: actions/cache@v4

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ SITE_BIND ?= 127.0.0.1
 SITE_PORT ?= 8000
 SITE_OPEN ?= 0
 MUJOCO_DOWNLOAD_DIR ?= $(CURDIR)/.cache/mujoco
+SHOWCASE_MUJOCO_GL ?= egl
+SHOWCASE_PYOPENGL_PLATFORM ?= $(SHOWCASE_MUJOCO_GL)
 ROBOWBC_BINARY ?= $(CURDIR)/target/debug/robowbc
 SITE_PYTHON_DEPS ?= numpy joblib onnxruntime==1.24.4 pyyaml mujoco Pillow
 PYTHON_SDK_DIST_DIR ?= $(CURDIR)/dist
@@ -20,7 +22,7 @@ PYTHON_SDK_TARGET_DIR ?= $(CURDIR)/target/python-sdk-wheel
 
 .DEFAULT_GOAL := help
 
-.PHONY: help toolchain build build-release check test clippy fmt fmt-check rust-doc mdbook-install docs-book docs verify smoke models-public site-python-deps benchmark-robowbc benchmark-official benchmark-summary benchmark-nvidia site showcase-verify site-smoke site-serve-check site-serve python-sdk-deps python-sdk-build python-sdk-install python-sdk-smoke python-sdk-verify ci
+.PHONY: help toolchain build build-release check test clippy fmt fmt-check rust-doc mdbook-install docs-book docs verify smoke models-public site-python-deps site-render-check benchmark-robowbc benchmark-official benchmark-summary benchmark-nvidia site showcase-verify site-smoke site-serve-check site-serve python-sdk-deps python-sdk-build python-sdk-install python-sdk-smoke python-sdk-verify ci
 
 help: ## Show available targets and useful variables.
 	@awk 'BEGIN {FS = ":.*## "; print "Targets:"} /^[a-zA-Z0-9_.-]+:.*## / {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -29,6 +31,8 @@ help: ## Show available targets and useful variables.
 	@printf "  %-20s %s\n" "MDBOOK" "$(MDBOOK)"
 	@printf "  %-20s %s\n" "SITE_OUTPUT_DIR" "$(SITE_OUTPUT_DIR)"
 	@printf "  %-20s %s\n" "MUJOCO_DOWNLOAD_DIR" "$(MUJOCO_DOWNLOAD_DIR)"
+	@printf "  %-20s %s\n" "SHOWCASE_MUJOCO_GL" "$(SHOWCASE_MUJOCO_GL)"
+	@printf "  %-20s %s\n" "SHOWCASE_PYOPENGL_PLATFORM" "$(SHOWCASE_PYOPENGL_PLATFORM)"
 	@printf "  %-20s %s\n" "PYTHON_SDK_DIST_DIR" "$(PYTHON_SDK_DIST_DIR)"
 	@printf "  %-20s %s\n" "PYTHON_SDK_MUJOCO_DOWNLOAD_DIR" "$(PYTHON_SDK_MUJOCO_DOWNLOAD_DIR)"
 	@printf "  %-20s %s\n" "PYTHON_SDK_TARGET_DIR" "$(PYTHON_SDK_TARGET_DIR)"
@@ -89,6 +93,11 @@ models-public: ## Download the public policy checkpoints used by the site and be
 site-python-deps: ## Install Python dependencies required for site generation and proof-pack capture.
 	$(PYTHON) -m pip install $(SITE_PYTHON_DEPS)
 
+site-render-check: ## Verify the MuJoCo offscreen renderer works before building screenshot-bearing proof packs.
+	MUJOCO_GL="$(SHOWCASE_MUJOCO_GL)" \
+	PYOPENGL_PLATFORM="$(SHOWCASE_PYOPENGL_PLATFORM)" \
+	$(PYTHON) scripts/check_mujoco_headless.py
+
 benchmark-robowbc: ## Regenerate normalized RoboWBC benchmark artifacts.
 	$(PYTHON) scripts/bench_robowbc_compare.py --all
 
@@ -104,6 +113,8 @@ benchmark-summary: ## Render benchmark Markdown and HTML summaries from the norm
 benchmark-nvidia: benchmark-robowbc benchmark-official benchmark-summary ## Rebuild the full NVIDIA benchmark comparison package.
 
 site: ## Build the full static site bundle with policy pages, proof packs, and benchmarks.
+	MUJOCO_GL="$(SHOWCASE_MUJOCO_GL)" \
+	PYOPENGL_PLATFORM="$(SHOWCASE_PYOPENGL_PLATFORM)" \
 	MUJOCO_DOWNLOAD_DIR="$(MUJOCO_DOWNLOAD_DIR)" \
 	$(PYTHON) scripts/build_site.py \
 		--repo-root . \
@@ -112,6 +123,7 @@ site: ## Build the full static site bundle with policy pages, proof packs, and b
 
 showcase-verify: ## Run the same showcase build + bundle validation path used in CI.
 	$(MAKE) site-python-deps
+	$(MAKE) site-render-check
 	$(MAKE) models-public
 	$(MAKE) site
 	$(MAKE) site-smoke

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ GitHub Pages site.
 
 ```bash
 make site
+make showcase-verify
 make site-serve SITE_OPEN=1
 ```
 
@@ -120,12 +121,22 @@ make site-serve SITE_OPEN=1
 build. It picks `./.cache/mujoco` by default, downloads MuJoCo there when
 needed, rebuilds the `robowbc` binary with
 `robowbc-cli/sim-auto-download,robowbc-cli/vis`, runs the benchmark
-generators, and assembles the final static bundle into `/tmp/robowbc-site`.
+generators, forces the same `MUJOCO_GL=egl` / `PYOPENGL_PLATFORM=egl`
+offscreen path that the GitHub showcase job uses, and assembles the final
+static bundle into `/tmp/robowbc-site`.
 Set `MUJOCO_DOWNLOAD_DIR=/your/cache make site` if you want a different cache
 location, or override `SITE_OUTPUT_DIR=/your/output make site` if you want the
 site somewhere else. `make site-smoke` validates the generated bundle layout
 without serving it, and `make site-serve-check` does a short start/stop probe
 of the local HTTP server.
+
+`make showcase-verify` is the closest local equivalent to the GitHub `showcase`
+job. It installs the site Python deps, runs the same headless MuJoCo EGL render
+smoke check that CI now relies on, downloads the public checkpoints, builds the
+site bundle, and fails if any MuJoCo-backed policy page ships a proof-pack
+manifest without real screenshots. On Ubuntu, install the headless EGL runtime
+first if that render smoke check fails:
+`sudo apt-get install -y libegl1 libegl-mesa0 libgles2 libgl1-mesa-dri libgbm1`.
 
 The output folder contains `index.html`, `manifest.json`, `policies/<policy>/`
 folders with per-policy HTML plus raw run artifacts, `benchmarks/nvidia/` with

--- a/docs/roboharness-integration.md
+++ b/docs/roboharness-integration.md
@@ -149,13 +149,21 @@ works normally.
   `cargo build --release --features robowbc-cli/sim,robowbc-cli/vis`
 - Python 3.10+
 - `roboharness`, `mujoco`, and `Pillow` installed
+- Linux EGL runtime packages when running headless screenshot capture:
+  `libegl1 libegl-mesa0 libgles2 libgl1-mesa-dri libgbm1`
 
 Example:
 
 ```bash
 pip install mujoco Pillow
 pip install /path/to/roboharness
+sudo apt-get install -y libegl1 libegl-mesa0 libgles2 libgl1-mesa-dri libgbm1
 ```
+
+For full local parity with the GitHub showcase job, prefer `make
+showcase-verify` from the repo root. That path now runs a fail-fast MuJoCo EGL
+render smoke check before it builds the site and rejects any generated bundle
+that still reports `capture_status != "ok"` for MuJoCo-backed proof packs.
 
 ## Meshless fallback
 

--- a/scripts/check_mujoco_headless.py
+++ b/scripts/check_mujoco_headless.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Fail fast when MuJoCo headless rendering is not available.
+
+This is the same offscreen rendering path used by proof-pack screenshot
+capture. `make showcase-verify` runs this first so local developer checks and
+the GitHub Actions showcase job fail on the same prerequisite instead of
+shipping a site bundle with skipped screenshots.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from roboharness_report import ensure_headless_mujoco_env, is_headless_render_backend_error
+
+PROBE_XML = """
+<mujoco model="headless_probe">
+  <worldbody>
+    <geom type="plane" size="1 1 0.1"/>
+    <body name="probe_box" pos="0 0 0.1">
+      <joint type="free"/>
+      <geom type="box" size="0.05 0.05 0.05" rgba="0.85 0.45 0.25 1"/>
+    </body>
+  </worldbody>
+</mujoco>
+""".strip()
+
+
+def render_probe() -> tuple[str, tuple[int, ...]]:
+    ensure_headless_mujoco_env()
+
+    import mujoco
+
+    backend = os.environ.get("MUJOCO_GL", "auto")
+    model = mujoco.MjModel.from_xml_string(PROBE_XML)
+    data = mujoco.MjData(model)
+    renderer = mujoco.Renderer(model, height=64, width=64)
+    try:
+        mujoco.mj_forward(model, data)
+        renderer.update_scene(data)
+        frame = renderer.render()
+    finally:
+        close = getattr(renderer, "close", None)
+        if callable(close):
+            close()
+    return backend, tuple(int(dimension) for dimension in frame.shape)
+
+
+def package_hint() -> str:
+    if sys.platform != "linux":
+        return ""
+    return (
+        "Install the EGL/Mesa runtime used by CI before retrying, for example:\n"
+        "  sudo apt-get install -y libegl1 libegl-mesa0 libgles2 libgl1-mesa-dri libgbm1"
+    )
+
+
+def main() -> int:
+    try:
+        backend, frame_shape = render_probe()
+    except Exception as exc:
+        backend = os.environ.get("MUJOCO_GL", "auto")
+        if is_headless_render_backend_error(exc):
+            hint = package_hint()
+            raise SystemExit(
+                "MuJoCo headless render smoke check failed for the configured "
+                f"backend ({backend}): {type(exc).__name__}: {exc}\n"
+                "This blocks proof-pack screenshot capture, so "
+                "`make showcase-verify` refuses to continue.\n"
+                f"{hint}".rstrip()
+            ) from exc
+        raise
+
+    print(
+        "MuJoCo headless render smoke check passed: "
+        f"backend={backend} frame_shape={frame_shape}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_site_bundle.py
+++ b/scripts/validate_site_bundle.py
@@ -19,10 +19,92 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def main() -> int:
-    args = parse_args()
-    root = args.root.resolve()
+def load_json(path: Path) -> object:
+    return json.loads(path.read_text(encoding="utf-8"))
 
+
+def detail_dir(root: Path, entry: dict[str, object]) -> Path:
+    detail_page = entry.get("detail_page")
+    if not isinstance(detail_page, str) or not detail_page:
+        raise SystemExit("detail_page missing from manifest entry")
+    return root / detail_page
+
+
+def validate_detail_page(detail_path: Path) -> str:
+    detail_index = detail_path / "index.html"
+    if not detail_index.is_file():
+        raise SystemExit(f"missing policy detail page: {detail_index}")
+    return detail_index.read_text(encoding="utf-8")
+
+
+def validate_ok_detail_page(detail_path: Path, detail_text: str) -> None:
+    detail_index = detail_path / "index.html"
+    if "../../assets/rerun-web-viewer/index.js" not in detail_text:
+        raise SystemExit(f"detail page missing rebased viewer path: {detail_index}")
+    if 'data-rrd-file="run.rrd"' not in detail_text:
+        raise SystemExit(f"detail page missing local run recording path: {detail_index}")
+    if "proof_pack_manifest.json" not in detail_text:
+        raise SystemExit(f"detail page missing proof-pack manifest reference: {detail_index}")
+
+
+def validate_proof_pack_capture(root: Path, entry: dict[str, object], detail_text: str) -> None:
+    card_id = str(entry.get("card_id", "<unknown>"))
+    meta = entry.get("_meta")
+    if not isinstance(meta, dict):
+        raise SystemExit(f"{card_id}: manifest entry missing _meta payload")
+
+    if meta.get("showcase_transport") != "mujoco":
+        return
+
+    manifest_rel = meta.get("proof_pack_manifest_file")
+    if not isinstance(manifest_rel, str) or not manifest_rel:
+        raise SystemExit(f"{card_id}: missing proof_pack_manifest_file")
+
+    manifest_path = root / manifest_rel
+    if not manifest_path.is_file():
+        raise SystemExit(f"{card_id}: missing proof-pack manifest: {manifest_path}")
+
+    proof_pack_manifest = load_json(manifest_path)
+    if not isinstance(proof_pack_manifest, dict):
+        raise SystemExit(f"{card_id}: invalid proof-pack manifest payload: {manifest_path}")
+
+    capture_status = proof_pack_manifest.get("capture_status")
+    if capture_status != "ok":
+        raise SystemExit(
+            f"{card_id}: expected proof-pack capture_status=ok, found {capture_status!r}"
+        )
+
+    checkpoints = proof_pack_manifest.get("checkpoints")
+    if not isinstance(checkpoints, list) or not checkpoints:
+        raise SystemExit(f"{card_id}: proof-pack manifest has no checkpoints")
+
+    if "Screenshots unavailable for this build" in detail_text:
+        raise SystemExit(f"{card_id}: detail page still shows screenshot fallback copy")
+
+    proof_pack_root = manifest_path.parent
+    for checkpoint in checkpoints:
+        if not isinstance(checkpoint, dict):
+            raise SystemExit(f"{card_id}: proof-pack checkpoint payload is not an object")
+        relative_dir = checkpoint.get("relative_dir")
+        cameras = checkpoint.get("cameras")
+        if not isinstance(relative_dir, str) or not relative_dir:
+            raise SystemExit(f"{card_id}: proof-pack checkpoint missing relative_dir")
+        if not isinstance(cameras, list) or not cameras:
+            raise SystemExit(f"{card_id}: proof-pack checkpoint missing camera list")
+
+        checkpoint_dir = proof_pack_root / relative_dir
+        if not checkpoint_dir.is_dir():
+            raise SystemExit(f"{card_id}: missing proof-pack checkpoint directory: {checkpoint_dir}")
+
+        for camera in cameras:
+            if not isinstance(camera, str) or not camera:
+                raise SystemExit(f"{card_id}: invalid proof-pack camera entry: {camera!r}")
+            image_path = checkpoint_dir / f"{camera}_rgb.png"
+            if not image_path.is_file():
+                raise SystemExit(f"{card_id}: missing proof-pack screenshot: {image_path}")
+
+
+def validate_site_bundle(root: Path) -> None:
     if not (root / "index.html").is_file():
         raise SystemExit(f"missing site home page: {root / 'index.html'}")
     if not (root / "manifest.json").is_file():
@@ -32,31 +114,35 @@ def main() -> int:
     if not (root / "benchmarks" / "nvidia" / "index.html").is_file():
         raise SystemExit("missing benchmark page")
 
-    manifest = json.loads((root / "manifest.json").read_text(encoding="utf-8"))
+    manifest = load_json(root / "manifest.json")
+    if not isinstance(manifest, list):
+        raise SystemExit("site manifest must be a JSON array")
     if not manifest:
         raise SystemExit("site manifest is empty")
     if not all("detail_page" in entry for entry in manifest):
         raise SystemExit("detail_page missing from manifest")
-    if not all((root / entry["detail_page"] / "index.html").is_file() for entry in manifest):
-        raise SystemExit("missing policy detail page")
 
     ok_entries = [entry for entry in manifest if entry.get("status") == "ok"]
     if not ok_entries:
         raise SystemExit("expected at least one successful policy entry")
 
-    detail_dir = root / ok_entries[0]["detail_page"]
-    detail_text = (detail_dir / "index.html").read_text(encoding="utf-8")
-    if "../../assets/rerun-web-viewer/index.js" not in detail_text:
-        raise SystemExit("detail page missing rebased viewer path")
-    if 'data-rrd-file="run.rrd"' not in detail_text:
-        raise SystemExit("detail page missing local run recording path")
-    if "proof_pack_manifest.json" not in detail_text:
-        raise SystemExit("detail page missing proof-pack manifest reference")
+    for entry in manifest:
+        if not isinstance(entry, dict):
+            raise SystemExit("site manifest entries must be JSON objects")
+        path = detail_dir(root, entry)
+        detail_text = validate_detail_page(path)
+        if entry.get("status") == "ok":
+            validate_ok_detail_page(path, detail_text)
+            validate_proof_pack_capture(root, entry, detail_text)
 
     index_text = (root / "index.html").read_text(encoding="utf-8")
     if "benchmarks/nvidia/index.html" not in index_text:
         raise SystemExit("site home missing benchmark link")
 
+def main() -> int:
+    args = parse_args()
+    root = args.root.resolve()
+    validate_site_bundle(root)
     print(f"site bundle smoke check passed: {root}")
     return 0
 

--- a/tests/test_validate_site_bundle.py
+++ b/tests/test_validate_site_bundle.py
@@ -1,0 +1,117 @@
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATOR_PATH = ROOT / "scripts" / "validate_site_bundle.py"
+
+SPEC = importlib.util.spec_from_file_location("validate_site_bundle", VALIDATOR_PATH)
+VALIDATOR = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(VALIDATOR)
+
+
+class ValidateSiteBundleTests(unittest.TestCase):
+    def write_site(
+        self,
+        root: Path,
+        *,
+        capture_status: str,
+        include_fallback_copy: bool,
+    ) -> None:
+        (root / "assets" / "rerun-web-viewer").mkdir(parents=True)
+        (root / "benchmarks" / "nvidia").mkdir(parents=True)
+        policy_dir = root / "policies" / "gear_sonic"
+        checkpoint_dir = policy_dir / "roboharness_run" / "trial_001" / "start_tick_0000"
+        checkpoint_dir.mkdir(parents=True)
+
+        (root / "index.html").write_text(
+            '<a href="benchmarks/nvidia/index.html">benchmarks</a>', encoding="utf-8"
+        )
+        (root / "assets" / "rerun-web-viewer" / "index.js").write_text(
+            "export default {};",
+            encoding="utf-8",
+        )
+        (root / "benchmarks" / "nvidia" / "index.html").write_text(
+            "<html></html>",
+            encoding="utf-8",
+        )
+
+        detail_copy = (
+            "Screenshots unavailable for this build."
+            if include_fallback_copy
+            else "Visual checkpoints ready."
+        )
+        (policy_dir / "index.html").write_text(
+            "\n".join(
+                [
+                    '<script src="../../assets/rerun-web-viewer/index.js"></script>',
+                    '<div data-rrd-file="run.rrd"></div>',
+                    '<a href="proof_pack_manifest.json">Proof-pack manifest</a>',
+                    detail_copy,
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+        checkpoints: list[dict[str, object]]
+        if capture_status == "ok":
+            checkpoints = [
+                {
+                    "name": "start_tick_0000",
+                    "relative_dir": "roboharness_run/trial_001/start_tick_0000",
+                    "cameras": ["track", "side", "top"],
+                }
+            ]
+            for camera in ("track", "side", "top"):
+                (checkpoint_dir / f"{camera}_rgb.png").write_bytes(b"png")
+        else:
+            checkpoints = []
+
+        (policy_dir / "proof_pack_manifest.json").write_text(
+            json.dumps(
+                {
+                    "capture_status": capture_status,
+                    "checkpoints": checkpoints,
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        (root / "manifest.json").write_text(
+            json.dumps(
+                [
+                    {
+                        "card_id": "gear_sonic",
+                        "status": "ok",
+                        "detail_page": "policies/gear_sonic/",
+                        "_meta": {
+                            "showcase_transport": "mujoco",
+                            "proof_pack_manifest_file": "policies/gear_sonic/proof_pack_manifest.json",
+                        },
+                    }
+                ]
+            ),
+            encoding="utf-8",
+        )
+
+    def test_validate_site_bundle_accepts_ok_proof_pack_capture(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self.write_site(root, capture_status="ok", include_fallback_copy=False)
+            VALIDATOR.validate_site_bundle(root)
+
+    def test_validate_site_bundle_rejects_skipped_proof_pack_capture(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            self.write_site(root, capture_status="skipped", include_fallback_copy=True)
+            with self.assertRaises(SystemExit) as ctx:
+                VALIDATOR.validate_site_bundle(root)
+            self.assertIn("capture_status=ok", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- install the EGL/Mesa runtime in the showcase job and force the same `MUJOCO_GL=egl` / `PYOPENGL_PLATFORM=egl` path locally and in CI
- add a fail-fast MuJoCo render smoke check plus stricter site-bundle validation that rejects `capture_status != "ok"` for MuJoCo proof packs
- document `make showcase-verify` as the local CI-equivalent command and cover the new validator with tests

## Verification
- `make ci PYTHON=python3 SITE_OUTPUT_DIR=/tmp/robowbc-site-check MUJOCO_DOWNLOAD_DIR=/tmp/mujoco PYTHON_SDK_MUJOCO_DOWNLOAD_DIR=/tmp/mujoco`
- `python3 -m pytest -q tests/test_validate_site_bundle.py`
- generated `/tmp/robowbc-site-check/policies/gear_sonic/proof_pack_manifest.json` with `capture_status=ok` and 5 checkpoints
