### PR TITLE
feat: ship the Phase 1 external integration surface

### DIFF
--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -2,14 +2,20 @@
 
 ## Current Milestone
 
-### v0.1 Roboharness Visual Harness Integration
+### v0.2 External Integration Surface
 
-**Status:** Archived / shipped 2026-04-27
-**Archive:** `.planning/milestones/v0.1-ROADMAP.md`
-**Audit:** `.planning/milestones/v0.1-MILESTONE-AUDIT.md`
+**Status:** Complete
+**Goal:** turn RoboWBC into a customer-facing embedded inference runtime for
+outside locomotion and manipulation pipelines, with Python SDK and adapter
+surfaces as the main adoption path.
+
+## Phase Checklist
+
+- [x] **Phase 1: Build a customer-facing external integration surface for locomotion and manipulation**
 
 ## Milestones
 
+- ✅ **v0.2 External Integration Surface** — Phase 1 completed and validated on 2026-04-29
 - ✅ **v0.1 Roboharness Visual Harness Integration** — Phases 1-6 archived on 2026-04-27
 
 ## Archived Milestones
@@ -25,11 +31,53 @@ Archive artifacts:
 
 </details>
 
+## Delivered
+
+- Phase 1 froze the embedded v1 command contract around
+  `Observation -> Policy.predict() -> JointPositionTargets` and added truthful
+  `Policy.capabilities()` metadata for shipped wrappers.
+- The Python SDK now exposes structured public command types for
+  `velocity`, `motion_tokens`, `joint_targets`, and `kinematic_pose`, while
+  preserving the legacy flat observation path for the existing flat command
+  families.
+- `robowbc.MujocoSession` now accepts the canonical
+  `{"kinematic_pose": [{"name": ..., "translation": [...], "rotation_xyzw": [...]}]}`
+  action shape and round-trips it through config, live stepping, and state
+  save/restore.
+- The repo now ships official locomotion and manipulation adapters plus
+  embedded-runtime docs that explicitly keep `EndEffectorPoses`,
+  server/daemon, and ROS2/zenoh customer APIs out of the v1 public surface.
+
+## Verification Notes
+
+- Fresh-environment preflight passed:
+  `rustc --version`, `cargo --version`, `cargo build`, and `cargo check`.
+- Workspace verification passed:
+  `cargo test --workspace --all-targets`,
+  `cargo clippy --workspace --all-targets -- -D warnings`,
+  `cargo fmt --all -- --check`, and `cargo doc --workspace --no-deps`.
+- Python SDK verification passed:
+  `make python-sdk-verify`,
+  `cargo test --manifest-path crates/robowbc-py/Cargo.toml -- --test-threads=1`
+  with `PYTHON_LIBDIR`, `LD_LIBRARY_PATH`, and `MUJOCO_DOWNLOAD_DIR=/tmp/mujoco`,
+  `cargo clippy --manifest-path crates/robowbc-py/Cargo.toml --all-targets -- -D warnings`,
+  `cargo fmt --manifest-path crates/robowbc-py/Cargo.toml --all -- --check`,
+  and `cargo doc --manifest-path crates/robowbc-py/Cargo.toml --no-deps`
+  with `MUJOCO_DOWNLOAD_DIR=/tmp/mujoco`.
+- Example and docs verification passed:
+  `python3 -m py_compile crates/robowbc-py/examples/lerobot_adapter.py crates/robowbc-py/examples/manipulation_adapter.py examples/python/mujoco_kinematic_pose_session.py scripts/python_sdk_smoke.py`
+  and
+  `rg -n "embedded runtime|capabilit|kinematic_pose|EndEffectorPoses|server/daemon|ROS2|zenoh|WbcRegistry::build" README.md docs/python-sdk.md docs/configuration.md docs/adding-a-model.md`.
+
 ## Current Status
 
-No active milestone is open.
+Milestone `v0.2 External Integration Surface` is implementation-complete.
+Phase 1 shipped with all three execution plans complete and summary artifacts in
+`.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/`.
 
-Start the next milestone with `$gsd-new-milestone` when ready.
+Next recommended run:
+
+- `$gsd-complete-milestone`
 
 ## Carry-Forward Notes
 
@@ -41,3 +89,44 @@ Start the next milestone with `$gsd-new-milestone` when ready.
   `send_joint_targets_can_use_default_pd_gains_when_requested`,
   `send_joint_targets_clamps_pd_control_to_actuator_ctrlrange`, and
   `multi_substep_send_matches_repeated_single_step_pd_recomputation`.
+
+## Active Phase Details
+
+### Phase 1: Build a customer-facing external integration surface for locomotion and manipulation
+
+**Status:** Complete
+**Goal:** ship a stable external integration surface so outside teams can embed
+RoboWBC into Python, LeRobot/GR00T-style, and Rust-owned robot pipelines
+without depending on the CLI or showcase/report stack.
+**Requirements**:
+- freeze one public embedded runtime contract around
+  `Observation -> Policy.predict() -> JointPositionTargets`
+- support both locomotion-oriented and manipulation-oriented external users
+  through a single product surface
+- prioritize Python SDK, live session ingress, policy capability metadata, and
+  official adapters over showcase-only work
+- use `KinematicPose` as the public manipulation command shape and keep
+  server/daemon architecture out of scope for this first surface
+**Depends on:** Nothing (first phase)
+**Plans:** 3 plans
+
+Plans:
+**Wave 1**
+- [x] `01-01` — Freeze the core supported-command capability contract for built
+  policies and harden the flat Python-backed policy path
+
+**Wave 2** *(blocked on Wave 1 completion)*
+- [x] `01-02` — Add structured Python command types, expose policy
+  capabilities, and teach `MujocoSession` the public `kinematic_pose` shape
+
+**Wave 3** *(blocked on Wave 2 completion)*
+- [x] `01-03` — Ship official locomotion/manipulation adapters plus embedded
+  runtime docs and examples
+
+Cross-cutting constraints:
+- Public v1 runtime contract stays
+  `Observation -> Policy.predict() -> JointPositionTargets`
+- `KinematicPose` is the single public manipulation command shape in v1
+- `EndEffectorPoses` stays out of the public SDK surface
+- No server/daemon, ROS2/zenoh customer API, or new wrapper families in this
+  phase

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,19 +1,19 @@
 ---
 gsd_state_version: 1.0
-milestone: v0.1
-milestone_name: Roboharness Visual Harness Integration
-current_phase: Archived
-current_phase_name: Between milestones
+milestone: v0.2
+milestone_name: External Integration Surface
+current_phase: 1
+current_phase_name: Build a customer-facing external integration surface for locomotion and manipulation
 current_plan: Complete
-status: archived
-stopped_at: Between milestones
-last_updated: "2026-04-27T13:58:25.134Z"
-last_activity: 2026-04-27
+status: completed
+stopped_at: Phase 1 complete
+last_updated: "2026-04-29T15:30:00+08:00"
+last_activity: 2026-04-29
 progress:
-  total_phases: 6
-  completed_phases: 6
-  total_plans: 6
-  completed_plans: 6
+  total_phases: 1
+  completed_phases: 1
+  total_plans: 3
+  completed_plans: 3
   percent: 100
 ---
 
@@ -21,20 +21,21 @@ progress:
 
 ## Current Position
 
-**Current Phase:** Archived
-**Current Phase Name:** Between milestones
-**Total Phases:** 6
+**Current Phase:** 1
+**Current Phase Name:** Build a customer-facing external integration surface for locomotion and manipulation
+**Total Phases:** 1
 **Current Plan:** Complete
-**Total Plans in Phase:** 1
-**Status:** v0.1 milestone archived; ready for the next milestone
-**Last Activity:** 2026-04-27
-**Last Activity Description:** v0.1 milestone completed and archived
-**Progress:** [██████████] 100%
+**Total Plans in Phase:** 3
+**Status:** Phase complete
+**Last Activity:** 2026-04-29
+**Last Activity Description:** Phase 1 completed and validated — 3 plans shipped
+**Progress:** [##########] 100%
 
 ## Decisions Made
 
 | Phase | Decision | Rationale |
 |---|---|---|
+| v0.2-1 | Keep the public embedded contract at `Observation -> Policy.predict() -> JointPositionTargets`, expose truthful `Policy.capabilities()`, and make `KinematicPose` the single public manipulation command shape | Outside callers need honest capability discovery and one canonical manipulation seam without expanding into server/daemon or transport-facing APIs |
 | 1 | Keep `run_report.json` authoritative for runtime metrics and write replay truth into `run_report_replay_trace.json` | Long-run visual replay needs uncapped state without weakening the online metrics contract |
 | 2 | Treat proof packs as optional report artifacts and keep showcase/benchmark pages as overview surfaces | Drill-down evidence should remain additive instead of replacing the existing summary layer |
 | 3 | Expose the live MuJoCo backend from `robowbc-py` while keeping policy inference and stepping in Rust | roboharness needs a Python adapter seam without duplicating or drifting core control semantics |
@@ -46,6 +47,12 @@ progress:
 
 ### Roadmap Evolution
 
+- Milestone v0.2 started: External Integration Surface
+- Phase 1 added: Build a customer-facing external integration surface for locomotion and manipulation
+- Phase 1 context created: `01-CONTEXT.md` seeded from the current external integration discussion and plan
+- Phase 1 Plan 01 completed: the core runtime now exposes truthful supported-command metadata, shipped wrappers implement `capabilities()`, and the flat PyO3 backend rejects unsupported structured commands explicitly
+- Phase 1 Plan 02 completed: the Python SDK now exposes structured command classes, `Policy.capabilities()`, canonical `kinematic_pose` session ingress, and normalized nested relative paths in file-based config loading
+- Phase 1 Plan 03 completed: official locomotion/manipulation adapters, a live `MujocoSession` manipulation example, and embedded-runtime docs/examples now ship together
 - Phase 4 added: Make the visual harness phase-aware with lag-selectable phase-end comparisons
 - Phase 4 planned: `04-01-PLAN.md` carries the phase metadata, lag selector, proof-pack, and site-validation work
 - Phase 4 completed: `04-01-SUMMARY.md` records the phase-aware proof-pack contract, bundle validation coverage, and end-to-end showcase verification
@@ -62,6 +69,6 @@ progress:
 
 ## Session
 
-Last Date: 2026-04-27T21:58:00+08:00
-Stopped At: Between milestones
-Resume File: .planning/milestones/v0.1-ROADMAP.md
+Last Date: 2026-04-29T15:30:00+08:00
+Stopped At: Phase 1 complete
+Resume File: .planning/ROADMAP.md

--- a/.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-01-PLAN.md
+++ b/.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-01-PLAN.md
@@ -1,0 +1,158 @@
+---
+phase: 01-build-a-customer-facing-external-integration-surface-for-loc
+plan: 01
+type: execute
+wave: 1
+depends_on: []
+files_modified:
+  - crates/robowbc-core/src/lib.rs
+  - crates/robowbc-registry/src/lib.rs
+  - crates/robowbc-ort/src/lib.rs
+  - crates/robowbc-ort/src/decoupled.rs
+  - crates/robowbc-ort/src/wbc_agile.rs
+  - crates/robowbc-ort/src/bfm_zero.rs
+  - crates/robowbc-ort/src/hover.rs
+  - crates/robowbc-ort/src/wholebody_vla.rs
+  - crates/robowbc-pyo3/src/lib.rs
+autonomous: true
+requirements: []
+must_haves:
+  truths:
+    - "D-01 / D-02 / D-04 / D-05 / D-07: the public embedded-runtime contract stays `Observation -> Policy.predict() -> JointPositionTargets`, and a built policy exposes supported command kinds before inference."
+    - "D-06: `EndEffectorPoses` remains an internal command only and does not appear in the public v1 capability surface."
+    - "D-16 / D-17 / D-18: Phase 1 stays embedded-first, adds no server/daemon or ROS2/zenoh customer API, and does not broaden scope into new wrapper families."
+  artifacts:
+    - path: "crates/robowbc-core/src/lib.rs"
+      provides: "Authoritative public `WbcCommandKind` / `PolicyCapabilities` types plus `WbcPolicy::capabilities()`."
+      min_lines: 40
+    - path: "crates/robowbc-ort/src/decoupled.rs"
+      provides: "Truthful capability metadata for the velocity-only Decoupled WBC wrapper."
+      min_lines: 10
+    - path: "crates/robowbc-ort/src/hover.rs"
+      provides: "Truthful capability metadata for the dual-mode HOVER wrapper."
+      min_lines: 10
+    - path: "crates/robowbc-ort/src/wholebody_vla.rs"
+      provides: "Truthful capability metadata for the manipulation-only WholeBodyVLA wrapper."
+      min_lines: 10
+    - path: "crates/robowbc-pyo3/src/lib.rs"
+      provides: "Explicit rejection of unsupported structured commands in the flat Python-backed policy path."
+      min_lines: 20
+  key_links:
+    - from: "crates/robowbc-core/src/lib.rs"
+      to: "crates/robowbc-ort/src/hover.rs"
+      via: "shared `WbcCommandKind` / `PolicyCapabilities` implementation"
+      pattern: "capabilities|KinematicPose|Velocity"
+    - from: "crates/robowbc-core/src/lib.rs"
+      to: "crates/robowbc-pyo3/src/lib.rs"
+      via: "capability truth and explicit unsupported-command guardrails"
+      pattern: "PolicyCapabilities|UnsupportedCommand"
+---
+
+<objective>
+Freeze the honest supported-command contract for the embedded runtime before the
+Python SDK surface grows around it.
+
+Purpose: give outside callers a truthful way to discover whether a built policy
+supports `velocity`, `motion_tokens`, `joint_targets`, or `kinematic_pose`
+before attempting inference, while keeping the public v1 contract embedded-
+first and explicitly excluding `EndEffectorPoses`.
+Output: core capability metadata, wrapper-specific implementations, and an
+explicit flat-backend rejection path for unsupported structured commands.
+</objective>
+
+<execution_context>
+@$HOME/.codex/get-shit-done/workflows/execute-plan.md
+@$HOME/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-CONTEXT.md
+@.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-RESEARCH.md
+@.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-VALIDATION.md
+@crates/robowbc-core/src/lib.rs
+@crates/robowbc-registry/src/lib.rs
+@crates/robowbc-ort/src/lib.rs
+@crates/robowbc-ort/src/decoupled.rs
+@crates/robowbc-ort/src/wbc_agile.rs
+@crates/robowbc-ort/src/bfm_zero.rs
+@crates/robowbc-ort/src/hover.rs
+@crates/robowbc-ort/src/wholebody_vla.rs
+@crates/robowbc-pyo3/src/lib.rs
+@configs/wholebody_vla_x2.toml
+</context>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description | Data Crossing |
+|----------|-------------|---------------|
+| Built policy -> external caller | customer code queries capabilities before inference | supported command kinds |
+| Rust wrapper -> Python-backed `py_model` path | structured commands may reach a flat backend | command kind, flattened command payload |
+
+## STRIDE Register
+
+| threat_id | category | component | disposition | mitigation_plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-01-01 | Tampering | capability metadata vs real wrapper behavior | mitigate | make each shipped wrapper implement `capabilities()` explicitly and add tests that keep the metadata aligned with actual `UnsupportedCommand` behavior |
+| T-01-02 | Tampering | `PyModelPolicy` flat command conversion | mitigate | remove the current empty-vector fallback for `KinematicPose` / `EndEffectorPoses` and return a named `UnsupportedCommand` error instead |
+| T-01-03 | Denial of Service | unsupported command discovery path | mitigate | provide a pre-inference capability surface so callers can branch before expensive model setup or runtime failures |
+</threat_model>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add public supported-command metadata to the core trait boundary</name>
+  <files>crates/robowbc-core/src/lib.rs, crates/robowbc-registry/src/lib.rs</files>
+  <read_first>crates/robowbc-core/src/lib.rs, crates/robowbc-registry/src/lib.rs, .planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-CONTEXT.md, .planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-RESEARCH.md</read_first>
+  <action>Implement D-04, D-05, D-06, and D-07 at the core trait boundary. Add a public `WbcCommandKind` enum with exactly the v1 customer-facing command kinds `Velocity`, `MotionTokens`, `JointTargets`, and `KinematicPose`. Add a public `PolicyCapabilities` struct with a `supported_commands` field and any lightweight helper methods needed for fast checks. Extend `WbcPolicy` with `fn capabilities(&self) -> PolicyCapabilities` so capability truth lives beside `predict()`, `reset()`, `control_frequency_hz()`, and `supported_robots()`. Keep `WbcCommand::EndEffectorPoses` in the internal enum, but do not place it in the public v1 capability taxonomy. Update the registry test fixtures so `MockPolicy` implements the new method and registry builds still return trait objects that preserve capability access.</action>
+  <verify>cargo test -p robowbc-core && cargo test -p robowbc-registry</verify>
+  <acceptance_criteria>
+    - `crates/robowbc-core/src/lib.rs` contains `pub enum WbcCommandKind`
+    - `crates/robowbc-core/src/lib.rs` contains `pub struct PolicyCapabilities`
+    - `crates/robowbc-core/src/lib.rs` contains `fn capabilities(&self) -> PolicyCapabilities`
+    - `crates/robowbc-registry/src/lib.rs` still builds and its mock policy tests pass after the trait change
+  </acceptance_criteria>
+  <done>The embedded runtime has one authoritative supported-command contract that outside callers can query before inference</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Implement truthful capabilities on the shipped wrappers and harden the flat Python backend</name>
+  <files>crates/robowbc-ort/src/lib.rs, crates/robowbc-ort/src/decoupled.rs, crates/robowbc-ort/src/wbc_agile.rs, crates/robowbc-ort/src/bfm_zero.rs, crates/robowbc-ort/src/hover.rs, crates/robowbc-ort/src/wholebody_vla.rs, crates/robowbc-pyo3/src/lib.rs</files>
+  <read_first>crates/robowbc-ort/src/lib.rs, crates/robowbc-ort/src/decoupled.rs, crates/robowbc-ort/src/wbc_agile.rs, crates/robowbc-ort/src/bfm_zero.rs, crates/robowbc-ort/src/hover.rs, crates/robowbc-ort/src/wholebody_vla.rs, crates/robowbc-pyo3/src/lib.rs, configs/wholebody_vla_x2.toml, .planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-CONTEXT.md</read_first>
+  <action>Implement D-07 and D-18 on the shipped wrapper layer without expanding scope into new wrapper families. Implement `capabilities()` on every shipped wrapper touched by the current public product surface. Use these exact truths: `GearSonicPolicy` supports `Velocity` and `MotionTokens`; `DecoupledWbcPolicy`, `WbcAgilePolicy`, and `BfmZeroPolicy` support `Velocity`; `HoverPolicy` supports `Velocity` and `KinematicPose`; `WholeBodyVlaPolicy` supports `KinematicPose`. Update `PyModelPolicy` in `crates/robowbc-pyo3/src/lib.rs` so it advertises only the flat commands it can really consume (`Velocity`, `MotionTokens`, `JointTargets`) and replace the current empty-vector fallback for `WbcCommand::EndEffectorPoses(_)` and `WbcCommand::KinematicPose(_)` with an explicit `WbcError::UnsupportedCommand` that names the unsupported command and points callers to capability discovery instead of silent misuse.</action>
+  <verify>cargo test -p robowbc-ort --lib && cargo test -p robowbc-pyo3</verify>
+  <acceptance_criteria>
+    - `rg -n "fn capabilities\\(&self\\)" crates/robowbc-ort/src/lib.rs crates/robowbc-ort/src/decoupled.rs crates/robowbc-ort/src/wbc_agile.rs crates/robowbc-ort/src/bfm_zero.rs crates/robowbc-ort/src/hover.rs crates/robowbc-ort/src/wholebody_vla.rs crates/robowbc-pyo3/src/lib.rs` returns a match for every touched wrapper file
+    - `crates/robowbc-pyo3/src/lib.rs` no longer contains the empty-vector fallback for `KinematicPose`
+    - `crates/robowbc-pyo3/src/lib.rs` contains an explicit `UnsupportedCommand` path for unsupported structured commands
+    - `cargo test -p robowbc-ort --lib` and `cargo test -p robowbc-pyo3` exit successfully
+  </acceptance_criteria>
+  <done>Every built policy now advertises truthful supported commands, and the flat Python backend fails fast instead of pretending manipulation works</done>
+</task>
+
+</tasks>
+
+<verification>
+- [ ] On a fresh environment, `rustc --version && cargo --version && cargo build && cargo check` completed before running test commands (per `AGENTS.md`)
+- [ ] `cargo test -p robowbc-core` passes
+- [ ] `cargo test -p robowbc-registry` passes
+- [ ] `cargo test -p robowbc-ort --lib` passes
+- [ ] `cargo test -p robowbc-pyo3` passes
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
+- [ ] `cargo fmt --all -- --check` passes
+- [ ] `cargo doc --workspace --no-deps` passes
+</verification>
+
+<success_criteria>
+- All tasks completed
+- Outside callers can discover supported command kinds from a built policy
+- The v1 public capability surface includes `velocity`, `motion_tokens`, `joint_targets`, and `kinematic_pose` only
+- `robowbc-pyo3` rejects unsupported structured commands explicitly instead of flattening them silently
+- The contract remains embedded-first and does not expand into server/daemon or transport-specific customer APIs
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-01-SUMMARY.md`
+</output>

--- a/.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-01-SUMMARY.md
+++ b/.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-01-SUMMARY.md
@@ -1,0 +1,45 @@
+# Plan 01-01 Summary
+
+## Outcome
+
+Wave 1 froze the supported-command contract for the embedded runtime before the
+Python surface expanded around it. Built policies now advertise truthful v1
+command capabilities, the registry preserves that metadata through built trait
+objects, and the flat PyO3-backed policy path fails fast on unsupported
+structured commands instead of silently flattening them.
+
+## Implemented
+
+- Added public `WbcCommandKind` and `PolicyCapabilities` types to
+  `robowbc-core`, plus helper methods and `WbcPolicy::capabilities()`.
+- Updated the registry fixtures so built trait objects preserve capability
+  access after the trait change.
+- Implemented truthful `capabilities()` values across shipped wrappers:
+  `GearSonicPolicy` supports `velocity` and `motion_tokens`;
+  `DecoupledWbcPolicy`, `WbcAgilePolicy`, and `BfmZeroPolicy` support
+  `velocity`;
+  `HoverPolicy` supports `velocity` and `kinematic_pose`;
+  `WholeBodyVlaPolicy` supports `kinematic_pose`.
+- Hardened `PyModelPolicy` so it advertises only the flat commands it can
+  really consume: `velocity`, `motion_tokens`, and `joint_targets`.
+- Replaced the old flat fallback for `KinematicPose` and `EndEffectorPoses`
+  with an explicit `WbcError::UnsupportedCommand` path that points callers to
+  capability discovery.
+
+## Verification
+
+- `cargo test -p robowbc-core`
+- `cargo test -p robowbc-registry`
+- `cargo test -p robowbc-ort --lib`
+- `cargo test -p robowbc-pyo3`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo fmt --all -- --check`
+- `cargo doc --workspace --no-deps`
+
+## Notes
+
+- `EndEffectorPoses` remains an internal command enum variant and is
+  intentionally absent from the public v1 capability taxonomy.
+- The embedded runtime contract stays
+  `Observation -> Policy.predict() -> JointPositionTargets`; no server/daemon
+  or transport-facing customer API was added in this wave.

--- a/.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-02-PLAN.md
+++ b/.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-02-PLAN.md
@@ -1,0 +1,155 @@
+---
+phase: 01-build-a-customer-facing-external-integration-surface-for-loc
+plan: 02
+type: execute
+wave: 2
+depends_on:
+  - "01"
+files_modified:
+  - crates/robowbc-py/src/lib.rs
+  - scripts/python_sdk_smoke.py
+autonomous: true
+requirements: []
+must_haves:
+  truths:
+    - "D-08 / D-09 / D-10: the Python SDK remains the primary customer-facing surface, keeps the existing flat `Observation(command_type, command_data)` path working for the current flat commands, and adds a structured command API for new integrations."
+    - "D-11 / D-12 / D-13: `KinematicPose` becomes the single public manipulation shape in the Python SDK, and `MujocoSession` accepts manipulation commands instead of staying locomotion-only."
+    - "D-07: capability metadata must be visible from the Python `Policy` surface before callers attempt inference or live session stepping."
+  artifacts:
+    - path: "crates/robowbc-py/src/lib.rs"
+      provides: "Structured Python command classes, Python-visible capability metadata, and a `MujocoSession` manipulation ingress path."
+      min_lines: 150
+    - path: "scripts/python_sdk_smoke.py"
+      provides: "Installed-wheel smoke coverage for capability discovery, structured manipulation commands, and legacy compatibility."
+      min_lines: 25
+  key_links:
+    - from: "crates/robowbc-core/src/lib.rs"
+      to: "crates/robowbc-py/src/lib.rs"
+      via: "shared `WbcCommandKind` / `PolicyCapabilities` contract"
+      pattern: "PolicyCapabilities|kinematic_pose|supported_commands"
+    - from: "configs/wholebody_vla_x2.toml"
+      to: "crates/robowbc-py/src/lib.rs"
+      via: "runtime `kinematic_pose` TOML parsing and session command round-trip"
+      pattern: "runtime.kinematic_pose.links"
+    - from: "crates/robowbc-py/src/lib.rs"
+      to: "scripts/python_sdk_smoke.py"
+      via: "public Python command classes and capability access"
+      pattern: "KinematicPoseCommand|capabilities"
+---
+
+<objective>
+Make the Python SDK the primary embedded-runtime product surface for both
+locomotion and manipulation without breaking the current flat callers.
+
+Purpose: add a structured Python command API, expose capability metadata
+through `Policy`, and teach `MujocoSession` to accept, store, and emit
+`kinematic_pose` commands through one canonical shape.
+Output: Python-visible `PolicyCapabilities`, structured command classes,
+capability-aware live session command handling, and updated SDK smoke coverage.
+</objective>
+
+<execution_context>
+@$HOME/.codex/get-shit-done/workflows/execute-plan.md
+@$HOME/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-CONTEXT.md
+@.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-RESEARCH.md
+@.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-VALIDATION.md
+@.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-01-PLAN.md
+@crates/robowbc-py/src/lib.rs
+@crates/robowbc-core/src/lib.rs
+@configs/wholebody_vla_x2.toml
+@scripts/python_sdk_smoke.py
+</context>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description | Data Crossing |
+|----------|-------------|---------------|
+| Python caller -> SDK command objects | outside integrations create locomotion or manipulation commands | command kind, scalar payloads, named link poses |
+| `MujocoSession` runtime config / live step / save-state | one command shape must round-trip through multiple Python entrypoints | structured command payloads, current command state |
+
+## STRIDE Register
+
+| threat_id | category | component | disposition | mitigation_plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-02-01 | Tampering | `kinematic_pose` payload validation | mitigate | validate link names plus `translation[3]` / `rotation_xyzw[4]` lengths in one parser before building `WbcCommand::KinematicPose` |
+| T-02-02 | Tampering | session command round-trip | mitigate | add one canonical `SessionCommandSpec::KinematicPose` and reuse it for TOML config, `step()`, `get_state()`, `save_state()`, and `restore_state()` |
+| T-02-03 | Denial of Service | compatibility regression for existing flat callers | mitigate | preserve the flat observation path for `velocity`, `motion_tokens`, and `joint_targets`, and lock it with direct tests and installed-wheel smoke |
+</threat_model>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Add structured Python command classes while preserving the legacy flat observation path</name>
+  <files>crates/robowbc-py/src/lib.rs</files>
+  <read_first>crates/robowbc-py/src/lib.rs, crates/robowbc-core/src/lib.rs, .planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-CONTEXT.md, .planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-RESEARCH.md</read_first>
+  <action>Implement D-08, D-09, D-10, and D-11 in the Python SDK surface. Add Python-visible `PolicyCapabilities`, `VelocityCommand`, `MotionTokensCommand`, `JointTargetsCommand`, `LinkPose`, and `KinematicPoseCommand` types in `crates/robowbc-py/src/lib.rs`. Update `Observation` so new integrations can pass a structured `command=` object, while current callers can keep using `command_type` plus `command_data` for `velocity`, `motion_tokens`, and `joint_targets`. Do not invent a flattened `command_data` encoding for `kinematic_pose`; the manipulation path must enter through the new structured `command=` surface only. Keep `command_type` and `command_data` readable for the legacy flat commands so existing callers and docs do not break unexpectedly.</action>
+  <verify>cargo test --manifest-path crates/robowbc-py/Cargo.toml</verify>
+  <acceptance_criteria>
+    - `crates/robowbc-py/src/lib.rs` exports `PolicyCapabilities`, `VelocityCommand`, `MotionTokensCommand`, `JointTargetsCommand`, `LinkPose`, and `KinematicPoseCommand`
+    - `crates/robowbc-py/src/lib.rs` lets `Observation` accept a structured `command=` object without removing the existing flat constructor path for `velocity`, `motion_tokens`, and `joint_targets`
+    - `crates/robowbc-py/src/lib.rs` does not introduce a fake flat `command_data` encoding for `kinematic_pose`
+    - `cargo test --manifest-path crates/robowbc-py/Cargo.toml` exits successfully after the API change
+  </acceptance_criteria>
+  <done>The Python SDK exposes a structured command vocabulary without regressing the existing flat callers</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Expose capability metadata through `Policy` and teach `MujocoSession` the canonical `kinematic_pose` shape</name>
+  <files>crates/robowbc-py/src/lib.rs</files>
+  <read_first>crates/robowbc-py/src/lib.rs, crates/robowbc-core/src/lib.rs, configs/wholebody_vla_x2.toml, .planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-01-PLAN.md</read_first>
+  <action>Implement D-07, D-11, D-12, and D-13 in the live Python session surface. Expose `Policy.capabilities()` from the Python `Policy` wrapper and return `supported_commands` as snake_case strings that mirror `WbcCommandKind`. Remove the current `runtime.kinematic_pose is not yet supported by robowbc.MujocoSession` guard. Add `SessionCommandSpec::KinematicPose` plus one parser and one serializer for the structured manipulation shape so these paths all use the same representation: TOML `[[runtime.kinematic_pose.links]]`, `step({"kinematic_pose": [{"name": ..., "translation": [...], "rotation_xyzw": [...]}]})`, `get_state()["command"]`, `save_state()["current_command"]`, and `restore_state(...)`. Add a pre-tick capability check so `MujocoSession` rejects commands that are not listed by `policy.capabilities().supported_commands` before reaching `run_control_tick`.</action>
+  <verify>cargo test --manifest-path crates/robowbc-py/Cargo.toml</verify>
+  <acceptance_criteria>
+    - `crates/robowbc-py/src/lib.rs` contains `fn capabilities(&self)` on the Python `Policy` wrapper
+    - `crates/robowbc-py/src/lib.rs` contains `SessionCommandSpec::KinematicPose`
+    - `crates/robowbc-py/src/lib.rs` no longer contains the string `runtime.kinematic_pose is not yet supported by robowbc.MujocoSession`
+    - `parse_action_command`, `command_dict`, `get_state`, `save_state`, and `restore_state` all handle the same structured `kinematic_pose` command shape
+    - `MujocoSession` rejects unsupported commands before a control tick begins
+  </acceptance_criteria>
+  <done>The live Python session can accept, persist, and emit the public manipulation command shape safely</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Add direct SDK regressions and installed-wheel smoke coverage for the new contract</name>
+  <files>crates/robowbc-py/src/lib.rs, scripts/python_sdk_smoke.py</files>
+  <read_first>crates/robowbc-py/src/lib.rs, scripts/python_sdk_smoke.py, Makefile, .planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-VALIDATION.md</read_first>
+  <action>Implement D-08 through D-13 in the verification surface. Add direct tests in `crates/robowbc-py/src/lib.rs` for legacy observation compatibility, `KinematicPoseCommand` translation, TOML `runtime.kinematic_pose` parsing, `parse_action_command` / `command_dict` round-trips, and capability gating. Expand `scripts/python_sdk_smoke.py` so the installed-wheel path checks `Policy.capabilities()`, structured manipulation object construction, and the preserved legacy `Observation(command_type, command_data)` path in one run. Keep the smoke script lightweight enough for `make python-sdk-verify`, but make it fail loudly on missing capability fields or missing structured-command exports.</action>
+  <verify>cargo test --manifest-path crates/robowbc-py/Cargo.toml && make python-sdk-verify</verify>
+  <acceptance_criteria>
+    - `crates/robowbc-py/src/lib.rs` contains direct tests for `kinematic_pose` parsing and legacy flat observation compatibility
+    - `scripts/python_sdk_smoke.py` imports `PolicyCapabilities` or `policy.capabilities()`
+    - `scripts/python_sdk_smoke.py` imports `KinematicPoseCommand`
+    - `make python-sdk-verify` exits successfully
+  </acceptance_criteria>
+  <done>The Python SDK contract is protected both in-crate and through the installed-wheel smoke path</done>
+</task>
+
+</tasks>
+
+<verification>
+- [ ] On a fresh environment, `rustc --version && cargo --version && cargo build && cargo check` completed before running test commands (per `AGENTS.md`)
+- [ ] `cargo test --manifest-path crates/robowbc-py/Cargo.toml` passes
+- [ ] `make python-sdk-verify` passes
+- [ ] `cargo clippy --manifest-path crates/robowbc-py/Cargo.toml --all-targets -- -D warnings` passes
+- [ ] `cargo fmt --manifest-path crates/robowbc-py/Cargo.toml --all -- --check` passes
+- [ ] `cargo doc --manifest-path crates/robowbc-py/Cargo.toml --no-deps` passes
+</verification>
+
+<success_criteria>
+- All tasks completed
+- Python users can discover supported commands from `Policy.capabilities()`
+- The legacy flat observation path continues to work for the current flat command kinds
+- `KinematicPose` is available through a structured public Python surface and live `MujocoSession` actions
+- The live session uses one canonical `kinematic_pose` shape across config, step, state export, and save/restore
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-02-SUMMARY.md`
+</output>

--- a/.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-02-SUMMARY.md
+++ b/.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-02-SUMMARY.md
@@ -1,0 +1,49 @@
+# Plan 01-02 Summary
+
+## Outcome
+
+Wave 2 made the Python SDK the real embedded-runtime surface for this phase.
+The SDK now exposes capability metadata before inference, preserves the legacy
+flat command path for the existing command families, and adds one structured
+manipulation contract built around named link poses.
+
+## Implemented
+
+- Added `Policy.capabilities()` on the Python `Policy` wrapper, returning
+  `PolicyCapabilities.supported_commands` as stable `snake_case` strings.
+- Added structured Python command classes:
+  `VelocityCommand`, `MotionTokensCommand`, `JointTargetsCommand`, `LinkPose`,
+  and `KinematicPoseCommand`.
+- Kept the flat `Observation(command_type, command_data)` path for
+  `velocity`, `motion_tokens`, and `joint_targets`.
+- Intentionally kept `kinematic_pose` off the flat `command_data` surface.
+- Added `SessionCommandSpec::KinematicPose` plus one canonical
+  `kinematic_pose` shape across:
+  TOML runtime config, `MujocoSession.step()`, `get_state()`, `save_state()`,
+  and `restore_state()`.
+- Added pre-tick capability gating for `MujocoSession`, so unsupported commands
+  fail before `run_control_tick`.
+- Fixed Python config loading so file-based entry points normalize relative
+  `config_path`, `model_path`, and `context_path` values before building a
+  policy or session.
+- Made `robowbc-py` testable through plain `cargo test` by:
+  switching away from hard-coded PyO3 `extension-module` feature usage,
+  adding `rlib` output,
+  and enabling PyO3 `auto-initialize` for crate-local tests.
+- Expanded the installed-wheel smoke path to cover capability discovery,
+  structured command construction, and preserved legacy compatibility.
+
+## Verification
+
+- `PYTHON_LIBDIR="$(python3 - <<'PY' ...)" LD_LIBRARY_PATH=... MUJOCO_DOWNLOAD_DIR=/tmp/mujoco cargo test --manifest-path crates/robowbc-py/Cargo.toml -- --test-threads=1`
+- `make python-sdk-verify`
+- `cargo clippy --manifest-path crates/robowbc-py/Cargo.toml --all-targets -- -D warnings`
+- `cargo fmt --manifest-path crates/robowbc-py/Cargo.toml --all -- --check`
+- `MUJOCO_DOWNLOAD_DIR=/tmp/mujoco cargo doc --manifest-path crates/robowbc-py/Cargo.toml --no-deps`
+
+## Notes
+
+- The `robowbc-py` crate still needs `MUJOCO_DOWNLOAD_DIR` set to an absolute
+  path for `mujoco-auto-download` builds.
+- Crate-local Rust tests need `LD_LIBRARY_PATH` to include the active Python
+  `LIBDIR` when using the local Conda Python runtime.

--- a/.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-03-PLAN.md
+++ b/.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-03-PLAN.md
@@ -1,0 +1,179 @@
+---
+phase: 01-build-a-customer-facing-external-integration-surface-for-loc
+plan: 03
+type: execute
+wave: 3
+depends_on:
+  - "01"
+  - "02"
+files_modified:
+  - crates/robowbc-py/examples/lerobot_adapter.py
+  - crates/robowbc-py/examples/manipulation_adapter.py
+  - examples/python/mujoco_kinematic_pose_session.py
+  - README.md
+  - docs/python-sdk.md
+  - docs/configuration.md
+  - docs/adding-a-model.md
+autonomous: true
+requirements: []
+must_haves:
+  truths:
+    - "D-14 / D-15: Phase 1 ships one official locomotion adapter and one official manipulation adapter, and both preserve the same `{\"action\": joint_targets}` output seam for outside callers."
+    - "D-01 / D-02 / D-03 / D-10: the docs position RoboWBC as an embedded runtime product with Python as the primary adoption path and embedded Rust as the secondary path."
+    - "D-11 / D-16 / D-17 / D-18: the public manipulation story uses `KinematicPose`, explicitly excludes `EndEffectorPoses`, and keeps server/daemon, ROS2/zenoh customer APIs, and new wrapper families out of scope."
+  artifacts:
+    - path: "crates/robowbc-py/examples/lerobot_adapter.py"
+      provides: "Capability-aware official locomotion adapter for LeRobot / GR00T-style seams."
+      min_lines: 20
+    - path: "crates/robowbc-py/examples/manipulation_adapter.py"
+      provides: "Official named-link manipulation adapter using the public `KinematicPose` contract."
+      min_lines: 40
+    - path: "examples/python/mujoco_kinematic_pose_session.py"
+      provides: "Live embedded Python session example for `kinematic_pose` stepping."
+      min_lines: 30
+    - path: "README.md"
+      provides: "Embedded-runtime positioning plus a short embedded-Rust snippet."
+      min_lines: 20
+    - path: "docs/python-sdk.md"
+      provides: "Customer-facing command and adapter matrix for locomotion plus manipulation."
+      min_lines: 40
+    - path: "docs/adding-a-model.md"
+      provides: "Contributor guidance for implementing `capabilities()` honestly."
+      min_lines: 10
+  key_links:
+    - from: "crates/robowbc-py/examples/lerobot_adapter.py"
+      to: "crates/robowbc-py/src/lib.rs"
+      via: "structured velocity command helper and `Policy.capabilities()`"
+      pattern: "VelocityCommand|capabilities"
+    - from: "crates/robowbc-py/examples/manipulation_adapter.py"
+      to: "crates/robowbc-py/src/lib.rs"
+      via: "shared `KinematicPoseCommand` / named link pose contract"
+      pattern: "KinematicPoseCommand|LinkPose"
+    - from: "docs/adding-a-model.md"
+      to: "crates/robowbc-core/src/lib.rs"
+      via: "new `capabilities()` requirement on policy implementations"
+      pattern: "PolicyCapabilities|capabilities"
+---
+
+<objective>
+Ship copyable adoption seams and docs so outside teams can embed RoboWBC
+without reverse-engineering CLI demos or internals.
+
+Purpose: make the new capability-aware Python surface real for users by
+shipping an official locomotion adapter, an official manipulation adapter, a
+live `kinematic_pose` session example, and docs that clearly frame RoboWBC as
+an embedded runtime product.
+Output: official adapter examples, embedded-session example, and docs/readme
+updates that explain both the primary Python path and the secondary embedded
+Rust path.
+</objective>
+
+<execution_context>
+@$HOME/.codex/get-shit-done/workflows/execute-plan.md
+@$HOME/.codex/get-shit-done/templates/summary.md
+</execution_context>
+
+<context>
+@.planning/ROADMAP.md
+@.planning/STATE.md
+@.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-CONTEXT.md
+@.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-RESEARCH.md
+@.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-VALIDATION.md
+@.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-01-PLAN.md
+@.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-02-PLAN.md
+@README.md
+@docs/python-sdk.md
+@docs/configuration.md
+@docs/adding-a-model.md
+@crates/robowbc-py/examples/lerobot_adapter.py
+@configs/wholebody_vla_x2.toml
+@docs/community/lerobot-rfc.md
+</context>
+
+<threat_model>
+## Trust Boundaries
+
+| Boundary | Description | Data Crossing |
+|----------|-------------|---------------|
+| Example adapters -> external users | outside teams may copy the examples verbatim into their own control loops | capability checks, observation shapes, action output seam |
+| Docs/README -> implementation | customer-facing positioning must stay aligned with the actual SDK and session contract | public command names, config keys, code snippets |
+
+## STRIDE Register
+
+| threat_id | category | component | disposition | mitigation_plan |
+|-----------|----------|-----------|-------------|-----------------|
+| T-03-01 | Tampering | example adapters | mitigate | make each official adapter check `Policy.capabilities()` at initialization and fail fast on unsupported policies instead of deferring mismatch discovery to inference time |
+| T-03-02 | Repudiation | docs and README snippets | mitigate | keep docs tied to real command names and real config keys, and verify them with grep plus example `py_compile` checks |
+| T-03-03 | Tampering | manipulation example payload validation | mitigate | validate required link-pose keys and fixed vector lengths in the example helpers so copied code fails loudly on malformed input |
+</threat_model>
+
+<tasks>
+
+<task type="auto">
+  <name>Task 1: Make the official locomotion adapter capability-aware without changing its external seam</name>
+  <files>crates/robowbc-py/examples/lerobot_adapter.py</files>
+  <read_first>crates/robowbc-py/examples/lerobot_adapter.py, crates/robowbc-py/src/lib.rs, docs/community/lerobot-rfc.md, .planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-CONTEXT.md</read_first>
+  <action>Implement D-14 on the official locomotion adapter seam. Upgrade `crates/robowbc-py/examples/lerobot_adapter.py` so `RoboWBCController` calls `policy.capabilities()` during initialization, fails fast unless `"velocity"` is supported, constructs the new `VelocityCommand` instead of raw `command_type` / `command_data`, and keeps the existing `step(obs_dict) -> {"action": list[float]}` contract intact. Keep the LeRobot / GR00T-style `[vx, vy, omega]` to 6D RoboWBC velocity expansion in one helper so the adapter still accepts both 3-float and 6-float task commands without duplicating the conversion logic.</action>
+  <verify>python3 -m py_compile crates/robowbc-py/examples/lerobot_adapter.py</verify>
+  <acceptance_criteria>
+    - `crates/robowbc-py/examples/lerobot_adapter.py` contains a `capabilities` check before inference
+    - `crates/robowbc-py/examples/lerobot_adapter.py` uses `VelocityCommand`
+    - the adapter still returns `{"action": targets.positions}`
+    - `python3 -m py_compile crates/robowbc-py/examples/lerobot_adapter.py` exits successfully
+  </acceptance_criteria>
+  <done>The official locomotion adapter now uses the supported command contract explicitly and still matches the existing controller seam</done>
+</task>
+
+<task type="auto">
+  <name>Task 2: Add an official manipulation adapter and a live `kinematic_pose` session example</name>
+  <files>crates/robowbc-py/examples/manipulation_adapter.py, examples/python/mujoco_kinematic_pose_session.py</files>
+  <read_first>crates/robowbc-py/src/lib.rs, configs/wholebody_vla_x2.toml, crates/robowbc-py/examples/lerobot_adapter.py, .planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-RESEARCH.md</read_first>
+  <action>Implement D-11 and D-15 on the official manipulation adoption seam. Add `crates/robowbc-py/examples/manipulation_adapter.py` with an official manipulation controller that accepts named link poses in the shape `{"links": [{"name": "...", "translation": [x, y, z], "rotation_xyzw": [qx, qy, qz, qw]}]}`, validates the required keys and lengths, checks that the policy supports `"kinematic_pose"`, constructs `KinematicPoseCommand`, and returns `{"action": targets.positions}`. Add `examples/python/mujoco_kinematic_pose_session.py` that loads `configs/wholebody_vla_x2.toml`, opens `robowbc.MujocoSession`, calls `session.step({"kinematic_pose": [{"name": ..., "translation": [...], "rotation_xyzw": [...]}]})`, and prints the returned command / joint-target state so outside teams can copy a live embedded manipulation seam immediately.</action>
+  <verify>python3 -m py_compile crates/robowbc-py/examples/manipulation_adapter.py examples/python/mujoco_kinematic_pose_session.py</verify>
+  <acceptance_criteria>
+    - `crates/robowbc-py/examples/manipulation_adapter.py` exists
+    - `crates/robowbc-py/examples/manipulation_adapter.py` uses `KinematicPoseCommand`
+    - `examples/python/mujoco_kinematic_pose_session.py` exists and calls `MujocoSession.step` with `kinematic_pose`
+    - both example files fail fast on malformed link-pose payloads or unsupported policies
+    - `python3 -m py_compile crates/robowbc-py/examples/manipulation_adapter.py examples/python/mujoco_kinematic_pose_session.py` exits successfully
+  </acceptance_criteria>
+  <done>Outside teams have a first-party manipulation example alongside the locomotion adapter</done>
+</task>
+
+<task type="auto">
+  <name>Task 3: Reposition the README and docs around the embedded runtime product surface</name>
+  <files>README.md, docs/python-sdk.md, docs/configuration.md, docs/adding-a-model.md</files>
+  <read_first>README.md, docs/python-sdk.md, docs/configuration.md, docs/adding-a-model.md, crates/robowbc-py/src/lib.rs, crates/robowbc-core/src/lib.rs, .planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-CONTEXT.md</read_first>
+  <action>Implement D-01, D-02, D-03, D-10, D-16, D-17, and D-18 in the public repo narrative. Update `README.md`, `docs/python-sdk.md`, `docs/configuration.md`, and `docs/adding-a-model.md` so the first-class story is RoboWBC as an embedded runtime surface. Add one short embedded-Rust snippet that uses `WbcRegistry::build` plus `policy.capabilities()` to show the secondary Rust-owned adoption path. Update the Python docs to show both the preserved flat command path and the new structured command classes, document the exact `kinematic_pose` shape for both `Observation(..., command=...)` and `MujocoSession.step({"kinematic_pose": ...})`, and explicitly state the v1 non-goals: no server/daemon surface, no ROS2/zenoh customer API, no new wrapper families, and no public `EndEffectorPoses` surface. Update `docs/adding-a-model.md` so new wrappers must implement `capabilities()` honestly alongside `predict()` and `supported_robots()`.</action>
+  <verify>rg -n "embedded runtime|capabilit|kinematic_pose|EndEffectorPoses|server/daemon|ROS2|zenoh|WbcRegistry::build" README.md docs/python-sdk.md docs/configuration.md docs/adding-a-model.md</verify>
+  <acceptance_criteria>
+    - `README.md` contains an embedded-runtime framing and an embedded-Rust snippet using `WbcRegistry::build`
+    - `docs/python-sdk.md` documents `KinematicPoseCommand` and `Policy.capabilities()`
+    - `docs/configuration.md` documents the public `kinematic_pose` command shape for both config and live session usage
+    - `docs/adding-a-model.md` documents the `capabilities()` requirement for new wrappers
+    - the docs explicitly state the v1 non-goals and the exclusion of public `EndEffectorPoses`
+  </acceptance_criteria>
+  <done>The repo now reads like one intentional embedded runtime product instead of a CLI project with scattered integration examples</done>
+</task>
+
+</tasks>
+
+<verification>
+- [ ] On a fresh environment, `rustc --version && cargo --version && cargo build && cargo check` completed before running test commands (per `AGENTS.md`)
+- [ ] `python3 -m py_compile crates/robowbc-py/examples/lerobot_adapter.py` passes
+- [ ] `python3 -m py_compile crates/robowbc-py/examples/manipulation_adapter.py examples/python/mujoco_kinematic_pose_session.py` passes
+- [ ] `rg -n "embedded runtime|capabilit|kinematic_pose|EndEffectorPoses|server/daemon|ROS2|zenoh|WbcRegistry::build" README.md docs/python-sdk.md docs/configuration.md docs/adding-a-model.md` returns the expected matches
+- [ ] `make python-sdk-verify` passes
+</verification>
+
+<success_criteria>
+- All tasks completed
+- An official locomotion adapter and an official manipulation adapter both ship with the same `{"action": ...}` output seam
+- The live `kinematic_pose` session path is demonstrated by a checked-in example
+- The README and docs clearly present Python as the primary embedded path and Rust as the secondary embedded path
+- The public docs describe the exact command matrix and v1 non-goals without drifting from the implementation
+</success_criteria>
+
+<output>
+After completion, create `.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-03-SUMMARY.md`
+</output>

--- a/.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-03-SUMMARY.md
+++ b/.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-03-SUMMARY.md
@@ -1,0 +1,58 @@
+# Plan 01-03 Summary
+
+## Outcome
+
+Wave 3 shipped the first-party adoption seams and repositioned the public docs
+around RoboWBC as an embedded runtime product rather than a CLI-first project.
+The examples now reflect the capability-aware Python surface, and the docs
+describe one canonical manipulation contract.
+
+## Implemented
+
+- Updated `crates/robowbc-py/examples/lerobot_adapter.py` to:
+  - check `Policy.capabilities()` during initialization,
+  - fail fast unless `velocity` is supported,
+  - construct `VelocityCommand`,
+  - preserve the existing `step(obs_dict) -> {"action": targets}` seam.
+- Added `crates/robowbc-py/examples/manipulation_adapter.py` as the official
+  named-link manipulation adapter using `KinematicPoseCommand`.
+- Added `examples/python/mujoco_kinematic_pose_session.py` showing the live
+  `MujocoSession.step({"kinematic_pose": [...]})` seam.
+- Expanded `scripts/python_sdk_smoke.py` to validate:
+  capability discovery,
+  structured velocity commands,
+  preserved legacy flat observations,
+  and structured `KinematicPoseCommand` construction.
+- Updated `README.md` to frame RoboWBC as an embedded runtime with:
+  Python as the primary path,
+  embedded Rust as the secondary path,
+  and explicit v1 non-goals:
+  no `server/daemon`,
+  no public `ROS2` or `zenoh` customer API,
+  no public `EndEffectorPoses`,
+  and no new wrapper families.
+- Rewrote `docs/python-sdk.md` around the actual public command surface,
+  including `Policy.capabilities()`, structured command classes, and the live
+  `kinematic_pose` session shape.
+- Updated `docs/configuration.md` to document both TOML
+  `[[runtime.kinematic_pose.links]]` and live
+  `session.step({"kinematic_pose": [...]})`.
+- Updated `docs/adding-a-model.md` so new wrappers must implement
+  `capabilities()` honestly alongside `predict()` and `supported_robots()`.
+
+## Verification
+
+- `python3 -m py_compile crates/robowbc-py/examples/lerobot_adapter.py crates/robowbc-py/examples/manipulation_adapter.py examples/python/mujoco_kinematic_pose_session.py scripts/python_sdk_smoke.py`
+- `rg -n "embedded runtime|capabilit|kinematic_pose|EndEffectorPoses|server/daemon|ROS2|zenoh|WbcRegistry::build" README.md docs/python-sdk.md docs/configuration.md docs/adding-a-model.md`
+- `make python-sdk-verify`
+- `cargo fmt --all -- --check`
+- `cargo test --workspace --all-targets`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo doc --workspace --no-deps`
+
+## Notes
+
+- The manipulation examples intentionally validate payload shape early so copied
+  downstream code fails loudly on malformed link-pose data.
+- The public manipulation story is now consistently `kinematic_pose`; no public
+  example or doc path relies on `EndEffectorPoses`.

--- a/.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-CONTEXT.md
+++ b/.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-CONTEXT.md
@@ -1,0 +1,168 @@
+# Phase 1: Build a customer-facing external integration surface for locomotion and manipulation - Context
+
+**Gathered:** 2026-04-28
+**Status:** Ready for planning
+**Source:** session discussion + external integration surface plan
+
+<domain>
+## Phase Boundary
+
+This phase turns RoboWBC into a customer-facing embedded inference runtime for
+outside users. The deliverable is a stable external integration surface for
+both locomotion-oriented and manipulation-oriented pipelines, with the Python
+SDK as the primary adoption path and embedded Rust as the secondary path.
+
+This phase does not introduce a policy server, daemon, or multi-process runtime
+product. It does not add new model families. It does not prioritize showcase
+or report polish over the integration surface itself.
+
+</domain>
+
+<decisions>
+## Implementation Decisions
+
+### Product shape
+- **D-01:** RoboWBC v1 external adoption should be positioned as an embedded
+  runtime product, not a CLI-only tool and not a policy-server-first system.
+- **D-02:** The primary integration story is in-process Python embedding; the
+  secondary story is embedded Rust for teams that own their own robot loop.
+- **D-03:** Product-surface work takes priority over docs-only or showcase-only
+  work for this phase.
+
+### Public runtime contract
+- **D-04:** The public boundary is
+  `Observation -> Policy.predict() -> JointPositionTargets`.
+- **D-05:** The v1 public command set is `velocity`, `motion_tokens`,
+  `joint_targets`, and `kinematic_pose`.
+- **D-06:** `EndEffectorPoses` stays out of the public v1 SDK surface.
+- **D-07:** Policies should expose capability metadata so callers can discover
+  supported command types before attempting inference.
+
+### Python SDK
+- **D-08:** Keep backward compatibility for the current
+  `Observation(command_type, command_data)` calling style where already
+  supported.
+- **D-09:** Add a structured command API for new integrations instead of
+  forcing everything through flat `command_data`.
+- **D-10:** The Python SDK should become the main customer-facing surface,
+  including policy capability metadata and manipulation-ready command input.
+
+### Manipulation path
+- **D-11:** Manipulation support should use `KinematicPose` as the single
+  public representation in v1.
+- **D-12:** The live Python MuJoCo session should accept manipulation commands
+  instead of remaining locomotion-only.
+- **D-13:** The phase must support both locomotion and manipulation in one
+  milestone; manipulation readiness is not deferred behind a locomotion-only
+  product story.
+
+### Official adapters
+- **D-14:** Ship one official locomotion adapter for LeRobot / GR00T-style
+  velocity-controller seams.
+- **D-15:** Ship one official manipulation adapter that accepts named link poses
+  and produces the same joint-target output shape.
+
+### Out of scope
+- **D-16:** Do not build a server/daemon/multi-process deployment surface in
+  this phase.
+- **D-17:** Do not add ROS2-specific or zenoh-specific customer-facing APIs in
+  this phase.
+- **D-18:** Do not broaden scope into new policy families beyond the existing
+  shipped wrappers.
+
+### the agent's Discretion
+- Exact symbol names for the new structured Python command classes
+- Exact layout of the customer-facing integration matrix docs
+- Whether manipulation examples live beside the existing LeRobot adapter or in a
+  new example module, as long as the public seam is clear
+
+</decisions>
+
+<specifics>
+## Specific Ideas
+
+- The user explicitly compared the repo to `groot_wbc` and `rl_sar` style
+  pipelines where simulation, policy, and interactive messages can become
+  awkward when parallelized.
+- The repo should be sellable to outside teams as a pipeline seam, not just as
+  a local demo CLI.
+- A realistic adoption target is a team already using GR00T WBC for
+  manipulation-like work that wants to swap in RoboWBC without rebuilding their
+  full runtime stack.
+- The plan should cover both locomotion and manipulation at once, but bias the
+  first milestone toward the product surface rather than a docs package.
+
+</specifics>
+
+<canonical_refs>
+## Canonical References
+
+**Downstream agents MUST read these before planning or implementing.**
+
+### Public product surface
+- `README.md` — current public positioning, shipped policy status, and Python
+  SDK entrypoints
+- `docs/python-sdk.md` — current external Python API, live MuJoCo session, and
+  LeRobot integration story
+- `docs/configuration.md` — current command/config surface and runtime shape
+
+### Phase goal and architecture
+- `.planning/ROADMAP.md` — active milestone and Phase 1 goal
+- `.planning/STATE.md` — current milestone state and carry-forward constraints
+- `crates/robowbc-core/src/lib.rs` — source of truth for `WbcPolicy`,
+  `Observation`, `WbcCommand`, and `JointPositionTargets`
+
+### Extensibility and examples
+- `docs/adding-a-model.md` — pattern for policy wrappers and contract-driven
+  integration
+- `crates/robowbc-py/examples/lerobot_adapter.py` — existing locomotion adapter
+  seam to extend or parallel
+- `examples/python/roboharness_backend.py` — current Python-to-Rust ownership
+  boundary for live simulation
+
+</canonical_refs>
+
+<code_context>
+## Existing Code Insights
+
+### Reusable Assets
+- `crates/robowbc-core/src/lib.rs`: already defines the normalized runtime
+  contract and the command variants that matter for this phase.
+- `crates/robowbc-py/src/lib.rs`: already owns Python-facing `Observation`,
+  `Policy`, and `MujocoSession`; this is the primary integration surface to
+  extend.
+- `crates/robowbc-py/examples/lerobot_adapter.py`: already proves the
+  locomotion-controller adapter seam for velocity-command use cases.
+
+### Established Patterns
+- Policy wrappers validate command variants explicitly and return
+  `UnsupportedCommand` when a contract is not supported.
+- The runtime is single-process and embedded-first today; Rust owns inference
+  and MuJoCo stepping even when Python is the user-facing entrypoint.
+- Policy loading is config-driven through registry-based construction rather
+  than hard-coded per-model entrypoints.
+
+### Integration Points
+- Add policy capability metadata at the core trait level and thread it through
+  shipped wrappers plus Python bindings.
+- Extend Python command conversion in `crates/robowbc-py/src/lib.rs` so
+  `KinematicPose` is no longer missing from the public SDK/session path.
+- Add or update official adapter examples so outside users can copy a stable
+  seam instead of reverse-engineering internal demos.
+
+</code_context>
+
+<deferred>
+## Deferred Ideas
+
+- Policy server / daemon / RPC deployment surface
+- ROS2- or zenoh-native customer-facing API layer
+- First-class public `EndEffectorPoses` SDK support
+- New wrapper families beyond the currently shipped policies
+
+</deferred>
+
+---
+
+*Phase: 01-build-a-customer-facing-external-integration-surface-for-loc*
+*Context gathered: 2026-04-28*

--- a/.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-RESEARCH.md
+++ b/.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-RESEARCH.md
@@ -1,0 +1,367 @@
+# Phase 1: Build a customer-facing external integration surface for locomotion and manipulation - Research
+
+**Researched:** 2026-04-28
+**Domain:** embedded runtime capability metadata, Python SDK command surface,
+official locomotion/manipulation adapters
+**Confidence:** HIGH
+
+<user_constraints>
+## User Constraints (from CONTEXT.md)
+
+### Locked Decisions
+- RoboWBC v1 must be positioned as an embedded runtime product, not a CLI-only
+  tool and not a policy-server-first system.
+- The primary integration story is in-process Python embedding; the secondary
+  story is embedded Rust for teams that own their own robot loop.
+- Product-surface work takes priority over docs-only or showcase-only polish in
+  this phase.
+- The public runtime boundary stays
+  `Observation -> Policy.predict() -> JointPositionTargets`.
+- The v1 public command set is `velocity`, `motion_tokens`, `joint_targets`,
+  and `kinematic_pose`.
+- `EndEffectorPoses` stays out of the public v1 SDK surface.
+- Policies must expose capability metadata so callers can discover supported
+  command types before attempting inference.
+- Existing `Observation(command_type, command_data)` callers should keep
+  working where they already do.
+- New Python integrations should use a structured command API instead of being
+  forced through flat `command_data`.
+- The Python SDK is the main customer-facing surface and must cover capability
+  metadata plus manipulation-ready command input.
+- Manipulation support uses `KinematicPose` as the single public v1 shape.
+- The live Python MuJoCo session must accept manipulation commands instead of
+  staying locomotion-only.
+- The milestone must support both locomotion and manipulation together; the
+  manipulation story is not deferred behind a locomotion-only product.
+- Ship one official locomotion adapter for LeRobot / GR00T-style
+  velocity-controller seams.
+- Ship one official manipulation adapter that accepts named link poses and
+  produces the same joint-target output shape.
+
+### the agent's Discretion
+- Exact public symbol names for the structured Python command classes.
+- Exact layout of the customer-facing integration matrix docs.
+- Whether the manipulation examples live beside the existing LeRobot adapter or
+  as a separate example module, as long as the public seam is explicit.
+
+### Deferred Ideas (OUT OF SCOPE)
+- Policy server / daemon / RPC deployment surface.
+- ROS2- or zenoh-native customer-facing APIs.
+- First-class public `EndEffectorPoses` SDK support.
+- New wrapper families beyond the currently shipped policies.
+</user_constraints>
+
+<architectural_responsibility_map>
+## Architectural Responsibility Map
+
+| Capability | Primary Tier | Secondary Tier | Rationale |
+|------------|--------------|----------------|-----------|
+| Honest supported-command metadata | API/Backend (`crates/robowbc-core`, shipped wrappers, `crates/robowbc-pyo3`) | Python SDK | The Rust trait boundary is the source of truth for what a built policy can consume; Python should present, not redefine, that truth. |
+| Structured public command API for external users | Python SDK (`crates/robowbc-py`) | API/Backend | The main adoption path is Python embedding, so structured customer-facing commands belong in the PyO3 layer while still mapping losslessly into `WbcCommand`. |
+| Live manipulation ingress in the MuJoCo session | Python SDK (`crates/robowbc-py`) | API/Backend | The CLI already accepts `runtime.kinematic_pose`; the missing product gap is the Python session/action surface. |
+| Official locomotion and manipulation adapters | Examples/docs (`crates/robowbc-py/examples`, `examples/python`) | Python SDK | Outside teams need copyable seams, not just a lower-level SDK. |
+| Product positioning and embedded-Rust guidance | README/docs | API/Backend | The repo already contains the embedded Rust pieces; the missing work is framing and documenting them as a stable integration surface. |
+</architectural_responsibility_map>
+
+<research_summary>
+## Summary
+
+Phase 1 is mostly a public-surface problem, not a new-runtime problem. The
+core enum already contains `WbcCommand::KinematicPose`, the CLI already accepts
+`[[runtime.kinematic_pose.links]]`, and the repo already ships manipulation-
+capable wrappers (`wholebody_vla`, `hover`) alongside the locomotion-oriented
+ones. The missing customer-facing seam is that Python callers still interact
+through a flattened `command_type` / `command_data` API, `MujocoSession`
+explicitly rejects `runtime.kinematic_pose`, and there is no capability
+metadata anywhere in the public surface.
+
+The current failure mode is especially clear in `crates/robowbc-pyo3/src/lib.rs`:
+the flat Python-backed policy path cannot represent `KinematicPose` or
+`EndEffectorPoses`, and today it silently flattens those commands to an empty
+float vector. That is acceptable for an internal prototype but not for a
+customer-facing embedded runtime. Phase 1 should therefore make capability
+truth explicit: callers should be able to ask a loaded policy what command
+shapes it supports, and unsupported structured commands should fail fast before
+reaching model inference.
+
+The lowest-risk implementation path is:
+
+1. add explicit capability metadata at the `WbcPolicy` boundary,
+2. expose that metadata through the Python SDK,
+3. add a structured Python command API that introduces `KinematicPose` without
+   breaking the existing flat locomotion-oriented calls,
+4. extend `MujocoSession` so its runtime config, live `step()` actions,
+   `get_state()`, `save_state()`, and `restore_state()` all round-trip the same
+   structured manipulation shape, and
+5. ship one official locomotion adapter and one official manipulation adapter
+   so outside teams can copy a stable seam immediately.
+
+**Primary recommendation:** treat capability metadata plus a structured Python
+command API as the contract freeze for this phase. Keep the legacy flat
+`Observation(command_type, command_data)` path working for `velocity`,
+`motion_tokens`, and `joint_targets`, but do not invent a fake flattened
+encoding for `kinematic_pose`. Introduce `KinematicPose` only through the new
+structured public surface.
+
+**Secondary recommendation:** keep `robowbc-pyo3` honest instead of broadening
+it in this phase. The user-supplied `py_model` backend should advertise only
+the flat commands it can truly consume and should return an explicit
+`UnsupportedCommand` error for `KinematicPose` rather than pretending the empty
+vector is meaningful.
+</research_summary>
+
+<implementation_findings>
+## Key Findings
+
+### 1. The Rust runtime already has the manipulation shape Phase 1 needs
+
+- `crates/robowbc-core/src/lib.rs` already defines
+  `WbcCommand::KinematicPose(BodyPose)`.
+- `crates/robowbc-cli/src/main.rs` already parses `runtime.kinematic_pose`.
+- `configs/wholebody_vla_x2.toml` already documents a concrete named-link pose
+  configuration for manipulation-style WBC input.
+
+**Implication:** Phase 1 does not need a brand-new manipulation contract. It
+needs the public Python surface to catch up with the existing Rust truth.
+
+### 2. The Python SDK is still flat and locomotion-biased
+
+- `crates/robowbc-py/src/lib.rs` exposes `Observation` as
+  `command_type: String` plus `command_data: Vec<f32>`.
+- The public crate docs and `docs/python-sdk.md` only document the flat command
+  layout.
+- `MujocoSession.step()` accepts `velocity`, `motion_tokens`, and
+  `joint_targets`, but not `kinematic_pose`.
+
+**Implication:** the customer-facing gap is concentrated in `crates/robowbc-py`
+and docs/examples, not the deeper runtime layers.
+
+### 3. `MujocoSession` explicitly blocks the manipulation path today
+
+- `SessionRuntimeConfig` includes `kinematic_pose: Option<toml::Value>`.
+- `SessionCommandSpec::from_runtime_config()` returns the explicit error
+  `"runtime.kinematic_pose is not yet supported by robowbc.MujocoSession"`.
+- `parse_action_command()` and `command_dict()` do not handle
+  `kinematic_pose`.
+
+**Implication:** live embedded Python simulation is currently locomotion-only
+by construction, even though the CLI already supports the same runtime shape.
+
+### 4. There is no supported-command discovery API yet
+
+- `WbcPolicy` exposes `predict`, `reset`, `control_frequency_hz`, and
+  `supported_robots`, but not supported command metadata.
+- `WbcRegistry::policy_names()` returns only names.
+- `PyPolicy` exposes only `predict()` and `control_frequency_hz()`.
+- Current callers discover support by triggering `WbcError::UnsupportedCommand`
+  at inference time.
+
+**Implication:** outside users cannot fail fast or branch cleanly on supported
+command types before attempting a call.
+
+### 5. The `py_model` backend is the main honesty gap
+
+- `crates/robowbc-pyo3/src/lib.rs` currently maps
+  `WbcCommand::EndEffectorPoses(_)` and `WbcCommand::KinematicPose(_)` to
+  `vec![]` in `command_to_floats()`.
+- That means a Python-backed model can receive a structured manipulation
+  command with no explicit rejection.
+
+**Implication:** Phase 1 should not extend this backend to structured pose
+commands. It should explicitly declare that the v1 flat backend supports only
+flat command kinds and fail fast for the rest.
+
+### 6. The existing adapter and doc seams are strong foundations
+
+- `crates/robowbc-py/examples/lerobot_adapter.py` already proves the official
+  locomotion seam shape: `obs_dict -> Observation -> predict -> {"action": ...}`.
+- `README.md` and `docs/python-sdk.md` already present RoboWBC as config-driven
+  and Python-embeddable.
+- `docs/adding-a-model.md` already teaches wrapper authors how to implement
+  `WbcPolicy`.
+
+**Implication:** Phase 1 should extend these seams rather than inventing new
+top-level products or tutorial structures.
+</implementation_findings>
+
+<recommended_contract>
+## Recommended Contract
+
+### Core capability surface
+
+- Add a public `WbcCommandKind` enum with the v1 external command kinds:
+  `Velocity`, `MotionTokens`, `JointTargets`, and `KinematicPose`.
+- Add a public `PolicyCapabilities` struct with at least one authoritative field:
+  `supported_commands`.
+- Extend `WbcPolicy` with `fn capabilities(&self) -> PolicyCapabilities`.
+- Do **not** surface `EndEffectorPoses` in the customer-facing v1 capability
+  set even though it exists internally in `WbcCommand`.
+
+### Python SDK surface
+
+- Add structured Python command classes for the v1 public commands:
+  `VelocityCommand`, `MotionTokensCommand`, `JointTargetsCommand`,
+  `KinematicPoseCommand`, and a named-link helper such as `LinkPose`.
+- Keep the existing flat `Observation(command_type, command_data)` path for the
+  existing flat commands only.
+- Introduce `KinematicPose` through a new structured path such as
+  `Observation(..., command=KinematicPoseCommand(...))`; do not try to encode
+  named link poses into flat `command_data`.
+- Add `Policy.capabilities()` to the Python SDK and represent
+  `supported_commands` as snake_case strings (`"velocity"`,
+  `"motion_tokens"`, `"joint_targets"`, `"kinematic_pose"`).
+
+### `MujocoSession` surface
+
+- Remove the current hard rejection of `runtime.kinematic_pose`.
+- Add one internal `SessionCommandSpec::KinematicPose` shape and use it for:
+  - TOML `[[runtime.kinematic_pose.links]]`
+  - live `step({"kinematic_pose": [...]})`
+  - `get_state()["command"]`
+  - `save_state()["current_command"]`
+  - `restore_state(...)`
+- Add a pre-tick capability gate so `MujocoSession` rejects commands not listed
+  by `policy.capabilities()`.
+
+### Adapter surface
+
+- Keep the current locomotion adapter contract:
+  `step(obs_dict) -> {"action": list[float]}`.
+- Add an official manipulation adapter contract that accepts named link poses
+  and returns the same `{"action": list[float]}` shape.
+- Use `configs/wholebody_vla_x2.toml` as the canonical checked-in manipulation
+  example because it already defines named `runtime.kinematic_pose.links`.
+
+### Explicit Phase-1 deferral
+
+- `robowbc-pyo3` remains a flat-command backend in v1.
+- Server/daemon deployment remains deferred.
+- ROS2/zenoh customer-facing APIs remain deferred.
+- Public `EndEffectorPoses` SDK support remains deferred.
+</recommended_contract>
+
+<validation_architecture>
+## Validation Architecture
+
+### Fast loop
+
+- `cargo test -p robowbc-core`
+- `cargo test -p robowbc-ort --lib`
+- `cargo test -p robowbc-pyo3`
+- `cargo test --manifest-path crates/robowbc-py/Cargo.toml`
+- `python3 -m py_compile crates/robowbc-py/examples/lerobot_adapter.py`
+
+### Full loop
+
+- `cargo test --workspace --all-targets`
+- `make python-sdk-verify`
+
+### Why this is the right validation split
+
+- The Rust crate tests protect the capability contract and wrapper-specific
+  command handling.
+- `crates/robowbc-py` needs its own direct tests because the Python SDK surface
+  is where Phase 1 introduces the new structured command contract.
+- `make python-sdk-verify` is the highest-signal installed-wheel path for the
+  customer-facing Python surface and should remain the final gate for this
+  phase.
+</validation_architecture>
+
+<common_pitfalls>
+## Common Pitfalls
+
+### Pitfall 1: documenting capabilities without exposing them in code
+
+**What goes wrong:** docs claim a policy supports manipulation, but callers
+still discover that only by hitting `UnsupportedCommand` at runtime.
+**How to avoid:** put `capabilities()` on `WbcPolicy` and surface it through
+`PyPolicy`.
+
+### Pitfall 2: replacing the flat Python API instead of augmenting it
+
+**What goes wrong:** existing `Observation(command_type, command_data)` users
+break even though the phase only needs a new structured path for manipulation.
+**How to avoid:** preserve the flat path for the flat commands and add
+`KinematicPose` only through the new structured API.
+
+### Pitfall 3: inventing a fake float protocol for `KinematicPose`
+
+**What goes wrong:** named link poses get squeezed into an ad hoc float vector,
+which hides link names, breaks validation, and encourages silent misuse in
+`py_model`.
+**How to avoid:** keep `KinematicPose` structured end-to-end and make
+flat-command backends reject it explicitly.
+
+### Pitfall 4: teaching `MujocoSession` manipulation in one path only
+
+**What goes wrong:** `step()` accepts `kinematic_pose`, but runtime config,
+`save_state()`, or `restore_state()` still cannot round-trip it.
+**How to avoid:** add one canonical `SessionCommandSpec::KinematicPose` and use
+it everywhere the session stores or emits commands.
+</common_pitfalls>
+
+<open_questions>
+## Open Questions (RESOLVED)
+
+1. **Should Python expose capabilities as a dedicated class or a plain dict?**
+   - **RESOLVED:** expose a dedicated `PolicyCapabilities` Python class with
+     `supported_commands` as snake_case strings. This keeps the SDK docs and
+     examples stable, makes discovery self-documenting, and avoids turning the
+     public surface into an untyped ad hoc dict.
+
+2. **Should the official manipulation adapter target one policy or stay generic?**
+   - **RESOLVED:** make the adapter generic over named link poses, but use
+     `configs/wholebody_vla_x2.toml` as the first documented example. This
+     keeps the public seam reusable while still shipping one concrete,
+     checked-in manipulation path.
+</open_questions>
+
+<sources>
+## Sources
+
+### Primary (HIGH confidence)
+- `.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-CONTEXT.md`
+- `.planning/ROADMAP.md`
+- `.planning/STATE.md`
+- `crates/robowbc-core/src/lib.rs`
+- `crates/robowbc-py/src/lib.rs`
+- `crates/robowbc-pyo3/src/lib.rs`
+- `crates/robowbc-registry/src/lib.rs`
+- `crates/robowbc-cli/src/main.rs`
+- `crates/robowbc-py/examples/lerobot_adapter.py`
+- `configs/wholebody_vla_x2.toml`
+- `scripts/python_sdk_smoke.py`
+
+### Secondary (MEDIUM confidence)
+- `README.md`
+- `docs/python-sdk.md`
+- `docs/configuration.md`
+- `docs/adding-a-model.md`
+- `docs/community/lerobot-rfc.md`
+- `examples/python/roboharness_backend.py`
+</sources>
+
+<metadata>
+## Metadata
+
+**Research scope:**
+- Core capability metadata and public command taxonomy
+- Python SDK structured command surface and session ingress
+- Official adapter and docs positioning for external users
+
+**Confidence breakdown:**
+- Rust runtime command capabilities: HIGH
+- Python SDK manipulation gap: HIGH
+- Best path for official adapters/examples: HIGH
+- Exact public Python type names: MEDIUM
+
+**Research date:** 2026-04-28
+**Valid until:** until the Python SDK command surface or `WbcPolicy` trait
+changes materially
+</metadata>
+
+---
+
+*Phase: 01-build-a-customer-facing-external-integration-surface-for-loc*
+*Research completed: 2026-04-28*
+*Ready for planning: yes*

--- a/.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-VALIDATION.md
+++ b/.planning/phases/01-build-a-customer-facing-external-integration-surface-for-loc/01-VALIDATION.md
@@ -1,0 +1,111 @@
+---
+phase: 1
+slug: build-a-customer-facing-external-integration-surface-for-loc
+status: complete
+nyquist_compliant: true
+wave_0_complete: true
+created: 2026-04-28
+---
+
+# Phase 1 — Validation Strategy
+
+> Per-phase validation contract for feedback sampling during execution.
+
+---
+
+## Test Infrastructure
+
+| Property | Value |
+|----------|-------|
+| **Framework** | `cargo test` + installed-wheel Python SDK smoke + `python3 -m py_compile` |
+| **Config file** | `Makefile`, `crates/robowbc-py/Cargo.toml` |
+| **Fresh-environment preflight** | `rustc --version && cargo --version && cargo build && cargo check` |
+| **`robowbc-py` env** | `export PYTHON_LIBDIR="$(python3 -c 'import sysconfig; print(sysconfig.get_config_var(\"LIBDIR\") or \"\")')"` then `export LD_LIBRARY_PATH="$PYTHON_LIBDIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"` and `export MUJOCO_DOWNLOAD_DIR=/tmp/mujoco` |
+| **Quick run command** | `cargo test -p robowbc-core && cargo test -p robowbc-registry && cargo test -p robowbc-ort --lib && cargo test -p robowbc-pyo3 && cargo test --manifest-path crates/robowbc-py/Cargo.toml -- --test-threads=1` |
+| **Full suite command** | `cargo test --workspace --all-targets && cargo clippy --workspace --all-targets -- -D warnings && cargo fmt --all -- --check && cargo doc --workspace --no-deps && cargo test --manifest-path crates/robowbc-py/Cargo.toml -- --test-threads=1 && cargo clippy --manifest-path crates/robowbc-py/Cargo.toml --all-targets -- -D warnings && cargo fmt --manifest-path crates/robowbc-py/Cargo.toml --all -- --check && cargo doc --manifest-path crates/robowbc-py/Cargo.toml --no-deps && make python-sdk-verify` |
+| **Estimated runtime** | ~360 seconds |
+
+---
+
+## Sampling Rate
+
+- **Before the first test run on a fresh environment:** complete the
+  AGENTS.md preflight:
+  `rustc --version && cargo --version && cargo build && cargo check`
+- **Before any crate-local `robowbc-py` Rust command:** export the
+  `robowbc-py` environment values listed above so the active Python `LIBDIR`
+  and MuJoCo download directory are discoverable.
+- **After every task commit:** run the relevant subset of the quick command for
+  the files touched, plus `python3 -m py_compile` for changed example files.
+- **After every plan wave:** run
+  `cargo test --workspace --all-targets`, the AGENTS-required lint/doc checks
+  for every Rust crate touched in that wave, and `make python-sdk-verify`.
+- **Before `$gsd-verify-work`:** the full suite must be green.
+- **Max feedback latency:** target <30 seconds for hot reruns when a narrower
+  touched-crate subset exists; allow up to 120 seconds on cold builds.
+
+---
+
+## Per-Task Verification Map
+
+| Task ID | Plan | Wave | Requirement | Threat Ref | Secure Behavior | Test Type | Automated Command | File Exists | Status |
+|---------|------|------|-------------|------------|-----------------|-----------|-------------------|-------------|--------|
+| 01-01-01 | 01 | 1 | D-04 / D-05 / D-07 | T-01-01 | capability metadata matches the public v1 command contract exactly | unit | `cargo test -p robowbc-core && cargo test -p robowbc-registry && cargo clippy --workspace --all-targets -- -D warnings && cargo fmt --all -- --check && cargo doc --workspace --no-deps` | ✅ | ✅ green |
+| 01-01-02 | 01 | 1 | D-06 / D-07 / D-18 | T-01-02 / T-01-03 | shipped wrappers and `py_model` report only truthful supported commands and fail fast on unsupported structured commands | unit | `cargo test -p robowbc-ort --lib && cargo test -p robowbc-pyo3 && cargo clippy --workspace --all-targets -- -D warnings && cargo fmt --all -- --check && cargo doc --workspace --no-deps` | ✅ | ✅ green |
+| 01-02-01 | 02 | 2 | D-08 / D-09 / D-10 | T-02-03 | legacy flat `Observation` calls keep working while the structured Python command API is added | unit | `cargo test --manifest-path crates/robowbc-py/Cargo.toml -- --test-threads=1 && cargo clippy --manifest-path crates/robowbc-py/Cargo.toml --all-targets -- -D warnings && cargo fmt --manifest-path crates/robowbc-py/Cargo.toml --all -- --check && cargo doc --manifest-path crates/robowbc-py/Cargo.toml --no-deps` | ✅ | ✅ green |
+| 01-02-02 | 02 | 2 | D-11 / D-12 / D-13 | T-02-01 / T-02-02 | `MujocoSession` round-trips one canonical `kinematic_pose` shape through config, live step, and saved state | unit | `cargo test --manifest-path crates/robowbc-py/Cargo.toml -- --test-threads=1 && cargo clippy --manifest-path crates/robowbc-py/Cargo.toml --all-targets -- -D warnings && cargo fmt --manifest-path crates/robowbc-py/Cargo.toml --all -- --check && cargo doc --manifest-path crates/robowbc-py/Cargo.toml --no-deps` | ✅ | ✅ green |
+| 01-02-03 | 02 | 2 | D-07 / D-10 / D-11 | T-02-01 / T-02-03 | installed-wheel smoke covers capability discovery plus structured manipulation construction | smoke | `make python-sdk-verify` | ✅ | ✅ green |
+| 01-03-01 | 03 | 3 | D-14 | T-03-01 | official locomotion adapter checks capability support before inference and preserves the `{"action": ...}` seam | smoke | `python3 -m py_compile crates/robowbc-py/examples/lerobot_adapter.py` | ✅ | ✅ green |
+| 01-03-02 | 03 | 3 | D-15 | T-03-01 / T-03-03 | official manipulation adapter and live session example accept named link poses, reject malformed payloads, and preserve the `{"action": ...}` seam | smoke | `python3 -m py_compile crates/robowbc-py/examples/manipulation_adapter.py examples/python/mujoco_kinematic_pose_session.py` | ✅ task-owned | ✅ green |
+| 01-03-03 | 03 | 3 | D-01 / D-02 / D-03 / D-16 / D-17 | T-03-02 | docs and README describe the embedded-runtime surface, v1 command matrix, and explicit non-goals without drift from the implementation | docs | `rg -n "embedded runtime|capabilit|kinematic_pose|server/daemon|ROS2|zenoh|WbcRegistry::build" README.md docs/python-sdk.md docs/configuration.md docs/adding-a-model.md` | ✅ | ✅ green |
+
+*Status: ⬜ pending · ✅ green · ❌ red · ⚠️ flaky*
+
+---
+
+## Wave 0 Requirements
+
+Existing infrastructure covers all phase requirements. Phase-specific SDK
+regressions and smoke coverage are delivered inside Plan 02 Task 3 rather than
+through a separate Wave 0 prerequisite.
+
+---
+
+## Manual-Only Verifications
+
+| Behavior | Requirement | Why Manual | Test Instructions |
+|----------|-------------|------------|-------------------|
+| The README and Python docs read like one intentional embedded runtime product instead of a CLI project with extra examples | D-01 / D-02 / D-03 / D-10 | Automated checks can confirm strings and snippets exist, but only a human can judge whether the framing is coherent for outside teams | Read `README.md` plus `docs/python-sdk.md` together and confirm the primary Python story, secondary embedded-Rust story, and explicit v1 non-goals are obvious without hunting through the repo |
+| The locomotion and manipulation adapters feel like parallel seams instead of unrelated demos | D-14 / D-15 | Only a human review can judge whether both examples use the same conceptual contract and are easy to copy into another project | Compare `crates/robowbc-py/examples/lerobot_adapter.py` and `crates/robowbc-py/examples/manipulation_adapter.py` and confirm both initialize a policy, check capabilities, build one command, and return `{"action": ...}` |
+
+Manual review was completed during the docs/examples pass for Wave 3, and the
+phase write-up keeps those results aligned with the shipped examples and public
+docs.
+
+## Verification Evidence
+
+- `rustc --version && cargo --version && cargo build && cargo check`
+- `cargo test --workspace --all-targets`
+- `cargo clippy --workspace --all-targets -- -D warnings`
+- `cargo doc --workspace --no-deps`
+- `cargo fmt --all -- --check`
+- `PYTHON_LIBDIR="$(python3 -c 'import sysconfig; print(sysconfig.get_config_var(\"LIBDIR\") or \"\")')"; LD_LIBRARY_PATH="$PYTHON_LIBDIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" MUJOCO_DOWNLOAD_DIR=/tmp/mujoco cargo test --manifest-path crates/robowbc-py/Cargo.toml -- --test-threads=1`
+- `MUJOCO_DOWNLOAD_DIR=/tmp/mujoco cargo clippy --manifest-path crates/robowbc-py/Cargo.toml --all-targets -- -D warnings`
+- `MUJOCO_DOWNLOAD_DIR=/tmp/mujoco cargo doc --manifest-path crates/robowbc-py/Cargo.toml --no-deps`
+- `cargo fmt --manifest-path crates/robowbc-py/Cargo.toml --all -- --check`
+- `make python-sdk-verify`
+- `python3 -m py_compile crates/robowbc-py/examples/lerobot_adapter.py crates/robowbc-py/examples/manipulation_adapter.py examples/python/mujoco_kinematic_pose_session.py scripts/python_sdk_smoke.py`
+- `rg -n "embedded runtime|capabilit|kinematic_pose|EndEffectorPoses|server/daemon|ROS2|zenoh|WbcRegistry::build" README.md docs/python-sdk.md docs/configuration.md docs/adding-a-model.md`
+
+---
+
+## Validation Sign-Off
+
+- [x] All tasks have automated verify or explicit Wave 0 coverage
+- [x] Sampling continuity: no 3 consecutive tasks without automated verify
+- [x] Wave 0 covers all missing references
+- [x] No watch-mode flags
+- [x] Feedback latency target defined for hot reruns
+- [x] `nyquist_compliant: true` set in frontmatter
+
+**Approval:** approved

--- a/Makefile
+++ b/Makefile
@@ -182,7 +182,7 @@ site-serve: ## Serve the generated site bundle locally. Set SITE_OPEN=1 to open 
 		$$extra_args
 
 python-sdk-deps: ## Install Python build dependencies for local SDK verification.
-	$(PYTHON) -m pip install "maturin>=1.4,<2.0"
+	$(PYTHON) -m pip install "maturin>=1.9.4,<2.0"
 
 python-sdk-build: python-sdk-deps ## Build the local RoboWBC Python wheel with an absolute MuJoCo cache path.
 	mkdir -p "$(PYTHON_SDK_DIST_DIR)" "$(abspath $(PYTHON_SDK_MUJOCO_DOWNLOAD_DIR))"

--- a/README.md
+++ b/README.md
@@ -14,16 +14,57 @@ Unified inference runtime for humanoid whole-body control policies.
   <a href="docs/founding-document.md"><strong>Founding Document</strong></a>
 </p>
 
-RoboWBC gives you one config-driven runtime for loading multiple WBC policies,
-running them through the same Rust CLI, and exporting the same JSON + Rerun
-report pipeline across smoke tests, MuJoCo runs, and hardware-oriented
-transports.
+RoboWBC is an embedded runtime for loading multiple WBC policies through one
+customer-facing contract. The primary adoption path is the Python SDK
+(`Registry`, `Observation`, `Policy`, and `MujocoSession`). Embedded Rust is
+the secondary path for teams that want to own the host loop directly. The CLI
+stays in the repo as the verification, benchmarking, and reporting surface for
+the same runtime.
 
 RoboWBC is a Linux-only project. The runtime backends fail fast on non-Linux
 targets instead of carrying partial or unverified platform fallbacks.
 
 Run `make help` to see the repo-level commands for build, validation,
 benchmarks, site generation, and local serving.
+
+## Embedded Runtime Surface
+
+Python is the primary embedded runtime seam:
+
+```python
+from robowbc import Observation, Registry, VelocityCommand
+
+policy = Registry.build("decoupled_wbc", "configs/decoupled_smoke.toml")
+print(policy.capabilities().supported_commands)
+
+obs = Observation(
+    joint_positions=[0.0] * 4,
+    joint_velocities=[0.0] * 4,
+    gravity_vector=[0.0, 0.0, -1.0],
+    command=VelocityCommand(linear=[0.2, 0.0, 0.0], angular=[0.0, 0.0, 0.1]),
+)
+targets = policy.predict(obs)
+print(targets.positions)
+```
+
+Embedded Rust is the secondary path:
+
+```rust
+use robowbc_core::WbcCommandKind;
+use robowbc_registry::WbcRegistry;
+
+let policy = WbcRegistry::build("my_policy", &policy_cfg)?;
+let capabilities = policy.capabilities();
+assert!(capabilities.supports(WbcCommandKind::Velocity));
+```
+
+Phase 1 deliberately keeps the surface narrow:
+
+- Python SDK first, embedded runtime second
+- no `server/daemon` surface
+- no `ROS2` or `zenoh` customer API
+- no public `EndEffectorPoses` surface
+- no new wrapper families beyond the shipped policy wrappers
 
 ## Published HTML reports
 
@@ -175,14 +216,18 @@ release exists upstream today.
 <summary><strong>Python SDK</strong></summary>
 
 ```bash
-pip install "maturin>=1.4,<2.0"
+pip install "maturin>=1.9.4,<2.0"
 maturin develop
 python -c "from robowbc import Registry; print(Registry.list_policies())"
 ```
 
 The standalone Python package lives in `crates/robowbc-py`, while
 `robowbc-pyo3` provides the runtime backend for user-supplied Python or
-PyTorch policies.
+PyTorch policies. First-party embedded examples live at:
+
+- `crates/robowbc-py/examples/lerobot_adapter.py` for velocity-driven locomotion
+- `crates/robowbc-py/examples/manipulation_adapter.py` for named-link `kinematic_pose`
+- `examples/python/mujoco_kinematic_pose_session.py` for live `MujocoSession.step({"kinematic_pose": ...})`
 </details>
 
 <details>

--- a/crates/robowbc-core/src/lib.rs
+++ b/crates/robowbc-core/src/lib.rs
@@ -33,6 +33,84 @@ impl std::fmt::Display for WbcError {
 
 impl std::error::Error for WbcError {}
 
+/// Public command taxonomy exposed to embedded `RoboWBC` callers.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WbcCommandKind {
+    /// Base linear/angular velocity command.
+    Velocity,
+    /// Tokenized motion reference command.
+    MotionTokens,
+    /// Direct joint-space target command.
+    JointTargets,
+    /// Whole-body kinematic pose command.
+    KinematicPose,
+}
+
+impl WbcCommandKind {
+    /// Returns the stable `snake_case` label used by external callers.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Velocity => "velocity",
+            Self::MotionTokens => "motion_tokens",
+            Self::JointTargets => "joint_targets",
+            Self::KinematicPose => "kinematic_pose",
+        }
+    }
+}
+
+impl std::fmt::Display for WbcCommandKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl TryFrom<&WbcCommand> for WbcCommandKind {
+    type Error = ();
+
+    fn try_from(command: &WbcCommand) -> std::result::Result<Self, Self::Error> {
+        match command {
+            WbcCommand::Velocity(_) => Ok(Self::Velocity),
+            WbcCommand::MotionTokens(_) => Ok(Self::MotionTokens),
+            WbcCommand::JointTargets(_) => Ok(Self::JointTargets),
+            WbcCommand::KinematicPose(_) => Ok(Self::KinematicPose),
+            WbcCommand::EndEffectorPoses(_) => Err(()),
+        }
+    }
+}
+
+/// Capability metadata exposed by a built policy before inference.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct PolicyCapabilities {
+    /// Public command kinds the policy can consume.
+    pub supported_commands: Vec<WbcCommandKind>,
+}
+
+impl PolicyCapabilities {
+    /// Build a normalized capability set.
+    #[must_use]
+    pub fn new(supported_commands: impl Into<Vec<WbcCommandKind>>) -> Self {
+        let mut supported_commands = supported_commands.into();
+        supported_commands.sort_unstable();
+        supported_commands.dedup();
+        Self { supported_commands }
+    }
+
+    /// Returns whether the capability set includes `kind`.
+    #[must_use]
+    pub fn supports(&self, kind: WbcCommandKind) -> bool {
+        self.supported_commands.contains(&kind)
+    }
+
+    /// Returns whether the capability set includes the public kind implied by
+    /// `command`.
+    #[must_use]
+    pub fn supports_command(&self, command: &WbcCommand) -> bool {
+        WbcCommandKind::try_from(command).is_ok_and(|kind| self.supports(kind))
+    }
+}
+
 /// Policy abstraction for whole-body control inference.
 ///
 /// Implementors convert a normalized [`Observation`] into
@@ -51,6 +129,9 @@ pub trait WbcPolicy: Send + Sync {
     /// Called at episode boundaries or when switching robots. The default
     /// implementation is a no-op for stateless policies.
     fn reset(&self) {}
+
+    /// Returns the public command kinds the policy accepts.
+    fn capabilities(&self) -> PolicyCapabilities;
 
     /// Returns the control frequency required by the policy runtime.
     fn control_frequency_hz(&self) -> u32;
@@ -323,6 +404,10 @@ mod tests {
             })
         }
 
+        fn capabilities(&self) -> PolicyCapabilities {
+            PolicyCapabilities::new(vec![WbcCommandKind::MotionTokens])
+        }
+
         fn control_frequency_hz(&self) -> u32 {
             50
         }
@@ -374,6 +459,32 @@ mod tests {
 
         assert_eq!(observation.joint_positions.len(), 2);
         assert!(matches!(observation.command, WbcCommand::Velocity(_)));
+    }
+
+    #[test]
+    fn policy_capabilities_track_public_commands() {
+        let capabilities = PolicyCapabilities::new(vec![
+            WbcCommandKind::Velocity,
+            WbcCommandKind::KinematicPose,
+            WbcCommandKind::Velocity,
+        ]);
+
+        assert_eq!(
+            capabilities.supported_commands,
+            vec![WbcCommandKind::Velocity, WbcCommandKind::KinematicPose]
+        );
+        assert!(capabilities.supports(WbcCommandKind::Velocity));
+        assert!(!capabilities.supports(WbcCommandKind::MotionTokens));
+    }
+
+    #[test]
+    fn public_command_kind_rejects_internal_end_effector_pose_variant() {
+        let command = WbcCommand::EndEffectorPoses(vec![SE3 {
+            translation: [0.0, 0.0, 0.0],
+            rotation_xyzw: [0.0, 0.0, 0.0, 1.0],
+        }]);
+
+        assert!(WbcCommandKind::try_from(&command).is_err());
     }
 
     #[test]

--- a/crates/robowbc-ort/src/bfm_zero.rs
+++ b/crates/robowbc-ort/src/bfm_zero.rs
@@ -14,8 +14,8 @@
 
 use crate::{OrtBackend, OrtConfig};
 use robowbc_core::{
-    JointPositionTargets, Observation, Result as CoreResult, RobotConfig, Twist, WbcCommand,
-    WbcError,
+    JointPositionTargets, Observation, PolicyCapabilities, Result as CoreResult, RobotConfig,
+    Twist, WbcCommand, WbcCommandKind, WbcError,
 };
 use robowbc_registry::{RegistryPolicy, WbcRegistration};
 use serde::{Deserialize, Serialize};
@@ -474,6 +474,10 @@ impl robowbc_core::WbcPolicy for BfmZeroPolicy {
 
     fn control_frequency_hz(&self) -> u32 {
         self.control_frequency_hz
+    }
+
+    fn capabilities(&self) -> PolicyCapabilities {
+        PolicyCapabilities::new(vec![WbcCommandKind::Velocity])
     }
 
     fn supported_robots(&self) -> &[RobotConfig] {

--- a/crates/robowbc-ort/src/decoupled.rs
+++ b/crates/robowbc-ort/src/decoupled.rs
@@ -12,8 +12,8 @@
 
 use crate::{OrtBackend, OrtConfig};
 use robowbc_core::{
-    JointPositionTargets, Observation, Result as CoreResult, RobotConfig, Twist, WbcCommand,
-    WbcError,
+    JointPositionTargets, Observation, PolicyCapabilities, Result as CoreResult, RobotConfig,
+    Twist, WbcCommand, WbcCommandKind, WbcError,
 };
 use robowbc_registry::{RegistryPolicy, WbcRegistration};
 use serde::{Deserialize, Serialize};
@@ -361,6 +361,10 @@ impl robowbc_core::WbcPolicy for DecoupledWbcPolicy {
 
     fn control_frequency_hz(&self) -> u32 {
         self.control_frequency_hz
+    }
+
+    fn capabilities(&self) -> PolicyCapabilities {
+        PolicyCapabilities::new(vec![WbcCommandKind::Velocity])
     }
 
     fn reset(&self) {

--- a/crates/robowbc-ort/src/hover.rs
+++ b/crates/robowbc-ort/src/hover.rs
@@ -29,8 +29,8 @@
 
 use crate::{OrtBackend, OrtConfig};
 use robowbc_core::{
-    BodyPose, JointPositionTargets, Observation, Result as CoreResult, RobotConfig, Twist,
-    WbcCommand, WbcError,
+    BodyPose, JointPositionTargets, Observation, PolicyCapabilities, Result as CoreResult,
+    RobotConfig, Twist, WbcCommand, WbcCommandKind, WbcError,
 };
 use robowbc_registry::{RegistryPolicy, WbcRegistration};
 use serde::{Deserialize, Serialize};
@@ -244,6 +244,13 @@ impl robowbc_core::WbcPolicy for HoverPolicy {
 
     fn control_frequency_hz(&self) -> u32 {
         self.control_frequency_hz
+    }
+
+    fn capabilities(&self) -> PolicyCapabilities {
+        PolicyCapabilities::new(vec![
+            WbcCommandKind::Velocity,
+            WbcCommandKind::KinematicPose,
+        ])
     }
 
     fn supported_robots(&self) -> &[RobotConfig] {

--- a/crates/robowbc-ort/src/lib.rs
+++ b/crates/robowbc-ort/src/lib.rs
@@ -39,7 +39,8 @@ use ort::session::builder::GraphOptimizationLevel;
 use ort::session::Session;
 use ort::value::Tensor;
 use robowbc_core::{
-    BasePose, JointPositionTargets, Observation, Result as CoreResult, RobotConfig, WbcCommand,
+    BasePose, JointPositionTargets, Observation, PolicyCapabilities, Result as CoreResult,
+    RobotConfig, WbcCommand, WbcCommandKind,
 };
 use robowbc_registry::{RegistryPolicy, WbcRegistration};
 use serde::{Deserialize, Serialize};
@@ -2730,6 +2731,10 @@ impl robowbc_core::WbcPolicy for GearSonicPolicy {
 
     fn reset(&self) {
         let _ = Self::reset(self);
+    }
+
+    fn capabilities(&self) -> PolicyCapabilities {
+        PolicyCapabilities::new(vec![WbcCommandKind::Velocity, WbcCommandKind::MotionTokens])
     }
 
     fn control_frequency_hz(&self) -> u32 {

--- a/crates/robowbc-ort/src/wbc_agile.rs
+++ b/crates/robowbc-ort/src/wbc_agile.rs
@@ -12,8 +12,8 @@
 
 use crate::{OrtBackend, OrtConfig, OrtTensorInput, OrtTensorOutput};
 use robowbc_core::{
-    JointPositionTargets, Observation, Result as CoreResult, RobotConfig, Twist, WbcCommand,
-    WbcError,
+    JointPositionTargets, Observation, PolicyCapabilities, Result as CoreResult, RobotConfig,
+    Twist, WbcCommand, WbcCommandKind, WbcError,
 };
 use robowbc_registry::{RegistryPolicy, WbcRegistration};
 use serde::{Deserialize, Serialize};
@@ -435,6 +435,10 @@ impl robowbc_core::WbcPolicy for WbcAgilePolicy {
 
     fn control_frequency_hz(&self) -> u32 {
         self.control_frequency_hz
+    }
+
+    fn capabilities(&self) -> PolicyCapabilities {
+        PolicyCapabilities::new(vec![WbcCommandKind::Velocity])
     }
 
     fn supported_robots(&self) -> &[RobotConfig] {

--- a/crates/robowbc-ort/src/wholebody_vla.rs
+++ b/crates/robowbc-ort/src/wholebody_vla.rs
@@ -44,8 +44,8 @@
 
 use crate::{OrtBackend, OrtConfig};
 use robowbc_core::{
-    BodyPose, JointPositionTargets, Observation, Result as CoreResult, RobotConfig, WbcCommand,
-    WbcError,
+    BodyPose, JointPositionTargets, Observation, PolicyCapabilities, Result as CoreResult,
+    RobotConfig, WbcCommand, WbcCommandKind, WbcError,
 };
 use robowbc_registry::{RegistryPolicy, WbcRegistration};
 use serde::{Deserialize, Serialize};
@@ -189,6 +189,10 @@ impl robowbc_core::WbcPolicy for WholeBodyVlaPolicy {
 
     fn control_frequency_hz(&self) -> u32 {
         self.control_frequency_hz
+    }
+
+    fn capabilities(&self) -> PolicyCapabilities {
+        PolicyCapabilities::new(vec![WbcCommandKind::KinematicPose])
     }
 
     fn supported_robots(&self) -> &[RobotConfig] {

--- a/crates/robowbc-py/Cargo.toml
+++ b/crates/robowbc-py/Cargo.toml
@@ -1,6 +1,7 @@
 # robowbc-py is intentionally excluded from the root workspace Cargo.toml to
-# avoid pyo3 feature-flag conflicts (extension-module vs auto-initialize).
-# Build this crate via: maturin develop
+# avoid pyo3 feature-flag conflicts. Build extension-module artifacts via
+# maturin, which sets PYO3_BUILD_EXTENSION_MODULE for wheel builds while still
+# allowing `cargo test` to link libpython locally.
 [workspace]
 
 [package]
@@ -13,10 +14,10 @@ description = "Python SDK for RoboWBC — PyO3 bindings exposing Registry, Obser
 
 [lib]
 name = "robowbc"
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-pyo3 = { version = "0.28", features = ["extension-module"] }
+pyo3 = { version = "0.28", features = ["auto-initialize"] }
 robowbc-comm = { path = "../robowbc-comm" }
 robowbc-core = { path = "../robowbc-core" }
 robowbc-ort = { path = "../robowbc-ort" }

--- a/crates/robowbc-py/examples/lerobot_adapter.py
+++ b/crates/robowbc-py/examples/lerobot_adapter.py
@@ -22,7 +22,7 @@ Interface mapping
 | ``observation.imu[:3]``             | ``gravity_vector``                       |
 | ``observation.imu[3:6]``            | ``angular_velocity``                     |
 +-------------------------------------+------------------------------------------+
-| ``observation.task_cmd``            | ``command_data`` (``command_type="velocity"``) |
+| ``observation.task_cmd``            | ``VelocityCommand``                     |
 +-------------------------------------+------------------------------------------+
 | ``action_dict["action"]``           | ``JointPositionTargets.positions``       |
 +-------------------------------------+------------------------------------------+
@@ -100,10 +100,35 @@ class RoboWBCController:
 
     def __init__(self, config_path: str) -> None:
         self._policy = robowbc.load_from_config(config_path)
+        self._capabilities = set(self._policy.capabilities().supported_commands)
+        if "velocity" not in self._capabilities:
+            supported = ", ".join(sorted(self._capabilities)) or "<none>"
+            raise RuntimeError(
+                "RoboWBCController requires a policy that supports the "
+                f"'velocity' command, got supported_commands=[{supported}]"
+            )
 
     # ------------------------------------------------------------------
     # LeRobot locomotion controller interface
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _velocity_command(command: Any) -> Any:
+        """Normalize LeRobot task commands into RoboWBC's 6D velocity surface."""
+        cmd_list = [float(value) for value in command]
+        if len(cmd_list) == 3:
+            return robowbc.VelocityCommand(
+                linear=[cmd_list[0], cmd_list[1], 0.0],
+                angular=[0.0, 0.0, cmd_list[2]],
+            )
+        if len(cmd_list) == 6:
+            return robowbc.VelocityCommand(
+                linear=cmd_list[:3],
+                angular=cmd_list[3:],
+            )
+        raise ValueError(
+            f"observation.task_cmd must have 3 or 6 elements, got {len(cmd_list)}"
+        )
 
     def step(self, obs_dict: dict[str, Any]) -> dict[str, list[float]]:
         """Run one inference step and return joint position targets.
@@ -131,7 +156,7 @@ class RoboWBCController:
             radians, matching the order in the loaded robot config.
         """
         imu = obs_dict["observation.imu"]
-        cmd = obs_dict["observation.task_cmd"]
+        command = self._velocity_command(obs_dict["observation.task_cmd"])
 
         # Gravity vector: projected_gravity is imu[:3].
         gravity = [float(imu[0]), float(imu[1]), float(imu[2])]
@@ -142,25 +167,12 @@ class RoboWBCController:
             float(imu[5]) if len(imu) > 5 else 0.0,
         ]
 
-        # Velocity command: expand [vx, vy, omega] → [vx, vy, vz, wx, wy, wz].
-        cmd_list = [float(v) for v in cmd]
-        if len(cmd_list) == 3:
-            # LeRobot convention: [forward, lateral, yaw_rate]
-            cmd_6 = [cmd_list[0], cmd_list[1], 0.0, 0.0, 0.0, cmd_list[2]]
-        elif len(cmd_list) == 6:
-            cmd_6 = cmd_list
-        else:
-            raise ValueError(
-                f"observation.task_cmd must have 3 or 6 elements, got {len(cmd_list)}"
-            )
-
         obs = robowbc.Observation(
             joint_positions=[float(v) for v in obs_dict["observation.state"]],
             joint_velocities=[float(v) for v in obs_dict["observation.velocity"]],
             gravity_vector=(gravity[0], gravity[1], gravity[2]),
             angular_velocity=(angular_velocity[0], angular_velocity[1], angular_velocity[2]),
-            command_type="velocity",
-            command_data=cmd_6,
+            command=command,
         )
         targets = self._policy.predict(obs)
         return {"action": targets.positions}

--- a/crates/robowbc-py/examples/manipulation_adapter.py
+++ b/crates/robowbc-py/examples/manipulation_adapter.py
@@ -1,0 +1,199 @@
+"""robowbc as a named-link manipulation backend.
+
+This adapter demonstrates the public embedded manipulation seam for RoboWBC:
+
+    controller.step(obs_dict) -> {"action": joint_targets}
+
+`obs_dict` keeps the same proprioception keys used by the locomotion adapter
+and adds one canonical manipulation payload:
+
+    {
+        "observation.state": [...],
+        "observation.velocity": [...],
+        "observation.imu": [gx, gy, gz, wx, wy, wz],
+        "links": [
+            {
+                "name": "left_wrist",
+                "translation": [x, y, z],
+                "rotation_xyzw": [qx, qy, qz, qw],
+            },
+            ...
+        ],
+    }
+
+The adapter validates the link-pose payload eagerly, checks that the selected
+policy supports `kinematic_pose`, constructs a `KinematicPoseCommand`, and
+returns the same `{"action": ...}` seam used by the locomotion example.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any
+
+try:
+    import robowbc
+except ImportError:
+    print("robowbc is not installed. Run: maturin develop", file=sys.stderr)
+    sys.exit(1)
+
+
+def _imu_components(imu: Any) -> tuple[list[float], list[float]]:
+    values = [float(value) for value in imu]
+    if len(values) < 3:
+        raise ValueError("observation.imu must provide at least 3 gravity values")
+    gravity = values[:3]
+    angular_velocity = [
+        values[3] if len(values) > 3 else 0.0,
+        values[4] if len(values) > 4 else 0.0,
+        values[5] if len(values) > 5 else 0.0,
+    ]
+    return gravity, angular_velocity
+
+
+class RoboWBCManipulationController:
+    """Dispatch named-link manipulation commands to robowbc."""
+
+    def __init__(self, config_path: str) -> None:
+        self._policy = robowbc.load_from_config(config_path)
+        self._capabilities = set(self._policy.capabilities().supported_commands)
+        if "kinematic_pose" not in self._capabilities:
+            supported = ", ".join(sorted(self._capabilities)) or "<none>"
+            raise RuntimeError(
+                "RoboWBCManipulationController requires a policy that supports "
+                f"'kinematic_pose', got supported_commands=[{supported}]"
+            )
+
+    @staticmethod
+    def _vector(payload: Any, field_name: str, expected_len: int) -> list[float]:
+        values = [float(value) for value in payload]
+        if len(values) != expected_len:
+            raise ValueError(
+                f"{field_name} must contain exactly {expected_len} floats, got {len(values)}"
+            )
+        return values
+
+    @classmethod
+    def _link_pose(cls, raw_link: Any, index: int) -> Any:
+        if not isinstance(raw_link, dict):
+            raise ValueError(f"links[{index}] must be a dict")
+
+        name = raw_link.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError(f"links[{index}].name must be a non-empty string")
+
+        translation = cls._vector(
+            raw_link.get("translation", []),
+            f"links[{index}].translation",
+            3,
+        )
+        rotation_xyzw = cls._vector(
+            raw_link.get("rotation_xyzw", []),
+            f"links[{index}].rotation_xyzw",
+            4,
+        )
+        return robowbc.LinkPose(
+            name=name,
+            translation=translation,
+            rotation_xyzw=rotation_xyzw,
+        )
+
+    @classmethod
+    def _kinematic_pose_command(cls, obs_dict: dict[str, Any]) -> Any:
+        raw_links = obs_dict.get("links")
+        if not isinstance(raw_links, list) or not raw_links:
+            raise ValueError("obs_dict['links'] must be a non-empty list of link pose dicts")
+        links = [cls._link_pose(raw_link, index) for index, raw_link in enumerate(raw_links)]
+        return robowbc.KinematicPoseCommand(links)
+
+    def step(self, obs_dict: dict[str, Any]) -> dict[str, list[float]]:
+        gravity, angular_velocity = _imu_components(obs_dict["observation.imu"])
+        command = self._kinematic_pose_command(obs_dict)
+        observation = robowbc.Observation(
+            joint_positions=[float(value) for value in obs_dict["observation.state"]],
+            joint_velocities=[float(value) for value in obs_dict["observation.velocity"]],
+            gravity_vector=gravity,
+            angular_velocity=angular_velocity,
+            command=command,
+        )
+        targets = self._policy.predict(observation)
+        return {"action": targets.positions}
+
+    def reset(self) -> None:
+        """Keep parity with locomotion-style controller seams."""
+
+    def control_frequency_hz(self) -> int:
+        return self._policy.control_frequency_hz()
+
+    def __repr__(self) -> str:
+        return (
+            "RoboWBCManipulationController("
+            f"control_frequency_hz={self.control_frequency_hz()})"
+        )
+
+
+def _synthetic_obs(n_joints: int) -> dict[str, Any]:
+    return {
+        "observation.state": [0.0] * n_joints,
+        "observation.velocity": [0.0] * n_joints,
+        "observation.imu": [0.0, 0.0, -1.0, 0.0, 0.0, 0.0],
+        "links": [
+            {
+                "name": "left_wrist",
+                "translation": [0.35, 0.20, 0.95],
+                "rotation_xyzw": [0.0, 0.0, 0.0, 1.0],
+            },
+            {
+                "name": "right_wrist",
+                "translation": [0.35, -0.20, 0.95],
+                "rotation_xyzw": [0.0, 0.0, 0.0, 1.0],
+            },
+        ],
+    }
+
+
+def run(config_path: str, n_joints: int, steps: int) -> int:
+    print(f"Loading manipulation policy from {config_path!r} ...")
+    try:
+        controller = RoboWBCManipulationController(config_path)
+    except RuntimeError as exc:
+        print(f"Could not load policy: {exc}", file=sys.stderr)
+        print(
+            "Tip: WholeBodyVLA requires a compatible local/private ONNX export at "
+            "models/wholebody_vla/wholebody_vla_x2.onnx.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Loaded: {controller!r}")
+    for step in range(steps):
+        action = controller.step(_synthetic_obs(n_joints))
+        preview = ", ".join(f"{value:.4f}" for value in action["action"][:3])
+        print(f"step {step:02d}: targets[0:3] = [{preview}]")
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Demonstrate robowbc's named-link manipulation adapter."
+    )
+    parser.add_argument(
+        "--config",
+        default="configs/wholebody_vla_x2.toml",
+        help="Path to a robowbc TOML config file (default: configs/wholebody_vla_x2.toml)",
+    )
+    parser.add_argument(
+        "--joints",
+        type=int,
+        default=23,
+        help="Number of joints for the synthetic observation (default: 23 for X2)",
+    )
+    parser.add_argument(
+        "--steps",
+        type=int,
+        default=1,
+        help="Number of inference steps to run (default: 1)",
+    )
+    args = parser.parse_args()
+    raise SystemExit(run(args.config, args.joints, args.steps))

--- a/crates/robowbc-py/src/lib.rs
+++ b/crates/robowbc-py/src/lib.rs
@@ -1,7 +1,7 @@
 //! Python SDK for `RoboWBC`.
 //!
-//! Exposes [`Registry`], [`Observation`], [`JointPositionTargets`], and
-//! [`Policy`] as Python classes, giving Python users a first-class API for
+//! Exposes `Registry`, `Observation`, `JointPositionTargets`, and `Policy`
+//! as Python classes, giving Python users a first-class API for
 //! loading and running whole-body control policies without writing Rust.
 //!
 //! # Usage
@@ -53,15 +53,84 @@
 use pyo3::exceptions::{PyRuntimeError, PyValueError};
 #[allow(clippy::wildcard_imports)]
 use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyDict};
+use pyo3::types::{PyBytes, PyDict, PyList};
 use robowbc_comm::{run_control_tick, CommConfig};
-use robowbc_core::{Observation, RobotConfig, Twist, WbcCommand, WbcPolicy};
+use robowbc_core::{
+    BodyPose as CoreBodyPose, LinkPose as CoreLinkPose, Observation, PolicyCapabilities,
+    RobotConfig, Twist, WbcCommand, WbcCommandKind, WbcPolicy, SE3,
+};
 use robowbc_registry::WbcRegistry;
 use robowbc_sim::{MujocoConfig, MujocoTransport};
 use serde::Deserialize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Instant;
+
+const RELATIVE_CONFIG_PATH_KEYS: &[&str] = &["config_path", "model_path", "context_path"];
+
+fn resolve_config_path(path: &Path, base_dir: &Path) -> PathBuf {
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+
+    for candidate_base in base_dir.ancestors() {
+        let candidate = candidate_base.join(path);
+        if candidate.exists() {
+            return candidate;
+        }
+    }
+
+    base_dir.join(path)
+}
+
+fn resolve_relative_config_paths(value: &mut toml::Value, base_dir: &Path) {
+    match value {
+        toml::Value::Table(table) => {
+            for (key, entry) in table.iter_mut() {
+                if RELATIVE_CONFIG_PATH_KEYS.contains(&key.as_str()) {
+                    if let Some(path_str) = entry.as_str() {
+                        let path = Path::new(path_str);
+                        if path.is_relative() {
+                            *entry = toml::Value::String(
+                                resolve_config_path(path, base_dir)
+                                    .to_string_lossy()
+                                    .into_owned(),
+                            );
+                        }
+                    }
+                } else {
+                    resolve_relative_config_paths(entry, base_dir);
+                }
+            }
+        }
+        toml::Value::Array(values) => {
+            for entry in values {
+                resolve_relative_config_paths(entry, base_dir);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn load_config_document(config_path: &Path) -> PyResult<toml::Value> {
+    let content = std::fs::read_to_string(config_path).map_err(|error| {
+        PyRuntimeError::new_err(format!(
+            "cannot read config file {}: {error}",
+            config_path.display()
+        ))
+    })?;
+    let mut parsed: toml::Value = content.parse().map_err(|error| {
+        PyRuntimeError::new_err(format!(
+            "invalid TOML in {}: {error}",
+            config_path.display()
+        ))
+    })?;
+    let absolute_config_path =
+        std::fs::canonicalize(config_path).unwrap_or_else(|_| config_path.to_path_buf());
+    let base_dir = absolute_config_path.parent().unwrap_or(Path::new("."));
+    resolve_relative_config_paths(&mut parsed, base_dir);
+    Ok(parsed)
+}
 
 /// Load a [`Policy`] from a robowbc TOML config file.
 ///
@@ -93,31 +162,417 @@ use std::time::Instant;
 /// ```
 #[pyfunction]
 fn load_from_config(config_path: &str) -> PyResult<PyPolicy> {
-    let content = std::fs::read_to_string(config_path).map_err(|e| {
-        PyRuntimeError::new_err(format!("cannot read config file {config_path:?}: {e}"))
-    })?;
-    let policy = WbcRegistry::build_from_toml_str(&content)
-        .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
+    let parsed = load_config_document(Path::new(config_path))?;
+    build_policy_from_document(&parsed, None)
+}
+
+#[derive(Debug, Clone)]
+enum PythonCommand {
+    Velocity(Twist),
+    MotionTokens(Vec<f32>),
+    JointTargets(Vec<f32>),
+    KinematicPose(CoreBodyPose),
+}
+
+impl PythonCommand {
+    fn from_legacy(command_type: &str, command_data: &[f32]) -> PyResult<Self> {
+        match command_type {
+            "velocity" => {
+                if command_data.len() < 6 {
+                    return Err(PyValueError::new_err(
+                        "velocity command_data must have at least 6 elements [vx, vy, vz, wx, wy, wz]",
+                    ));
+                }
+                Ok(Self::Velocity(Twist {
+                    linear: [command_data[0], command_data[1], command_data[2]],
+                    angular: [command_data[3], command_data[4], command_data[5]],
+                }))
+            }
+            "motion_tokens" => Ok(Self::MotionTokens(command_data.to_vec())),
+            "joint_targets" => Ok(Self::JointTargets(command_data.to_vec())),
+            "kinematic_pose" => Err(PyValueError::new_err(
+                "kinematic_pose must be provided through the structured command=KinematicPoseCommand(...) surface",
+            )),
+            other => Err(PyValueError::new_err(format!(
+                "unknown command_type {other:?}; expected \"velocity\", \"motion_tokens\", or \"joint_targets\""
+            ))),
+        }
+    }
+
+    fn from_python_command(command: &Bound<'_, PyAny>) -> PyResult<Self> {
+        if let Ok(command) = command.extract::<PyRef<'_, PyVelocityCommand>>() {
+            return Ok(Self::Velocity(command.to_twist()));
+        }
+        if let Ok(command) = command.extract::<PyRef<'_, PyMotionTokensCommand>>() {
+            return Ok(Self::MotionTokens(command.tokens.clone()));
+        }
+        if let Ok(command) = command.extract::<PyRef<'_, PyJointTargetsCommand>>() {
+            return Ok(Self::JointTargets(command.targets.clone()));
+        }
+        if let Ok(command) = command.extract::<PyRef<'_, PyKinematicPoseCommand>>() {
+            return Ok(Self::KinematicPose(command.to_body_pose()));
+        }
+
+        Err(PyValueError::new_err(
+            "command must be a VelocityCommand, MotionTokensCommand, JointTargetsCommand, or KinematicPoseCommand",
+        ))
+    }
+
+    fn command_type(&self) -> &'static str {
+        match self {
+            Self::Velocity(_) => "velocity",
+            Self::MotionTokens(_) => "motion_tokens",
+            Self::JointTargets(_) => "joint_targets",
+            Self::KinematicPose(_) => "kinematic_pose",
+        }
+    }
+
+    fn command_data(&self) -> Option<Vec<f32>> {
+        match self {
+            Self::Velocity(twist) => {
+                let mut data = twist.linear.to_vec();
+                data.extend_from_slice(&twist.angular);
+                Some(data)
+            }
+            Self::MotionTokens(tokens) | Self::JointTargets(tokens) => Some(tokens.clone()),
+            Self::KinematicPose(_) => None,
+        }
+    }
+
+    fn to_python_object(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        match self {
+            Self::Velocity(twist) => {
+                Py::new(py, PyVelocityCommand::from_twist(*twist)).map(|obj| obj.into_any())
+            }
+            Self::MotionTokens(tokens) => Py::new(
+                py,
+                PyMotionTokensCommand {
+                    tokens: tokens.clone(),
+                },
+            )
+            .map(|obj| obj.into_any()),
+            Self::JointTargets(targets) => Py::new(
+                py,
+                PyJointTargetsCommand {
+                    targets: targets.clone(),
+                },
+            )
+            .map(|obj| obj.into_any()),
+            Self::KinematicPose(body_pose) => {
+                Py::new(py, PyKinematicPoseCommand::from_body_pose(body_pose))
+                    .map(|obj| obj.into_any())
+            }
+        }
+    }
+
+    fn to_wbc_command(&self) -> WbcCommand {
+        match self {
+            Self::Velocity(twist) => WbcCommand::Velocity(*twist),
+            Self::MotionTokens(tokens) => WbcCommand::MotionTokens(tokens.clone()),
+            Self::JointTargets(targets) => WbcCommand::JointTargets(targets.clone()),
+            Self::KinematicPose(body_pose) => WbcCommand::KinematicPose(body_pose.clone()),
+        }
+    }
+}
+
+fn build_policy_from_document(
+    parsed: &toml::Value,
+    requested_name: Option<&str>,
+) -> PyResult<PyPolicy> {
+    let policy_section = parsed
+        .get("policy")
+        .ok_or_else(|| PyRuntimeError::new_err("missing [policy] table"))?;
+    let policy_name = match requested_name {
+        Some(name) => name.to_owned(),
+        None => policy_section
+            .get("name")
+            .and_then(toml::Value::as_str)
+            .ok_or_else(|| PyRuntimeError::new_err("missing [policy].name string field"))?
+            .to_owned(),
+    };
+    let mut policy_config = policy_section
+        .get("config")
+        .cloned()
+        .unwrap_or_else(|| toml::Value::Table(toml::map::Map::new()));
+
+    if let Some(robot) = load_robot_from_document(parsed)? {
+        policy_config =
+            insert_robot_into_policy(policy_config, &robot).map_err(PyRuntimeError::new_err)?;
+    }
+
+    let policy = WbcRegistry::build(&policy_name, &policy_config)
+        .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
     Ok(PyPolicy {
         inner: Arc::from(policy),
     })
+}
+
+fn load_robot_from_document(parsed: &toml::Value) -> PyResult<Option<RobotConfig>> {
+    let Some(config_path) = parsed
+        .get("robot")
+        .and_then(|robot| robot.get("config_path"))
+        .and_then(toml::Value::as_str)
+    else {
+        return Ok(None);
+    };
+
+    let robot = RobotConfig::from_toml_file(Path::new(config_path)).map_err(|error| {
+        PyRuntimeError::new_err(format!("failed to load robot config: {error}"))
+    })?;
+    Ok(Some(robot))
+}
+
+#[pyclass(name = "PolicyCapabilities", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyPolicyCapabilities {
+    #[pyo3(get)]
+    supported_commands: Vec<String>,
+}
+
+impl PyPolicyCapabilities {
+    fn from_core(capabilities: &PolicyCapabilities) -> Self {
+        Self {
+            supported_commands: capabilities
+                .supported_commands
+                .iter()
+                .map(|kind| kind.as_str().to_owned())
+                .collect(),
+        }
+    }
+}
+
+#[pymethods]
+impl PyPolicyCapabilities {
+    fn __repr__(&self) -> String {
+        format!(
+            "PolicyCapabilities(supported_commands={:?})",
+            self.supported_commands
+        )
+    }
+}
+
+#[pyclass(name = "VelocityCommand", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyVelocityCommand {
+    #[pyo3(get, set)]
+    linear: [f32; 3],
+    #[pyo3(get, set)]
+    angular: [f32; 3],
+}
+
+impl PyVelocityCommand {
+    fn from_twist(twist: Twist) -> Self {
+        Self {
+            linear: twist.linear,
+            angular: twist.angular,
+        }
+    }
+
+    fn to_twist(&self) -> Twist {
+        Twist {
+            linear: self.linear,
+            angular: self.angular,
+        }
+    }
+}
+
+#[pymethods]
+impl PyVelocityCommand {
+    #[new]
+    #[pyo3(signature = (linear, angular=None))]
+    fn new(linear: [f32; 3], angular: Option<[f32; 3]>) -> Self {
+        Self {
+            linear,
+            angular: angular.unwrap_or([0.0, 0.0, 0.0]),
+        }
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "VelocityCommand(linear={:?}, angular={:?})",
+            self.linear, self.angular
+        )
+    }
+}
+
+#[pyclass(name = "MotionTokensCommand", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyMotionTokensCommand {
+    #[pyo3(get, set)]
+    tokens: Vec<f32>,
+}
+
+#[pymethods]
+impl PyMotionTokensCommand {
+    #[new]
+    fn new(tokens: Vec<f32>) -> Self {
+        Self { tokens }
+    }
+
+    fn __repr__(&self) -> String {
+        format!("MotionTokensCommand(tokens={})", self.tokens.len())
+    }
+}
+
+#[pyclass(name = "JointTargetsCommand", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyJointTargetsCommand {
+    #[pyo3(get, set)]
+    targets: Vec<f32>,
+}
+
+#[pymethods]
+impl PyJointTargetsCommand {
+    #[new]
+    fn new(targets: Vec<f32>) -> Self {
+        Self { targets }
+    }
+
+    fn __repr__(&self) -> String {
+        format!("JointTargetsCommand(targets={})", self.targets.len())
+    }
+}
+
+#[pyclass(name = "LinkPose", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyLinkPose {
+    #[pyo3(get, set)]
+    name: String,
+    #[pyo3(get, set)]
+    translation: [f32; 3],
+    #[pyo3(get, set)]
+    rotation_xyzw: [f32; 4],
+}
+
+impl PyLinkPose {
+    fn to_core(&self) -> CoreLinkPose {
+        CoreLinkPose {
+            link_name: self.name.clone(),
+            pose: SE3 {
+                translation: self.translation,
+                rotation_xyzw: self.rotation_xyzw,
+            },
+        }
+    }
+
+    fn from_core(link: &CoreLinkPose) -> Self {
+        Self {
+            name: link.link_name.clone(),
+            translation: link.pose.translation,
+            rotation_xyzw: link.pose.rotation_xyzw,
+        }
+    }
+}
+
+#[pymethods]
+impl PyLinkPose {
+    #[new]
+    fn new(name: String, translation: [f32; 3], rotation_xyzw: [f32; 4]) -> PyResult<Self> {
+        if name.trim().is_empty() {
+            return Err(PyValueError::new_err("LinkPose.name must not be empty"));
+        }
+        Ok(Self {
+            name,
+            translation,
+            rotation_xyzw,
+        })
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "LinkPose(name={:?}, translation={:?}, rotation_xyzw={:?})",
+            self.name, self.translation, self.rotation_xyzw
+        )
+    }
+}
+
+fn extract_python_link_pose_objects(links: &Bound<'_, PyAny>) -> PyResult<Vec<PyLinkPose>> {
+    let list = links.cast::<PyList>().map_err(|_| {
+        PyValueError::new_err("KinematicPoseCommand.links must be a list of LinkPose objects")
+    })?;
+    if list.is_empty() {
+        return Err(PyValueError::new_err(
+            "KinematicPoseCommand.links must contain at least one LinkPose",
+        ));
+    }
+
+    list.iter()
+        .map(|item| {
+            item.extract::<PyRef<'_, PyLinkPose>>()
+                .map(|link| link.clone())
+                .map_err(|_| {
+                    PyValueError::new_err(
+                        "KinematicPoseCommand.links must contain only LinkPose objects",
+                    )
+                })
+        })
+        .collect()
+}
+
+#[pyclass(name = "KinematicPoseCommand", skip_from_py_object)]
+#[derive(Clone)]
+pub struct PyKinematicPoseCommand {
+    links: Vec<PyLinkPose>,
+}
+
+impl PyKinematicPoseCommand {
+    fn from_body_pose(body_pose: &CoreBodyPose) -> Self {
+        Self {
+            links: body_pose.links.iter().map(PyLinkPose::from_core).collect(),
+        }
+    }
+
+    fn to_body_pose(&self) -> CoreBodyPose {
+        CoreBodyPose {
+            links: self.links.iter().map(PyLinkPose::to_core).collect(),
+        }
+    }
+}
+
+#[pymethods]
+impl PyKinematicPoseCommand {
+    #[new]
+    fn new(links: &Bound<'_, PyAny>) -> PyResult<Self> {
+        Ok(Self {
+            links: extract_python_link_pose_objects(links)?,
+        })
+    }
+
+    #[getter]
+    fn links(&self, py: Python<'_>) -> PyResult<Vec<Py<PyLinkPose>>> {
+        self.links
+            .iter()
+            .cloned()
+            .map(|link| Py::new(py, link))
+            .collect()
+    }
+
+    #[setter]
+    fn set_links(&mut self, links: &Bound<'_, PyAny>) -> PyResult<()> {
+        self.links = extract_python_link_pose_objects(links)?;
+        Ok(())
+    }
+
+    fn __repr__(&self) -> String {
+        format!("KinematicPoseCommand(links={})", self.links.len())
+    }
 }
 
 /// Standardized sensor input for a WBC policy.
 ///
 /// Parameters
 /// ----------
-/// `joint_positions` : list[float]
+/// `joint_positions` : `list[float]`
 ///     Current joint positions in radians, one per actuated joint.
-/// `joint_velocities` : list[float]
+/// `joint_velocities` : `list[float]`
 ///     Current joint velocities in rad/s, same length as `joint_positions`.
-/// `gravity_vector` : tuple[float, float, float]
+/// `gravity_vector` : `tuple[float, float, float]`
 ///     Gravity direction in the robot body frame (typically `[0, 0, -1]`).
-/// `angular_velocity` : tuple[float, float, float], optional
+/// `angular_velocity` : `tuple[float, float, float]`, optional
 ///     Body-frame angular velocity from the IMU gyro in rad/s. Defaults to zeros.
 /// `command_type` : str
 ///     One of `"velocity"`, `"motion_tokens"`, or `"joint_targets"`.
-/// `command_data` : list[float]
+/// `command_data` : `list[float]`
 ///     Payload for the command type.  See module-level table for layouts.
 #[pyclass(name = "Observation", skip_from_py_object)]
 #[derive(Clone)]
@@ -134,83 +589,121 @@ pub struct PyObservation {
     /// Body-frame angular velocity from the IMU gyro in rad/s.
     #[pyo3(get, set)]
     pub angular_velocity: [f32; 3],
-    /// Command variant name.
-    #[pyo3(get, set)]
-    pub command_type: String,
-    /// Command payload floats.
-    #[pyo3(get, set)]
-    pub command_data: Vec<f32>,
+    /// Public command payload.
+    command: PythonCommand,
 }
 
 #[pymethods]
 impl PyObservation {
     #[new]
-    #[pyo3(signature = (joint_positions, joint_velocities, gravity_vector, command_type, command_data, angular_velocity=None))]
+    #[pyo3(signature = (joint_positions, joint_velocities, gravity_vector, command_type=None, command_data=None, angular_velocity=None, command=None))]
     fn new(
         joint_positions: Vec<f32>,
         joint_velocities: Vec<f32>,
         gravity_vector: [f32; 3],
-        command_type: String,
-        command_data: Vec<f32>,
+        command_type: Option<String>,
+        command_data: Option<Vec<f32>>,
         angular_velocity: Option<[f32; 3]>,
-    ) -> Self {
-        Self {
+        command: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<Self> {
+        let command = match (command, command_type, command_data) {
+            (Some(command), None, None) => PythonCommand::from_python_command(command)?,
+            (None, Some(command_type), Some(command_data)) => {
+                PythonCommand::from_legacy(&command_type, &command_data)?
+            }
+            (Some(_), Some(_), _) | (Some(_), _, Some(_)) => {
+                return Err(PyValueError::new_err(
+                    "Observation accepts either command=... or command_type plus command_data, not both",
+                ))
+            }
+            (None, Some(_), None) | (None, None, Some(_)) => {
+                return Err(PyValueError::new_err(
+                    "Observation requires both command_type and command_data when the structured command=... path is not used",
+                ))
+            }
+            (None, None, None) => {
+                return Err(PyValueError::new_err(
+                    "Observation requires either command=... or command_type plus command_data",
+                ))
+            }
+        };
+
+        Ok(Self {
             joint_positions,
             joint_velocities,
             gravity_vector,
             angular_velocity: angular_velocity.unwrap_or([0.0, 0.0, 0.0]),
-            command_type,
-            command_data,
-        }
+            command,
+        })
+    }
+
+    #[getter]
+    fn command_type(&self) -> String {
+        self.command.command_type().to_owned()
+    }
+
+    #[setter]
+    fn set_command_type(&mut self, command_type: String) -> PyResult<()> {
+        let command_data = self.command.command_data().ok_or_else(|| {
+            PyValueError::new_err(
+                "command_type cannot be reassigned for structured kinematic_pose commands; assign Observation.command instead",
+            )
+        })?;
+        self.command = PythonCommand::from_legacy(&command_type, &command_data)?;
+        Ok(())
+    }
+
+    #[getter]
+    fn command_data(&self) -> PyResult<Vec<f32>> {
+        self.command.command_data().ok_or_else(|| {
+            PyValueError::new_err(
+                "kinematic_pose does not expose flat command_data; use Observation.command",
+            )
+        })
+    }
+
+    #[setter]
+    fn set_command_data(&mut self, command_data: Vec<f32>) -> PyResult<()> {
+        let command_type = self.command.command_data().map(|_| self.command.command_type()).ok_or_else(
+            || {
+                PyValueError::new_err(
+                    "command_data cannot be reassigned for structured kinematic_pose commands; assign Observation.command instead",
+                )
+            },
+        )?;
+        self.command = PythonCommand::from_legacy(command_type, &command_data)?;
+        Ok(())
+    }
+
+    #[getter]
+    fn command(&self, py: Python<'_>) -> PyResult<Py<PyAny>> {
+        self.command.to_python_object(py)
+    }
+
+    #[setter]
+    fn set_command(&mut self, command: &Bound<'_, PyAny>) -> PyResult<()> {
+        self.command = PythonCommand::from_python_command(command)?;
+        Ok(())
     }
 
     fn __repr__(&self) -> String {
         format!(
             "Observation(joints={}, command_type={:?})",
             self.joint_positions.len(),
-            self.command_type
+            self.command.command_type()
         )
     }
 }
 
 /// Converts a [`PyObservation`] into the Rust [`Observation`] type.
 fn into_observation(obs: &PyObservation) -> PyResult<Observation> {
-    let command = match obs.command_type.as_str() {
-        "velocity" => {
-            if obs.command_data.len() < 6 {
-                return Err(PyValueError::new_err(
-                    "velocity command_data must have at least 6 elements [vx, vy, vz, wx, wy, wz]",
-                ));
-            }
-            WbcCommand::Velocity(Twist {
-                linear: [
-                    obs.command_data[0],
-                    obs.command_data[1],
-                    obs.command_data[2],
-                ],
-                angular: [
-                    obs.command_data[3],
-                    obs.command_data[4],
-                    obs.command_data[5],
-                ],
-            })
-        }
-        "motion_tokens" => WbcCommand::MotionTokens(obs.command_data.clone()),
-        "joint_targets" => WbcCommand::JointTargets(obs.command_data.clone()),
-        other => {
-            return Err(PyValueError::new_err(format!(
-                "unknown command_type {other:?}; expected \"velocity\", \"motion_tokens\", or \"joint_targets\""
-            )))
-        }
-    };
-
     Ok(Observation {
         joint_positions: obs.joint_positions.clone(),
         joint_velocities: obs.joint_velocities.clone(),
         gravity_vector: obs.gravity_vector,
         angular_velocity: obs.angular_velocity,
         base_pose: None,
-        command,
+        command: obs.command.to_wbc_command(),
         timestamp: Instant::now(),
     })
 }
@@ -316,6 +809,75 @@ impl SessionVelocityScheduleConfig {
     }
 }
 
+#[derive(Debug, Clone, Deserialize)]
+struct SessionKinematicPoseLinkConfig {
+    name: String,
+    translation: [f32; 3],
+    rotation_xyzw: [f32; 4],
+}
+
+#[derive(Debug, Clone, Deserialize)]
+struct SessionKinematicPoseConfig {
+    links: Vec<SessionKinematicPoseLinkConfig>,
+}
+
+impl SessionKinematicPoseConfig {
+    fn validate(&self) -> Result<(), String> {
+        if self.links.is_empty() {
+            return Err("runtime.kinematic_pose.links must contain at least one link".to_owned());
+        }
+
+        for (index, link) in self.links.iter().enumerate() {
+            if link.name.trim().is_empty() {
+                return Err(format!(
+                    "runtime.kinematic_pose.links[{index}].name must not be empty"
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
+    fn to_body_pose(&self) -> CoreBodyPose {
+        CoreBodyPose {
+            links: self
+                .links
+                .iter()
+                .map(|link| CoreLinkPose {
+                    link_name: link.name.clone(),
+                    pose: SE3 {
+                        translation: link.translation,
+                        rotation_xyzw: link.rotation_xyzw,
+                    },
+                })
+                .collect(),
+        }
+    }
+
+    fn from_body_pose(body_pose: &CoreBodyPose) -> Self {
+        Self {
+            links: body_pose
+                .links
+                .iter()
+                .map(|link| SessionKinematicPoseLinkConfig {
+                    name: link.link_name.clone(),
+                    translation: link.pose.translation,
+                    rotation_xyzw: link.pose.rotation_xyzw,
+                })
+                .collect(),
+        }
+    }
+}
+
+fn parse_runtime_kinematic_pose(value: &toml::Value) -> Result<CoreBodyPose, String> {
+    let config: SessionKinematicPoseConfig = value
+        .clone()
+        .try_into()
+        .map_err(|error| format!("invalid runtime.kinematic_pose payload: {error}"))?;
+    config.validate()?;
+    Ok(config.to_body_pose())
+}
+
 #[derive(Debug, Clone, Deserialize, Default)]
 struct SessionRuntimeConfig {
     #[serde(default)]
@@ -349,6 +911,7 @@ enum SessionCommandSpec {
     VelocitySchedule(SessionVelocityScheduleConfig),
     MotionTokens(Vec<f32>),
     JointTargets(Vec<f32>),
+    KinematicPose(CoreBodyPose),
 }
 
 impl SessionCommandSpec {
@@ -383,12 +946,6 @@ impl SessionCommandSpec {
             ));
         }
 
-        if runtime.kinematic_pose.is_some() {
-            return Err(
-                "runtime.kinematic_pose is not yet supported by robowbc.MujocoSession".to_owned(),
-            );
-        }
-
         if let Some(velocity) = runtime.velocity {
             return Ok(Self::Velocity(velocity));
         }
@@ -406,6 +963,12 @@ impl SessionCommandSpec {
                 );
             }
             return Ok(Self::MotionTokens(tokens.clone()));
+        }
+
+        if let Some(kinematic_pose) = &runtime.kinematic_pose {
+            return Ok(Self::KinematicPose(parse_runtime_kinematic_pose(
+                kinematic_pose,
+            )?));
         }
 
         if runtime.standing_placeholder_tracking || runtime.reference_motion_tracking {
@@ -447,6 +1010,9 @@ impl SessionCommandSpec {
             )),
             "motion_tokens" => Ok(Self::MotionTokens(command_data.to_vec())),
             "joint_targets" => Ok(Self::JointTargets(command_data.to_vec())),
+            "kinematic_pose" => Err(PyValueError::new_err(
+                "kinematic_pose cannot be expressed through command_type/command_data; use a structured kinematic_pose payload instead",
+            )),
             other => Err(PyValueError::new_err(format!(
                 "unknown command_type {other:?}; expected \"velocity\", \"velocity_schedule\", \"motion_tokens\", or \"joint_targets\""
             ))),
@@ -459,22 +1025,24 @@ impl SessionCommandSpec {
             Self::VelocitySchedule(_) => "velocity_schedule",
             Self::MotionTokens(_) => "motion_tokens",
             Self::JointTargets(_) => "joint_targets",
+            Self::KinematicPose(_) => "kinematic_pose",
         }
     }
 
-    fn command_data(&self) -> Vec<f32> {
+    fn command_data(&self) -> Option<Vec<f32>> {
         match self {
-            Self::Velocity([vx, vy, yaw_rate]) => vec![*vx, *vy, *yaw_rate],
-            Self::VelocitySchedule(schedule) => schedule.flatten(),
-            Self::MotionTokens(tokens) | Self::JointTargets(tokens) => tokens.clone(),
+            Self::Velocity([vx, vy, yaw_rate]) => Some(vec![*vx, *vy, *yaw_rate]),
+            Self::VelocitySchedule(schedule) => Some(schedule.flatten()),
+            Self::MotionTokens(tokens) | Self::JointTargets(tokens) => Some(tokens.clone()),
+            Self::KinematicPose(_) => None,
         }
     }
 
-    fn command_data_for_tick(&self, tick: usize, frequency_hz: u32) -> Vec<f32> {
+    fn command_data_for_tick(&self, tick: usize, frequency_hz: u32) -> Option<Vec<f32>> {
         match self {
             Self::VelocitySchedule(schedule) => {
                 let elapsed_secs = elapsed_secs_for_tick(tick, frequency_hz);
-                schedule.sample_velocity(elapsed_secs).to_vec()
+                Some(schedule.sample_velocity(elapsed_secs).to_vec())
             }
             _ => self.command_data(),
         }
@@ -496,6 +1064,7 @@ impl SessionCommandSpec {
             }
             Self::MotionTokens(tokens) => WbcCommand::MotionTokens(tokens.clone()),
             Self::JointTargets(targets) => WbcCommand::JointTargets(targets.clone()),
+            Self::KinematicPose(body_pose) => WbcCommand::KinematicPose(body_pose.clone()),
         }
     }
 }
@@ -523,10 +1092,86 @@ fn insert_robot_into_policy(
     Ok(policy_cfg)
 }
 
+fn parse_action_kinematic_pose(links: &Bound<'_, PyAny>) -> PyResult<CoreBodyPose> {
+    let list = links.cast::<PyList>().map_err(|_| {
+        PyValueError::new_err(
+            "action.kinematic_pose must be a list of link pose dicts with name, translation, and rotation_xyzw",
+        )
+    })?;
+    if list.is_empty() {
+        return Err(PyValueError::new_err(
+            "action.kinematic_pose must contain at least one link pose",
+        ));
+    }
+
+    let mut parsed_links = Vec::with_capacity(list.len());
+    for (index, item) in list.iter().enumerate() {
+        let dict = item.cast::<PyDict>().map_err(|_| {
+            PyValueError::new_err(format!(
+                "action.kinematic_pose[{index}] must be a dict with name, translation, and rotation_xyzw"
+            ))
+        })?;
+        let name = dict
+            .get_item("name")?
+            .ok_or_else(|| {
+                PyValueError::new_err(format!("action.kinematic_pose[{index}].name is required"))
+            })?
+            .extract::<String>()?;
+        if name.trim().is_empty() {
+            return Err(PyValueError::new_err(format!(
+                "action.kinematic_pose[{index}].name must not be empty"
+            )));
+        }
+        let translation = dict
+            .get_item("translation")?
+            .ok_or_else(|| {
+                PyValueError::new_err(format!(
+                    "action.kinematic_pose[{index}].translation is required"
+                ))
+            })?
+            .extract::<Vec<f32>>()?;
+        if translation.len() != 3 {
+            return Err(PyValueError::new_err(format!(
+                "action.kinematic_pose[{index}].translation must contain exactly 3 floats"
+            )));
+        }
+        let rotation_xyzw = dict
+            .get_item("rotation_xyzw")?
+            .ok_or_else(|| {
+                PyValueError::new_err(format!(
+                    "action.kinematic_pose[{index}].rotation_xyzw is required"
+                ))
+            })?
+            .extract::<Vec<f32>>()?;
+        if rotation_xyzw.len() != 4 {
+            return Err(PyValueError::new_err(format!(
+                "action.kinematic_pose[{index}].rotation_xyzw must contain exactly 4 floats"
+            )));
+        }
+
+        parsed_links.push(CoreLinkPose {
+            link_name: name,
+            pose: SE3 {
+                translation: [translation[0], translation[1], translation[2]],
+                rotation_xyzw: [
+                    rotation_xyzw[0],
+                    rotation_xyzw[1],
+                    rotation_xyzw[2],
+                    rotation_xyzw[3],
+                ],
+            },
+        });
+    }
+
+    Ok(CoreBodyPose {
+        links: parsed_links,
+    })
+}
+
 fn parse_action_command(action: &Bound<'_, PyAny>) -> PyResult<SessionCommandSpec> {
     let dict = action.cast::<PyDict>().map_err(|_| {
         PyValueError::new_err(
-            "action must be a dict containing command_type/command_data, velocity, motion_tokens, or joint_targets",
+            "action must be a dict containing command_type/command_data, velocity, motion_tokens, joint_targets, or kinematic_pose",
         )
     })?;
 
@@ -554,8 +1199,14 @@ fn parse_action_command(action: &Bound<'_, PyAny>) -> PyResult<SessionCommandSpe
         return SessionCommandSpec::from_command_type_and_data("joint_targets", &targets);
     }
 
+    if let Some(kinematic_pose) = dict.get_item("kinematic_pose")? {
+        return Ok(SessionCommandSpec::KinematicPose(
+            parse_action_kinematic_pose(&kinematic_pose)?,
+        ));
+    }
+
     Err(PyValueError::new_err(
-        "action must provide command_type/command_data, velocity, motion_tokens, or joint_targets",
+        "action must provide command_type/command_data, velocity, motion_tokens, joint_targets, or kinematic_pose",
     ))
 }
 
@@ -566,12 +1217,55 @@ fn command_dict(
     frequency_hz: u32,
 ) -> PyResult<Py<PyAny>> {
     let dict = PyDict::new(py);
-    dict.set_item("command_type", command.command_type())?;
-    dict.set_item(
-        "command_data",
-        command.command_data_for_tick(tick, frequency_hz),
-    )?;
+    match command {
+        SessionCommandSpec::KinematicPose(body_pose) => {
+            let links: Vec<Py<PyAny>> = SessionKinematicPoseConfig::from_body_pose(body_pose)
+                .links
+                .into_iter()
+                .map(|link| {
+                    let link_dict = PyDict::new(py);
+                    link_dict.set_item("name", link.name)?;
+                    link_dict.set_item("translation", link.translation.to_vec())?;
+                    link_dict.set_item("rotation_xyzw", link.rotation_xyzw.to_vec())?;
+                    Ok(link_dict.unbind().into_any())
+                })
+                .collect::<PyResult<_>>()?;
+            dict.set_item("kinematic_pose", links)?;
+        }
+        _ => {
+            dict.set_item("command_type", command.command_type())?;
+            dict.set_item(
+                "command_data",
+                command.command_data_for_tick(tick, frequency_hz),
+            )?;
+        }
+    }
     Ok(dict.unbind().into_any())
+}
+
+fn ensure_policy_supports_command(
+    policy_name: &str,
+    policy: &dyn WbcPolicy,
+    command: &WbcCommand,
+) -> PyResult<()> {
+    let command_kind = WbcCommandKind::try_from(command).map_err(|_| {
+        PyValueError::new_err(
+            "command is not part of the public embedded runtime surface for this phase",
+        )
+    })?;
+    let capabilities = policy.capabilities();
+    if !capabilities.supports(command_kind) {
+        let supported_commands = capabilities
+            .supported_commands
+            .iter()
+            .map(|kind| kind.as_str())
+            .collect::<Vec<_>>()
+            .join(", ");
+        return Err(PyValueError::new_err(format!(
+            "policy {policy_name:?} does not support {command_kind}; supported commands: [{supported_commands}]"
+        )));
+    }
+    Ok(())
 }
 
 fn base_pose_dict(
@@ -651,10 +1345,8 @@ impl PyMujocoSession {
             ));
         }
 
-        let content = std::fs::read_to_string(config_path).map_err(|error| {
-            PyRuntimeError::new_err(format!("cannot read config file {config_path:?}: {error}"))
-        })?;
-        let app: SessionConfig = toml::from_str(&content).map_err(|error| {
+        let parsed = load_config_document(Path::new(config_path))?;
+        let app: SessionConfig = parsed.try_into().map_err(|error| {
             PyRuntimeError::new_err(format!("invalid TOML in {config_path:?}: {error}"))
         })?;
         if app.comm.frequency_hz == 0 {
@@ -673,6 +1365,8 @@ impl PyMujocoSession {
             .map_err(PyRuntimeError::new_err)?;
         let policy = WbcRegistry::build(&app.policy.name, &policy_cfg)
             .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
+        let initial_command = default_command.command_for_tick(0, app.comm.frequency_hz);
+        ensure_policy_supports_command(&app.policy.name, policy.as_ref(), &initial_command)?;
         let transport = MujocoTransport::new(app.sim.clone(), robot.clone())
             .map_err(|error| PyRuntimeError::new_err(error.to_string()))?;
         let initial_state = transport.full_physics_state();
@@ -713,6 +1407,7 @@ impl PyMujocoSession {
             None => self.current_command.clone(),
         };
         let command = command_spec.command_for_tick(self.tick_index, self.command_frequency_hz);
+        ensure_policy_supports_command(&self.policy_name, self.policy.as_ref(), &command)?;
         let mut last_targets = None;
 
         run_control_tick(&mut self.transport, command, |obs| {
@@ -818,7 +1513,7 @@ impl PyMujocoSession {
 ///
 /// Attributes
 /// ----------
-/// positions : list[float]
+/// positions : `list[float]`
 ///     Per-joint target positions in radians.
 #[pyclass(name = "JointPositionTargets")]
 pub struct PyJointPositionTargets {
@@ -836,7 +1531,7 @@ impl PyJointPositionTargets {
 
 /// A loaded WBC policy ready for inference.
 ///
-/// Obtain an instance via [`Registry`].
+/// Obtain an instance via `Registry`.
 #[pyclass(name = "Policy")]
 pub struct PyPolicy {
     inner: Arc<dyn robowbc_core::WbcPolicy>,
@@ -871,6 +1566,11 @@ impl PyPolicy {
         self.inner.control_frequency_hz()
     }
 
+    /// Supported public command kinds for this policy.
+    fn capabilities(&self) -> PyPolicyCapabilities {
+        PyPolicyCapabilities::from_core(&self.inner.capabilities())
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "Policy(control_frequency_hz={})",
@@ -882,7 +1582,7 @@ impl PyPolicy {
 /// Factory for building registered WBC policies.
 ///
 /// All policies compiled into the library are available via this class.
-/// Use [`Registry::list_policies`] to discover what is available at runtime.
+/// Use `Registry.list_policies()` to discover what is available at runtime.
 #[pyclass(name = "Registry")]
 pub struct PyRegistry;
 
@@ -911,22 +1611,8 @@ impl PyRegistry {
     ///     If the file cannot be read, parsed, or the policy cannot be built.
     #[staticmethod]
     fn build(name: &str, config_path: &str) -> PyResult<PyPolicy> {
-        let content = std::fs::read_to_string(config_path).map_err(|e| {
-            PyRuntimeError::new_err(format!("cannot read config file {config_path:?}: {e}"))
-        })?;
-        let parsed: toml::Value = content.parse().map_err(|e| {
-            PyRuntimeError::new_err(format!("invalid TOML in {config_path:?}: {e}"))
-        })?;
-        let policy_config = parsed
-            .get("policy")
-            .and_then(|p| p.get("config"))
-            .cloned()
-            .unwrap_or_else(|| toml::Value::Table(toml::map::Map::new()));
-        let policy = WbcRegistry::build(name, &policy_config)
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
-        Ok(PyPolicy {
-            inner: Arc::from(policy),
-        })
+        let parsed = load_config_document(Path::new(config_path))?;
+        build_policy_from_document(&parsed, Some(name))
     }
 
     /// Build a policy from a full robowbc TOML config string.
@@ -950,17 +1636,208 @@ impl PyRegistry {
     ///     If parsing fails or the policy cannot be built.
     #[staticmethod]
     fn build_from_str(toml_str: &str) -> PyResult<PyPolicy> {
-        let policy = WbcRegistry::build_from_toml_str(toml_str)
-            .map_err(|e| PyRuntimeError::new_err(e.to_string()))?;
-        Ok(PyPolicy {
-            inner: Arc::from(policy),
-        })
+        let parsed: toml::Value = toml_str
+            .parse()
+            .map_err(|error| PyRuntimeError::new_err(format!("invalid TOML document: {error}")))?;
+        build_policy_from_document(&parsed, None)
     }
 
     /// Return all registered policy names sorted lexicographically.
     #[staticmethod]
     fn list_policies() -> Vec<&'static str> {
         WbcRegistry::policy_names()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pyo3::types::PyDict;
+    use std::time::Instant;
+
+    struct VelocityOnlyPolicy;
+
+    impl WbcPolicy for VelocityOnlyPolicy {
+        fn predict(
+            &self,
+            obs: &Observation,
+        ) -> robowbc_core::Result<robowbc_core::JointPositionTargets> {
+            Ok(robowbc_core::JointPositionTargets {
+                positions: obs.joint_positions.clone(),
+                timestamp: Instant::now(),
+            })
+        }
+
+        fn capabilities(&self) -> PolicyCapabilities {
+            PolicyCapabilities::new(vec![WbcCommandKind::Velocity])
+        }
+
+        fn control_frequency_hz(&self) -> u32 {
+            50
+        }
+
+        fn supported_robots(&self) -> &[RobotConfig] {
+            &[]
+        }
+    }
+
+    fn sample_link_pose() -> PyLinkPose {
+        PyLinkPose {
+            name: "left_wrist".to_owned(),
+            translation: [0.35, 0.2, 0.95],
+            rotation_xyzw: [0.0, 0.0, 0.0, 1.0],
+        }
+    }
+
+    #[test]
+    fn legacy_observation_path_preserves_flat_command_fields() {
+        let observation = PyObservation::new(
+            vec![0.0; 4],
+            vec![0.0; 4],
+            [0.0, 0.0, -1.0],
+            Some("motion_tokens".to_owned()),
+            Some(vec![0.1, 0.2]),
+            None,
+            None,
+        )
+        .expect("legacy observation should build");
+
+        assert_eq!(observation.command_type(), "motion_tokens");
+        assert_eq!(
+            observation
+                .command_data()
+                .expect("legacy commands expose flat data"),
+            vec![0.1, 0.2]
+        );
+        let rust_observation = into_observation(&observation).expect("legacy observation converts");
+        assert!(matches!(
+            rust_observation.command,
+            WbcCommand::MotionTokens(tokens) if tokens == vec![0.1, 0.2]
+        ));
+    }
+
+    #[test]
+    fn structured_kinematic_pose_command_round_trips_through_observation() {
+        Python::attach(|py| {
+            let command = Py::new(
+                py,
+                PyKinematicPoseCommand {
+                    links: vec![sample_link_pose()],
+                },
+            )
+            .expect("command should allocate");
+            let observation = PyObservation::new(
+                vec![0.0; 4],
+                vec![0.0; 4],
+                [0.0, 0.0, -1.0],
+                None,
+                None,
+                None,
+                Some(command.bind(py).as_any()),
+            )
+            .expect("structured observation should build");
+
+            assert_eq!(observation.command_type(), "kinematic_pose");
+            assert!(observation.command_data().is_err());
+
+            let rust_observation =
+                into_observation(&observation).expect("structured observation converts");
+            let WbcCommand::KinematicPose(body_pose) = rust_observation.command else {
+                panic!("expected kinematic pose command")
+            };
+            assert_eq!(body_pose.links.len(), 1);
+            assert_eq!(body_pose.links[0].link_name, "left_wrist");
+        });
+    }
+
+    #[test]
+    fn runtime_kinematic_pose_toml_parses_into_body_pose() {
+        let value: toml::Value = toml::from_str(
+            r#"
+                [[links]]
+                name = "left_wrist"
+                translation = [0.35, 0.20, 0.95]
+                rotation_xyzw = [0.0, 0.0, 0.0, 1.0]
+            "#,
+        )
+        .expect("toml parses");
+
+        let body_pose = parse_runtime_kinematic_pose(&value).expect("kinematic pose parses");
+        assert_eq!(body_pose.links.len(), 1);
+        assert_eq!(body_pose.links[0].link_name, "left_wrist");
+        assert_eq!(body_pose.links[0].pose.translation, [0.35, 0.2, 0.95]);
+    }
+
+    #[test]
+    fn action_command_and_command_dict_round_trip_kinematic_pose() {
+        Python::attach(|py| {
+            let action = PyDict::new(py);
+            let link = PyDict::new(py);
+            link.set_item("name", "left_wrist").expect("name set");
+            link.set_item("translation", vec![0.35_f32, 0.2, 0.95])
+                .expect("translation set");
+            link.set_item("rotation_xyzw", vec![0.0_f32, 0.0, 0.0, 1.0])
+                .expect("rotation set");
+            action
+                .set_item("kinematic_pose", vec![link.unbind().into_any()])
+                .expect("kinematic_pose set");
+
+            let spec = parse_action_command(action.as_any()).expect("action parses");
+            let SessionCommandSpec::KinematicPose(body_pose) = &spec else {
+                panic!("expected kinematic pose session command")
+            };
+            assert_eq!(body_pose.links.len(), 1);
+            assert_eq!(body_pose.links[0].link_name, "left_wrist");
+
+            let state = command_dict(py, &spec, 0, 50).expect("command dict builds");
+            let reparsed = parse_action_command(state.bind(py).as_any()).expect("state reparses");
+            let SessionCommandSpec::KinematicPose(reparsed_pose) = reparsed else {
+                panic!("expected reparsed kinematic pose")
+            };
+            assert_eq!(reparsed_pose.links[0].link_name, "left_wrist");
+            assert_eq!(reparsed_pose.links[0].pose.translation, [0.35, 0.2, 0.95]);
+        });
+    }
+
+    #[test]
+    fn capability_gate_rejects_unsupported_command() {
+        let body_pose = CoreBodyPose {
+            links: vec![CoreLinkPose {
+                link_name: "left_wrist".to_owned(),
+                pose: SE3 {
+                    translation: [0.0, 0.0, 0.0],
+                    rotation_xyzw: [0.0, 0.0, 0.0, 1.0],
+                },
+            }],
+        };
+        let error = ensure_policy_supports_command(
+            "velocity_only",
+            &VelocityOnlyPolicy,
+            &WbcCommand::KinematicPose(body_pose),
+        )
+        .expect_err("capability gate should reject unsupported kinematic pose");
+        assert!(error
+            .to_string()
+            .contains("does not support kinematic_pose"));
+    }
+
+    #[test]
+    fn registry_build_uses_robot_config_from_document() {
+        let config_path =
+            Path::new(env!("CARGO_MANIFEST_DIR")).join("../../configs/decoupled_smoke.toml");
+        let content = std::fs::read_to_string(&config_path).expect("config should exist");
+        let mut parsed: toml::Value = content.parse().expect("config parses");
+        resolve_relative_config_paths(
+            &mut parsed,
+            config_path
+                .parent()
+                .expect("config should have a parent directory"),
+        );
+
+        let policy =
+            build_policy_from_document(&parsed, None).expect("policy should build from document");
+        let capabilities = policy.inner.capabilities();
+        assert!(capabilities.supports(WbcCommandKind::Velocity));
     }
 }
 
@@ -974,6 +1851,12 @@ fn robowbc(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // (because none of its symbols are directly referenced here), causing all
     // inventory::submit! policy registrations to be absent at runtime.
     robowbc_ort::link_all_ort_policies();
+    m.add_class::<PyPolicyCapabilities>()?;
+    m.add_class::<PyVelocityCommand>()?;
+    m.add_class::<PyMotionTokensCommand>()?;
+    m.add_class::<PyJointTargetsCommand>()?;
+    m.add_class::<PyLinkPose>()?;
+    m.add_class::<PyKinematicPoseCommand>()?;
     m.add_class::<PyObservation>()?;
     m.add_class::<PyJointPositionTargets>()?;
     m.add_class::<PyPolicy>()?;

--- a/crates/robowbc-pyo3/src/lib.rs
+++ b/crates/robowbc-pyo3/src/lib.rs
@@ -62,7 +62,10 @@ use pyo3::prelude::{
     Py, PyAny, PyAnyMethods, PyDictMethods, PyErr, PyListMethods, PyResult, Python,
 };
 use pyo3::types::{PyDict, PyList};
-use robowbc_core::{JointPositionTargets, Observation, RobotConfig, WbcCommand, WbcError};
+use robowbc_core::{
+    JointPositionTargets, Observation, PolicyCapabilities, RobotConfig, WbcCommand, WbcCommandKind,
+    WbcError,
+};
 use robowbc_registry::{RegistryPolicy, WbcRegistration};
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
@@ -233,18 +236,21 @@ fn load_torch_checkpoint(py: Python<'_>, path: &Path) -> PyResult<Py<PyAny>> {
 }
 
 /// Flattens the command payload into a `Vec<f32>` suitable for model input.
-fn command_to_floats(command: &WbcCommand) -> Vec<f32> {
+fn command_to_floats(command: &WbcCommand) -> robowbc_core::Result<Vec<f32>> {
     match command {
-        WbcCommand::MotionTokens(tokens) => tokens.clone(),
+        WbcCommand::MotionTokens(tokens) => Ok(tokens.clone()),
         WbcCommand::Velocity(twist) => {
             let mut v = twist.linear.to_vec();
             v.extend_from_slice(&twist.angular);
-            v
+            Ok(v)
         }
-        WbcCommand::JointTargets(targets) => targets.clone(),
-        // `EndEffectorPoses` and `KinematicPose` are not representable as a flat
-        // float vector without a protocol — pass empty for now.
-        WbcCommand::EndEffectorPoses(_) | WbcCommand::KinematicPose(_) => vec![],
+        WbcCommand::JointTargets(targets) => Ok(targets.clone()),
+        WbcCommand::EndEffectorPoses(_) => Err(WbcError::UnsupportedCommand(
+            "PyModelPolicy supports only velocity, motion_tokens, and joint_targets; query capabilities() before predict",
+        )),
+        WbcCommand::KinematicPose(_) => Err(WbcError::UnsupportedCommand(
+            "PyModelPolicy does not support kinematic_pose; query capabilities() before predict",
+        )),
     }
 }
 
@@ -267,7 +273,7 @@ impl robowbc_core::WbcPolicy for PyModelPolicy {
         obs_flat.extend_from_slice(&obs.joint_velocities);
         obs_flat.extend_from_slice(&obs.gravity_vector);
         obs_flat.extend_from_slice(&obs.angular_velocity);
-        obs_flat.extend(command_to_floats(&obs.command));
+        obs_flat.extend(command_to_floats(&obs.command)?);
 
         Python::attach(|py| {
             // Zero-copy transfer of obs_flat into a numpy array.
@@ -307,6 +313,14 @@ impl robowbc_core::WbcPolicy for PyModelPolicy {
         50
     }
 
+    fn capabilities(&self) -> PolicyCapabilities {
+        PolicyCapabilities::new(vec![
+            WbcCommandKind::Velocity,
+            WbcCommandKind::MotionTokens,
+            WbcCommandKind::JointTargets,
+        ])
+    }
+
     fn supported_robots(&self) -> &[RobotConfig] {
         std::slice::from_ref(&self.robot)
     }
@@ -329,7 +343,10 @@ inventory::submit! {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use robowbc_core::{JointLimit, PdGains, Twist, WbcCommand, WbcPolicy};
+    use robowbc_core::{
+        BodyPose, JointLimit, LinkPose, PdGains, PolicyCapabilities, Twist, WbcCommand, WbcPolicy,
+        SE3,
+    };
     use std::path::PathBuf;
     use std::time::Instant;
 
@@ -556,6 +573,37 @@ mod tests {
         assert_eq!(policy.control_frequency_hz(), 50);
         assert_eq!(policy.supported_robots().len(), 1);
         assert_eq!(policy.supported_robots()[0].name, "test_robot");
+        assert_eq!(
+            policy.capabilities(),
+            PolicyCapabilities::new(vec![
+                WbcCommandKind::Velocity,
+                WbcCommandKind::MotionTokens,
+                WbcCommandKind::JointTargets,
+            ])
+        );
+    }
+
+    #[test]
+    fn structured_commands_are_rejected_by_flat_command_encoder() {
+        let end_effector_result = command_to_floats(&WbcCommand::EndEffectorPoses(vec![]));
+        assert!(matches!(
+            end_effector_result,
+            Err(WbcError::UnsupportedCommand(_))
+        ));
+
+        let kinematic_pose_result = command_to_floats(&WbcCommand::KinematicPose(BodyPose {
+            links: vec![LinkPose {
+                link_name: "left_wrist".to_owned(),
+                pose: SE3 {
+                    translation: [0.0, 0.0, 0.0],
+                    rotation_xyzw: [0.0, 0.0, 0.0, 1.0],
+                },
+            }],
+        }));
+        assert!(matches!(
+            kinematic_pose_result,
+            Err(WbcError::UnsupportedCommand(_))
+        ));
     }
 
     /// `PyTorch`-specific test — requires `torch` to be installed.

--- a/crates/robowbc-registry/src/lib.rs
+++ b/crates/robowbc-registry/src/lib.rs
@@ -166,7 +166,10 @@ impl WbcRegistry {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use robowbc_core::{JointPositionTargets, Observation, Result as CoreResult, RobotConfig};
+    use robowbc_core::{
+        JointPositionTargets, Observation, PolicyCapabilities, Result as CoreResult, RobotConfig,
+        WbcCommandKind,
+    };
     use std::time::Instant;
 
     #[derive(Debug)]
@@ -215,6 +218,10 @@ mod tests {
             })
         }
 
+        fn capabilities(&self) -> PolicyCapabilities {
+            PolicyCapabilities::new(vec![WbcCommandKind::MotionTokens])
+        }
+
         fn control_frequency_hz(&self) -> u32 {
             50
         }
@@ -247,6 +254,10 @@ mod tests {
         };
         let targets = policy.predict(&obs).expect("prediction succeeds");
         assert_eq!(targets.positions, vec![1.0, -2.0]);
+        assert_eq!(
+            policy.capabilities().supported_commands,
+            vec![WbcCommandKind::MotionTokens]
+        );
     }
 
     #[test]

--- a/docs/adding-a-model.md
+++ b/docs/adding-a-model.md
@@ -4,6 +4,12 @@ This tutorial walks through integrating a new WBC model into RoboWBC. We use
 the existing `DecoupledWbcPolicy` as a concrete reference — you can read its
 source in `crates/robowbc-ort/src/decoupled.rs` alongside this guide.
 
+New policies are added to the existing embedded runtime surface. Phase 1 does
+not add a `server/daemon`, `ROS2`, or `zenoh` customer API, and it does not
+re-expose public `EndEffectorPoses`. New wrappers should fit one of the
+shipped public command kinds and report that support honestly through
+`capabilities()`.
+
 ## The five steps
 
 1. Define the config struct
@@ -43,8 +49,8 @@ Every field in `MyPolicyConfig` maps 1:1 to TOML keys under `[policy.config]`.
 ```rust
 use std::sync::Mutex;
 use robowbc_core::{
-    JointPositionTargets, Observation, Result as CoreResult,
-    RobotConfig, WbcCommand, WbcError, WbcPolicy,
+    JointPositionTargets, Observation, PolicyCapabilities, Result as CoreResult,
+    RobotConfig, WbcCommand, WbcCommandKind, WbcError, WbcPolicy,
 };
 
 pub struct MyPolicy {
@@ -114,6 +120,10 @@ impl WbcPolicy for MyPolicy {
         })
     }
 
+    fn capabilities(&self) -> PolicyCapabilities {
+        PolicyCapabilities::new([WbcCommandKind::Velocity])
+    }
+
     fn control_frequency_hz(&self) -> u32 {
         self.control_frequency_hz
     }
@@ -123,6 +133,10 @@ impl WbcPolicy for MyPolicy {
     }
 }
 ```
+
+Every new wrapper must implement `capabilities()` honestly. If `predict()`
+rejects a command at runtime, that command kind must not appear in
+`PolicyCapabilities`.
 
 ### Thread safety
 
@@ -282,6 +296,7 @@ step that ensures all joints are covered exactly once.
 Key points from its implementation:
 - `build_rl_input` constructs `[lower_pos, lower_vel, gravity(3), vx, vy, yaw]`
 - Upper-body joints are filled from `RobotConfig::default_pose`
+- `capabilities()` returns the exact public commands the wrapper accepts
 - `RegistryPolicy::from_config` uses `toml::Value::try_into::<DecoupledWbcConfig>()`
 - The `inventory::submit!` line is at module level, outside any function
 
@@ -292,4 +307,5 @@ Key points from its implementation:
 | Forgetting `inventory::submit!` | `WbcRegistry::build` returns `UnknownPolicy` | Add the submit block at module scope |
 | Not adding `TypeId` in CLI | Works in tests, silently missing in binary | Add `TypeId::of::<MyPolicy>()` to CLI |
 | `Mutex` not around backend | Compile error: `OrtBackend` is not `Sync` | Wrap in `Mutex<OrtBackend>` |
+| `capabilities()` does not match `predict()` | Python/Rust callers pass a command your wrapper later rejects | Return only the command kinds your wrapper actually accepts |
 | Wrong input tensor shape | `ShapeMismatch` error at runtime | Print model's expected shape with `backend.input_names()` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,6 +1,13 @@
 # Configuration schema
 
-RoboWBC CLI reads a single TOML file for runtime selection of policy, robot, communication, and inference backend.
+RoboWBC uses one TOML schema across the CLI and the file-based embedded Python
+entry points (`load_from_config`, `Registry.build`, and `MujocoSession`). This
+document describes the embedded runtime configuration surface, not a
+`server/daemon`, `ROS2`, or `zenoh` customer API.
+
+For file-based Python entry points, relative `config_path`, `model_path`, and
+`context_path` values are normalized from the config document before the policy
+or session is built.
 
 ## Top-level sections
 
@@ -155,6 +162,23 @@ Rules:
 
 - Uses `runtime.kinematic_pose`
 
+Example:
+
+```toml
+[[runtime.kinematic_pose.links]]
+name = "left_wrist"
+translation = [0.35, 0.20, 0.95]
+rotation_xyzw = [0.0, 0.0, 0.0, 1.0]
+
+[[runtime.kinematic_pose.links]]
+name = "right_wrist"
+translation = [0.35, -0.20, 0.95]
+rotation_xyzw = [0.0, 0.0, 0.0, 1.0]
+```
+
+The public manipulation surface is `kinematic_pose` with named links. There is
+no public `EndEffectorPoses` config surface in v1.
+
 ### `bfm_zero`
 
 - Uses its own prompt/context config under `[policy.config.tracking]`
@@ -171,6 +195,37 @@ Rules:
 - `standing_placeholder_tracking` is only supported when `policy.name = "gear_sonic"`
 - Named `runtime.velocity_schedule.segments` must either all define
   `phase_name` or all omit it; duplicate or unsafe phase names are rejected
+- `runtime.kinematic_pose.links[*]` must provide `name`, `translation[3]`, and `rotation_xyzw[4]`
+
+## Live Python session command shapes
+
+`robowbc.MujocoSession.step(...)` accepts the same public command families as
+the embedded Python SDK:
+
+```python
+session.step({"velocity": [0.3, 0.0, 0.1]})
+session.step({"motion_tokens": [0.1, 0.2]})
+session.step({"joint_targets": [0.0] * 29})
+session.step(
+    {
+        "kinematic_pose": [
+            {
+                "name": "left_wrist",
+                "translation": [0.35, 0.20, 0.95],
+                "rotation_xyzw": [0.0, 0.0, 0.0, 1.0],
+            }
+        ]
+    }
+)
+```
+
+State export uses the same canonical shapes:
+
+- Flat commands appear as `{"command_type": "...", "command_data": [...]}`
+- Manipulation appears as `{"kinematic_pose": [...]}` with the named link-pose
+  payload shown above
+
+The checked-in reference example is `examples/python/mujoco_kinematic_pose_session.py`.
 
 ## Optional artifact sections
 

--- a/docs/python-sdk.md
+++ b/docs/python-sdk.md
@@ -1,12 +1,16 @@
 # Python SDK
 
-RoboWBC ships a first-class Python SDK backed by the same Rust runtime. Build
-it locally with `maturin develop`, or install a published `robowbc` wheel when
-one is available, then either:
+RoboWBC's primary customer-facing embedded runtime surface is the Python SDK.
+The CLI remains the repo's smoke, benchmark, and report path, but outside
+integrators are expected to embed RoboWBC through:
 
-- load a registered policy by name and call `policy.predict(obs)`, or
-- open a live `robowbc.MujocoSession` that keeps MuJoCo stepping and policy
-  inference in Rust while exposing a Python-facing simulator session
+- `Registry` or `load_from_config()` for policy construction
+- `Observation` plus `Policy.predict()` for direct inference
+- `MujocoSession` for a Rust-owned live simulation/control loop
+
+Embedded Rust is the secondary adoption path. Phase 1 intentionally does **not**
+add a `server/daemon` surface, a public `ROS2` or `zenoh` customer API, new
+wrapper families, or a public `EndEffectorPoses` surface.
 
 The Python SDK is Linux-only, matching the rest of the RoboWBC runtime.
 
@@ -17,14 +21,13 @@ Python 3.10 or later is required.
 ### Build from source
 
 ```bash
-# Requires Rust stable >= 1.75 and maturin
-pip install "maturin>=1.4,<2.0"
-export MUJOCO_DOWNLOAD_DIR="$(pwd)/.cache/mujoco"   # optional auto-download path for MujocoSession
-maturin develop          # installs an editable build into the current venv
+pip install "maturin>=1.9.4,<2.0"
+export MUJOCO_DOWNLOAD_DIR="$(pwd)/.cache/mujoco"   # optional for MujocoSession
+maturin develop
 ```
 
 The live `MujocoSession` API additionally requires MuJoCo at build and run
-time. You can either use a system MuJoCo install, or reuse RoboWBC's existing
+time. You can either use a system MuJoCo install, or reuse RoboWBC's
 auto-download path by setting `MUJOCO_DOWNLOAD_DIR` to an absolute directory
 before running `maturin develop`.
 
@@ -34,176 +37,173 @@ before running `maturin develop`.
 pip install robowbc
 ```
 
-Published wheels target `manylinux2014` (glibc >= 2.17), which covers modern
+Published wheels target `manylinux2014` (glibc >= 2.17), which covers the
 Linux distributions commonly used in robotics research.
 
-## Quick start
+## Config Loading Behavior
+
+The file-based Python entry points:
+
+- `robowbc.load_from_config(path)`
+- `Registry.build(name, path)`
+- `MujocoSession(path, ...)`
+
+normalize relative `config_path`, `model_path`, and `context_path` values from
+the TOML document before building the runtime objects. This keeps the checked-in
+repo configs working while also supporting app-local config files without
+rewriting every nested path manually.
+
+## Quick Start
 
 ```python
-from robowbc import Registry, Observation
+from robowbc import Observation, Registry, VelocityCommand
 
-# List all policies compiled into the wheel
-print(Registry.list_policies())
-# → ['bfm_zero', 'decoupled_wbc', 'gear_sonic', 'hover', 'wbc_agile', ...]
+policy = Registry.build("decoupled_wbc", "configs/decoupled_smoke.toml")
+print(policy.control_frequency_hz())              # 50
+print(policy.capabilities().supported_commands)   # ['velocity']
 
-# Load GEAR-SONIC from a TOML config file
-policy = Registry.build("gear_sonic", "configs/sonic_g1.toml")
-print(policy)                          # Policy(control_frequency_hz=50)
-print(policy.control_frequency_hz())  # 50
-
-# Build an observation for a Unitree G1 (29 DOF in `configs/sonic_g1.toml`)
 obs = Observation(
-    joint_positions=[0.0] * 29,
-    joint_velocities=[0.0] * 29,
+    joint_positions=[0.0] * 4,
+    joint_velocities=[0.0] * 4,
     gravity_vector=[0.0, 0.0, -1.0],
-    command_type="velocity",
-    command_data=[0.3, 0.0, 0.0, 0.0, 0.0, 0.0],
+    command=VelocityCommand(
+        linear=[0.2, 0.0, 0.0],
+        angular=[0.0, 0.0, 0.1],
+    ),
 )
 
-# Run one inference step
 targets = policy.predict(obs)
-print(targets.positions[:5])   # first 5 joint position targets (radians)
+print(targets.positions)
 ```
 
-## API Reference
+The module-level convenience wrapper is equivalent:
 
-### `Observation`
+```python
+import robowbc
 
-Standardized sensor input passed to every policy.
+policy = robowbc.load_from_config("configs/decoupled_smoke.toml")
+```
+
+## Command Surface
+
+`Observation` supports two command styles:
+
+1. The preserved flat path for existing callers:
 
 ```python
 Observation(
-    joint_positions: list[float],   # current joint angles (radians)
-    joint_velocities: list[float],  # current joint velocities (rad/s)
-    gravity_vector: tuple[float, float, float],  # gravity in body frame
-    command_type: str,              # "velocity" | "motion_tokens" | "joint_targets"
-    command_data: list[float],      # payload — see table below
-)
-```
-
-**Command types:**
-
-| `command_type`    | `command_data` layout                              |
-|-------------------|----------------------------------------------------|
-| `"velocity"`      | `[vx, vy, vz, wx, wy, wz]` — 6 floats             |
-| `"motion_tokens"` | arbitrary-length token vector                      |
-| `"joint_targets"` | per-joint target positions                         |
-
-All fields are readable and writable attributes.
-
-For the public `gear_sonic` config, the default path is `command_type="velocity"`.
-Empty `motion_tokens` select the standing-placeholder tracking contract, while
-non-empty motion tokens are only for the older fixture-style mock pipeline.
-
-### `JointPositionTargets`
-
-Return value of `Policy.predict`.
-
-| Attribute    | Type         | Description                                 |
-|--------------|--------------|---------------------------------------------|
-| `positions`  | `list[float]`| Per-joint target positions in radians.      |
-
-### `Policy`
-
-A loaded policy ready for inference. Obtain via `Registry`.
-
-| Method / Property            | Description                                    |
-|------------------------------|------------------------------------------------|
-| `predict(obs) → targets`     | Run one inference step.                        |
-| `control_frequency_hz() → int` | Required loop rate (typically 50 Hz).        |
-
-### `MujocoSession`
-
-Live Python-facing MuJoCo session around the Rust RoboWBC control path.
-
-```python
-MujocoSession(
-    config_path: str,
-    render_width: int = 640,
-    render_height: int = 480,
-)
-```
-
-The config must include a `[sim]` section. The session loads the robot config,
-builds the policy, creates `MujocoTransport`, and keeps the live control loop in
-Rust.
-
-Supported high-level `step()` action forms:
-
-- `{"velocity": [vx, vy, yaw_rate]}`
-- `{"motion_tokens": [...]}`
-- `{"joint_targets": [...]}`
-- `{"command_type": "...", "command_data": [...]}` for explicit command payloads
-
-Methods:
-
-| Method | Description |
-|--------|-------------|
-| `reset() -> dict` | Reset the simulator and policy state. |
-| `step(action=None) -> dict` | Advance one Rust-owned control tick. |
-| `get_state() -> dict` | Return current joint/base/MuJoCo state. |
-| `save_state() -> dict` | Save full MuJoCo physics state plus session command metadata. |
-| `restore_state(state) -> None` | Restore a state returned by `save_state()`. |
-| `capture_camera(name) -> dict` | Return RGB bytes plus width/height for a named camera or preset. |
-| `get_sim_time() -> float` | Return current simulator time in seconds. |
-
-The session does not reimplement the controller in Python. Each `step()` call:
-
-1. reads live simulator observations in Rust
-2. runs the policy in Rust
-3. sends targets through the Rust MuJoCo transport
-4. advances MuJoCo using the configured substep semantics
-
-### `Registry`
-
-Factory for building registered policies.
-
-| Static method                                   | Description                               |
-|-------------------------------------------------|-------------------------------------------|
-| `Registry.list_policies() → list[str]`          | All compiled-in policy names.             |
-| `Registry.build(name, config_path) → Policy`    | Build from a robowbc TOML config file.    |
-| `Registry.build_from_str(toml_str) → Policy`    | Build from a TOML string.                 |
-
-## Examples
-
-### Config-driven policy switching
-
-```python
-from robowbc import Registry, Observation
-
-# Same observation, different policy — just change the config file
-for config in ["configs/sonic_g1.toml", "configs/decoupled_smoke.toml"]:
-    policy = Registry.build("gear_sonic" if "sonic" in config else "decoupled_wbc", config)
-    print(f"{config}: {policy.control_frequency_hz()} Hz")
-```
-
-### 50 Hz control loop
-
-```python
-import time
-from robowbc import Registry, Observation
-
-policy = Registry.build("gear_sonic", "configs/sonic_g1.toml")
-dt = 1.0 / policy.control_frequency_hz()   # 0.02 s
-
-obs = Observation(
-    joint_positions=[0.0] * 23,
-    joint_velocities=[0.0] * 23,
+    joint_positions=[...],
+    joint_velocities=[...],
     gravity_vector=[0.0, 0.0, -1.0],
     command_type="velocity",
-    command_data=[0.5, 0.0, 0.0, 0.0, 0.0, 0.3],
+    command_data=[vx, vy, vz, wx, wy, wz],
 )
-
-for _ in range(100):                        # 2 seconds at 50 Hz
-    t0 = time.perf_counter()
-    targets = policy.predict(obs)
-    elapsed = time.perf_counter() - t0
-    time.sleep(max(0.0, dt - elapsed))
 ```
 
-A full runnable example is at `examples/python/gear_sonic_inference.py`.
+2. The structured path for new integrations:
 
-### Live MuJoCo session
+```python
+from robowbc import KinematicPoseCommand, LinkPose, Observation, VelocityCommand
+
+Observation(
+    joint_positions=[...],
+    joint_velocities=[...],
+    gravity_vector=[0.0, 0.0, -1.0],
+    command=VelocityCommand(
+        linear=[vx, vy, vz],
+        angular=[wx, wy, wz],
+    ),
+)
+
+Observation(
+    joint_positions=[...],
+    joint_velocities=[...],
+    gravity_vector=[0.0, 0.0, -1.0],
+    command=KinematicPoseCommand(
+        [
+            LinkPose(
+                name="left_wrist",
+                translation=[0.35, 0.20, 0.95],
+                rotation_xyzw=[0.0, 0.0, 0.0, 1.0],
+            )
+        ]
+    ),
+)
+```
+
+### Structured command classes
+
+| Class | Use |
+|------|-----|
+| `VelocityCommand` | 6D base twist: `linear=[vx, vy, vz]`, `angular=[wx, wy, wz]` |
+| `MotionTokensCommand` | Tokenized reference motion payload |
+| `JointTargetsCommand` | Direct joint-space target vector |
+| `KinematicPoseCommand` | Named link-pose command for manipulation |
+| `LinkPose` | One link pose inside `KinematicPoseCommand` |
+
+### Flat command compatibility
+
+The legacy `command_type` plus `command_data` path remains supported for:
+
+- `velocity`
+- `motion_tokens`
+- `joint_targets`
+
+`kinematic_pose` is intentionally **not** exposed as flat `command_data`.
+Use `Observation(..., command=KinematicPoseCommand([...]))` for the public
+manipulation path.
+
+### Public manipulation shape
+
+The public `kinematic_pose` contract is:
+
+```python
+KinematicPoseCommand(
+    [
+        LinkPose(
+            name="left_wrist",
+            translation=[x, y, z],
+            rotation_xyzw=[qx, qy, qz, qw],
+        ),
+        LinkPose(
+            name="right_wrist",
+            translation=[x, y, z],
+            rotation_xyzw=[qx, qy, qz, qw],
+        ),
+    ]
+)
+```
+
+There is no public `EndEffectorPoses` Python surface in v1. Use named
+`LinkPose` entries through `KinematicPoseCommand` instead.
+
+## `Policy` and `PolicyCapabilities`
+
+Use `Policy.capabilities()` before you attempt inference or wire an adapter:
+
+```python
+policy = Registry.build("decoupled_wbc", "configs/decoupled_smoke.toml")
+capabilities = policy.capabilities()
+if "velocity" not in capabilities.supported_commands:
+    raise RuntimeError(capabilities.supported_commands)
+```
+
+`PolicyCapabilities.supported_commands` returns stable snake_case command names
+mirroring `WbcCommandKind` in Rust:
+
+- `velocity`
+- `motion_tokens`
+- `joint_targets`
+- `kinematic_pose`
+
+This is the contract that the official adapters use to fail fast before
+inference.
+
+## `MujocoSession`
+
+`MujocoSession` keeps observation gathering, policy inference, target
+generation, and MuJoCo stepping inside Rust while exposing a Python-facing
+session object:
 
 ```python
 import robowbc
@@ -213,79 +213,94 @@ session = robowbc.MujocoSession(
     render_width=640,
     render_height=480,
 )
-
-state = session.reset()
-print(state["joint_names"][:3])
-
-for _ in range(10):
-    state = session.step({"velocity": [0.3, 0.0, 0.0]})
-
-capture = session.capture_camera("track")
-print(capture["width"], capture["height"], len(capture["rgb"]))
 ```
 
-The returned camera payload is intentionally simple: RGB bytes plus dimensions.
-The reference roboharness adapter at `examples/python/roboharness_backend.py`
-wraps that payload into `roboharness.core.capture.CameraView`.
+Supported `step()` action shapes:
+
+- `{"velocity": [vx, vy, yaw_rate]}`
+- `{"motion_tokens": [...]}`
+- `{"joint_targets": [...]}`
+- `{"command_type": "...", "command_data": [...]}` for explicit flat payloads
+- `{"kinematic_pose": [{"name": ..., "translation": [...], "rotation_xyzw": [...]}]}`
+
+The manipulation action shape is the same one returned by session state export:
+
+```python
+action = {
+    "kinematic_pose": [
+        {
+            "name": "left_wrist",
+            "translation": [0.35, 0.20, 0.95],
+            "rotation_xyzw": [0.0, 0.0, 0.0, 1.0],
+        }
+    ]
+}
+
+state = session.step(action)
+print(state["command"])
+```
+
+For flat commands, `get_state()`, `save_state()`, and `restore_state()` use
+`{"command_type": ..., "command_data": ...}`. For manipulation, they use the
+canonical `{"kinematic_pose": [...]}` dict shape shown above.
+
+`MujocoSession` also checks the built policy's capabilities before each control
+tick, so unsupported commands fail before they reach the control loop.
+
+### Live session example
+
+The checked-in reference example is:
+
+- `examples/python/mujoco_kinematic_pose_session.py`
+
+That file demonstrates `session.step({"kinematic_pose": [...]})` directly
+against `configs/wholebody_vla_x2.toml`.
+
+## Official adapters
+
+RoboWBC ships first-party copyable adapter seams:
+
+- `crates/robowbc-py/examples/lerobot_adapter.py`
+  Uses `Policy.capabilities()` plus `VelocityCommand` and preserves the
+  LeRobot-style `step(obs_dict) -> {"action": targets}` seam.
+- `crates/robowbc-py/examples/manipulation_adapter.py`
+  Uses `Policy.capabilities()` plus `KinematicPoseCommand` and preserves the
+  same `{"action": targets}` seam for manipulation callers.
+- `examples/python/roboharness_backend.py`
+  Adapts `MujocoSession` to roboharness while keeping the live control path in
+  Rust.
 
 ## LeRobot integration
 
-robowbc can act as a drop-in WBC inference backend for LeRobot's
-`GrootLocomotionController` and `HolosomaLocomotionController`.  Both
-controllers share a `step(obs_dict) → action_dict` interface that maps
-directly to robowbc's `Policy.predict`.
-
-A standalone `RoboWBCController` adapter is provided in
-`crates/robowbc-py/examples/lerobot_adapter.py`:
+`crates/robowbc-py/examples/lerobot_adapter.py` is the reference locomotion
+adapter for LeRobot / GR00T-style seams:
 
 ```python
 from lerobot_adapter import RoboWBCController
 
-# Load any robowbc policy via TOML config — no code changes for model switching.
-ctrl = RoboWBCController("configs/sonic_g1.toml")
-
-# LeRobot-style inference step.
+controller = RoboWBCController("configs/sonic_g1.toml")
 obs_dict = {
-    "observation.state":    joint_positions,   # list[float] or np.ndarray, n_joints
-    "observation.velocity": joint_velocities,  # list[float] or np.ndarray, n_joints
-    "observation.imu":      [gx, gy, gz, wx, wy, wz],  # gravity + angular vel
-    "observation.task_cmd": [vx, vy, omega],   # base velocity command (3 floats)
+    "observation.state": joint_positions,
+    "observation.velocity": joint_velocities,
+    "observation.imu": [gx, gy, gz, wx, wy, wz],
+    "observation.task_cmd": [vx, vy, omega],
 }
-action = ctrl.step(obs_dict)
-joint_targets = action["action"]   # list[float], n_joints
+action = controller.step(obs_dict)
+print(action["action"])
 ```
 
-The `load_from_config` convenience function (also available at module level)
-reads the TOML file and returns a `Policy` in one call:
-
-```python
-import robowbc
-policy = robowbc.load_from_config("configs/sonic_g1.toml")
-```
-
-See `docs/community/lerobot-rfc.md` for the full RFC and submission plan.
-
-## Roboharness live backend path
-
-`examples/python/roboharness_backend.py` shows the intended ownership boundary:
-
-- Python adapts `robowbc.MujocoSession` to roboharness's `SimulatorBackend`
-  protocol
-- Rust continues to own live simulator state reads, policy inference, target
-  generation, and MuJoCo stepping
-- roboharness remains an optional Python-side dependency; no RoboWBC Rust crate
-  depends on it directly
+That adapter normalizes LeRobot's 3-float `[vx, vy, omega]` task command into
+RoboWBC's 6D structured velocity command and fails fast unless the loaded
+policy advertises `velocity` support.
 
 ## Publishing new releases
 
 Wheels are built automatically on every `v*` tag via
-`.github/workflows/publish.yml`.  The workflow:
+`.github/workflows/publish.yml`. The workflow:
 
-1. Builds `manylinux2014` wheels via `PyO3/maturin-action`.
-2. Builds an sdist.
-3. Publishes everything to PyPI using [trusted publishing] (no API token
-   needed — configure the `pypi` GitHub environment in repo Settings →
-   Environments, then add the `miaodx/robowbc` publisher in your PyPI project).
+1. Builds `manylinux2014` wheels via `PyO3/maturin-action`
+2. Builds an sdist
+3. Publishes everything to PyPI using trusted publishing
 
 To cut a release:
 
@@ -293,5 +308,3 @@ To cut a release:
 git tag v0.2.0
 git push origin v0.2.0
 ```
-
-[trusted publishing]: https://docs.pypi.org/trusted-publishers/

--- a/examples/python/mujoco_kinematic_pose_session.py
+++ b/examples/python/mujoco_kinematic_pose_session.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Live `kinematic_pose` stepping example for `robowbc.MujocoSession`.
+
+This example uses the checked-in WholeBodyVLA config contract and sends one
+named-link manipulation command through the Rust-owned MuJoCo session API:
+
+    session.step({"kinematic_pose": [{"name": ..., "translation": [...], "rotation_xyzw": [...]}]})
+
+The public WholeBodyVLA repo does not currently ship a runnable checkpoint, so
+you need to place a compatible local/private ONNX export at the path referenced
+by `configs/wholebody_vla_x2.toml` before this example can execute fully.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from typing import Any
+
+try:
+    import robowbc
+except ImportError:
+    print("robowbc is not installed. Run: maturin develop", file=sys.stderr)
+    raise
+
+
+def _vector(values: Any, field_name: str, expected_len: int) -> list[float]:
+    floats = [float(value) for value in values]
+    if len(floats) != expected_len:
+        raise ValueError(
+            f"{field_name} must contain exactly {expected_len} floats, got {len(floats)}"
+        )
+    return floats
+
+
+def validate_kinematic_pose_action(action: dict[str, Any]) -> dict[str, Any]:
+    raw_links = action.get("kinematic_pose")
+    if not isinstance(raw_links, list) or not raw_links:
+        raise ValueError("action['kinematic_pose'] must be a non-empty list")
+
+    normalized_links: list[dict[str, Any]] = []
+    for index, raw_link in enumerate(raw_links):
+        if not isinstance(raw_link, dict):
+            raise ValueError(f"kinematic_pose[{index}] must be a dict")
+        name = raw_link.get("name")
+        if not isinstance(name, str) or not name.strip():
+            raise ValueError(f"kinematic_pose[{index}].name must be a non-empty string")
+        normalized_links.append(
+            {
+                "name": name,
+                "translation": _vector(
+                    raw_link.get("translation", []),
+                    f"kinematic_pose[{index}].translation",
+                    3,
+                ),
+                "rotation_xyzw": _vector(
+                    raw_link.get("rotation_xyzw", []),
+                    f"kinematic_pose[{index}].rotation_xyzw",
+                    4,
+                ),
+            }
+        )
+    return {"kinematic_pose": normalized_links}
+
+
+def sample_action() -> dict[str, Any]:
+    return validate_kinematic_pose_action(
+        {
+            "kinematic_pose": [
+                {
+                    "name": "left_wrist",
+                    "translation": [0.35, 0.20, 0.95],
+                    "rotation_xyzw": [0.0, 0.0, 0.0, 1.0],
+                },
+                {
+                    "name": "right_wrist",
+                    "translation": [0.35, -0.20, 0.95],
+                    "rotation_xyzw": [0.0, 0.0, 0.0, 1.0],
+                },
+            ]
+        }
+    )
+
+
+def main(config_path: str) -> int:
+    try:
+        session = robowbc.MujocoSession(config_path, render_width=640, render_height=480)
+    except RuntimeError as exc:
+        print(f"Could not open MujocoSession: {exc}", file=sys.stderr)
+        print(
+            "Tip: provide a compatible WholeBodyVLA ONNX model at "
+            "models/wholebody_vla/wholebody_vla_x2.onnx before running this example.",
+            file=sys.stderr,
+        )
+        return 1
+
+    state = session.reset()
+    print("Initial command:", state["command"])
+
+    action = sample_action()
+    state = session.step(action)
+    print("Updated command:", state["command"])
+    print("Joint targets preview:", (state.get("last_targets") or [])[:5])
+    return 0
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Demonstrate `robowbc.MujocoSession.step` with `kinematic_pose`."
+    )
+    parser.add_argument(
+        "--config",
+        default="configs/wholebody_vla_x2.toml",
+        help="Path to the WholeBodyVLA RoboWBC config (default: configs/wholebody_vla_x2.toml)",
+    )
+    args = parser.parse_args()
+    raise SystemExit(main(args.config))

--- a/scripts/python_sdk_smoke.py
+++ b/scripts/python_sdk_smoke.py
@@ -3,7 +3,15 @@
 
 from __future__ import annotations
 
-from robowbc import Observation, Registry
+from pathlib import Path
+
+from robowbc import (
+    KinematicPoseCommand,
+    LinkPose,
+    Observation,
+    Registry,
+    VelocityCommand,
+)
 
 
 def main() -> int:
@@ -11,16 +19,67 @@ def main() -> int:
     assert names, f"expected at least one policy, got: {names}"
     print("Registered policies:", names)
 
-    obs = Observation(
+    repo_root = Path(__file__).resolve().parents[1]
+    config_path = repo_root / "configs" / "decoupled_smoke.toml"
+
+    policy = Registry.build("decoupled_wbc", str(config_path))
+    capabilities = policy.capabilities()
+    assert hasattr(capabilities, "supported_commands"), capabilities
+    assert "velocity" in capabilities.supported_commands, capabilities
+    print("Policy capabilities:", capabilities.supported_commands)
+
+    structured_obs = Observation(
+        joint_positions=[0.0] * 4,
+        joint_velocities=[0.0] * 4,
+        gravity_vector=[0.0, 0.0, -1.0],
+        command=VelocityCommand(
+            linear=[0.2, 0.0, 0.0],
+            angular=[0.0, 0.0, 0.1],
+        ),
+    )
+    targets = policy.predict(structured_obs)
+    assert len(targets.positions) == 4, targets.positions
+    print("Structured velocity targets:", targets.positions)
+
+    legacy_obs = Observation(
         joint_positions=[0.0] * 4,
         joint_velocities=[0.0] * 4,
         gravity_vector=[0.0, 0.0, -1.0],
         command_type="motion_tokens",
         command_data=[0.1, 0.2],
     )
-    assert obs.joint_positions == [0.0] * 4
-    assert obs.command_type == "motion_tokens"
-    print("Observation:", obs)
+    assert legacy_obs.joint_positions == [0.0] * 4
+    assert legacy_obs.command_type == "motion_tokens"
+    assert len(legacy_obs.command_data) == 2
+    assert all(
+        abs(actual - expected) < 1e-6
+        for actual, expected in zip(legacy_obs.command_data, [0.1, 0.2], strict=True)
+    ), legacy_obs.command_data
+    print("Legacy observation:", legacy_obs)
+
+    manipulation_obs = Observation(
+        joint_positions=[0.0] * 4,
+        joint_velocities=[0.0] * 4,
+        gravity_vector=[0.0, 0.0, -1.0],
+        command=KinematicPoseCommand(
+            [
+                LinkPose(
+                    name="left_wrist",
+                    translation=[0.35, 0.20, 0.95],
+                    rotation_xyzw=[0.0, 0.0, 0.0, 1.0],
+                )
+            ]
+        ),
+    )
+    assert manipulation_obs.command_type == "kinematic_pose"
+    assert manipulation_obs.command.links[0].name == "left_wrist"
+    try:
+        _ = manipulation_obs.command_data
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("kinematic_pose should not expose flat command_data")
+    print("Structured manipulation observation:", manipulation_obs)
 
     try:
         Registry.build_from_str('[policy]\nname = "no_such_policy"')


### PR DESCRIPTION
## Summary
- add the embedded runtime capability contract and expose truthful policy capabilities through Rust and Python surfaces
- add structured Python command types, official locomotion/manipulation adapters, and the live kinematic-pose MuJoCo session example
- record the completed Phase 1 planning, validation, and summary artifacts for v0.2

## Verification
- cargo test --workspace --all-targets
- cargo clippy --workspace --all-targets -- -D warnings
- cargo doc --workspace --no-deps
- cargo fmt --all -- --check
- cargo test --manifest-path crates/robowbc-py/Cargo.toml -- --test-threads=1
- cargo clippy --manifest-path crates/robowbc-py/Cargo.toml --all-targets -- -D warnings
- cargo doc --manifest-path crates/robowbc-py/Cargo.toml --no-deps
- cargo fmt --manifest-path crates/robowbc-py/Cargo.toml --all -- --check
- make python-sdk-verify
- python3 -m py_compile crates/robowbc-py/examples/lerobot_adapter.py crates/robowbc-py/examples/manipulation_adapter.py examples/python/mujoco_kinematic_pose_session.py scripts/python_sdk_smoke.py