### PR TITLE
feat(teleop): keyboard teleop with crossterm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1696,6 +1696,15 @@ dependencies = [
 
 [[package]]
 name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "affbf0190ed2caf063e3def54ff444b449371d55c58e513a95ab98eca50adb49"
@@ -1889,9 +1898,13 @@ checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags 2.11.0",
  "crossterm_winapi",
+ "derive_more",
  "document-features",
+ "mio",
  "parking_lot",
  "rustix 1.1.4",
+ "signal-hook",
+ "signal-hook-mio",
  "winapi",
 ]
 
@@ -2738,6 +2751,28 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case 0.10.0",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
  "syn 2.0.117",
 ]
 
@@ -7376,7 +7411,7 @@ version = "0.31.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "805f4318a7d8ecdf97660906a81ad35dbb14158c33248241a3c9abb689aafce2"
 dependencies = [
- "convert_case",
+ "convert_case 0.11.0",
 ]
 
 [[package]]
@@ -9665,6 +9700,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "robowbc-teleop"
+version = "0.1.0"
+dependencies = [
+ "crossterm",
+ "robowbc-core",
+ "serde",
+ "thiserror 2.0.18",
+ "toml",
+]
+
+[[package]]
 name = "robowbc-transport"
 version = "0.1.0"
 dependencies = [
@@ -10289,6 +10335,27 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/robowbc-registry",
     "crates/robowbc-comm",
     "crates/robowbc-sim",
+    "crates/robowbc-teleop",
     "crates/robowbc-vis",
     "crates/robowbc-cli",
     "crates/robowbc-pyo3",

--- a/configs/teleop/keymap.toml
+++ b/configs/teleop/keymap.toml
@@ -1,0 +1,28 @@
+# Default keyboard teleop overlay for RoboWBC.
+#
+# This file is an OVERLAY: any commented-out entry falls back to the built-in
+# default. The defaults below match the rl_sar / GR00T conventions, kept as a
+# reference. Uncomment and edit any line to rebind that action.
+#
+# Recognized key specs:
+#   - single printable characters: "w", "]", "/", ...
+#   - "space" (case-insensitive)
+#   - "esc" / "escape"
+#   - "enter" / "return"
+#   - "tab"
+#   - "backspace"
+#
+# To use a non-default file, pass it to the runtime (FSM #126 wires the path
+# through the CLI config).
+
+# velocity_forward  = "w"
+# velocity_backward = "s"
+# velocity_left     = "a"
+# velocity_right    = "d"
+# yaw_left          = "q"
+# yaw_right         = "e"
+# zero_command      = "space"
+# emergency_stop    = "o"
+# engage            = "]"
+# reset             = "r"
+# quit              = "esc"

--- a/crates/robowbc-teleop/Cargo.toml
+++ b/crates/robowbc-teleop/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "robowbc-teleop"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+authors.workspace = true
+description = "Teleoperation input sources for RoboWBC (keyboard and beyond)"
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+robowbc-core = { path = "../robowbc-core" }
+crossterm = "0.29"
+serde = { workspace = true }
+toml = { workspace = true }
+thiserror = "2"
+
+[lints]
+workspace = true

--- a/crates/robowbc-teleop/examples/keyboard_demo.rs
+++ b/crates/robowbc-teleop/examples/keyboard_demo.rs
@@ -1,0 +1,47 @@
+//! Minimal smoke test for [`KeyboardTeleop`].
+//!
+//! Run with `cargo run -p robowbc-teleop --example keyboard_demo`. Press keys
+//! and watch the events stream out; press `Esc` to quit.
+//!
+//! Docker / non-interactive context note (per #127 acceptance criteria):
+//! the binary requires a real TTY. In `docker-compose.yml`, set
+//!
+//! ```yaml
+//! services:
+//!   robowbc:
+//!     tty: true
+//!     stdin_open: true
+//! ```
+//!
+//! and run with `docker compose run --rm robowbc <bin>` so the container
+//! attaches to your terminal. Without `tty: true`, [`enable_raw_mode`] errors
+//! with `Inappropriate ioctl for device`.
+
+use robowbc_teleop::{KeyboardTeleop, TeleopEvent, TeleopSource};
+use std::time::{Duration, Instant};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let mut teleop = KeyboardTeleop::new();
+    teleop.enable()?;
+
+    println!(
+        "robowbc-teleop demo — WSAD/QE for vel, space=zero, O=estop, ]=engage, R=reset, Esc=quit"
+    );
+
+    let tick = Duration::from_millis(20); // 50 Hz
+    let mut next = Instant::now() + tick;
+    loop {
+        for event in teleop.poll()? {
+            println!("{event:?}");
+            if matches!(event, TeleopEvent::Quit) {
+                teleop.disable()?;
+                return Ok(());
+            }
+        }
+        let now = Instant::now();
+        if now < next {
+            std::thread::sleep(next - now);
+        }
+        next += tick;
+    }
+}

--- a/crates/robowbc-teleop/src/keyboard.rs
+++ b/crates/robowbc-teleop/src/keyboard.rs
@@ -1,0 +1,430 @@
+//! Keyboard teleop source backed by [`crossterm`].
+//!
+//! [`KeyboardTeleop`] reads key events non-blockingly via
+//! [`crossterm::event::poll`]/[`crossterm::event::read`] and translates them
+//! through a [`KeymapConfig`] into [`TeleopEvent`]s. Velocity actions update
+//! an internal `(vx, vy, wz)` accumulator clamped to per-axis maxima; non-
+//! velocity actions (emergency stop, engage, reset, quit) emit one event each
+//! with no accumulator side-effect.
+//!
+//! # Threading
+//!
+//! [`KeyboardTeleop`] spawns no threads. The runtime FSM owns it and calls
+//! [`poll`](TeleopSource::poll) once per tick — this satisfies the issue's
+//! "no separate thread for input" acceptance criterion. Polling cost on an
+//! empty queue is dominated by a single [`crossterm::event::poll`] syscall
+//! with [`Duration::ZERO`].
+
+use crate::keymap::{KeymapConfig, TeleopAction};
+use crate::{TeleopError, TeleopEvent, TeleopSource};
+use crossterm::event::{poll, read, Event, KeyEvent, KeyEventKind};
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+use std::time::Duration;
+
+/// Maximum events drained per [`KeyboardTeleop::poll`] call so an avalanche
+/// of input cannot starve the FSM tick.
+const MAX_EVENTS_PER_POLL: usize = 64;
+
+/// Default linear-velocity step in m/s for one keypress.
+pub const DEFAULT_LINEAR_STEP_MPS: f32 = 0.1;
+/// Default yaw-rate step in rad/s for one keypress.
+pub const DEFAULT_YAW_STEP_RADPS: f32 = 0.2;
+/// Default linear-velocity clamp (per axis) in m/s.
+pub const DEFAULT_LINEAR_CLAMP_MPS: f32 = 1.0;
+/// Default yaw-rate clamp in rad/s.
+pub const DEFAULT_YAW_CLAMP_RADPS: f32 = 1.5;
+
+/// Configuration knobs for [`KeyboardTeleop`].
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct KeyboardTeleopConfig {
+    /// Linear velocity (vx, vy) step per keypress in m/s.
+    pub linear_step_mps: f32,
+    /// Yaw rate (wz) step per keypress in rad/s.
+    pub yaw_step_radps: f32,
+    /// Per-axis clamp for the linear velocity accumulator.
+    pub linear_clamp_mps: f32,
+    /// Clamp for the yaw-rate accumulator.
+    pub yaw_clamp_radps: f32,
+}
+
+impl Default for KeyboardTeleopConfig {
+    fn default() -> Self {
+        Self {
+            linear_step_mps: DEFAULT_LINEAR_STEP_MPS,
+            yaw_step_radps: DEFAULT_YAW_STEP_RADPS,
+            linear_clamp_mps: DEFAULT_LINEAR_CLAMP_MPS,
+            yaw_clamp_radps: DEFAULT_YAW_CLAMP_RADPS,
+        }
+    }
+}
+
+/// Cross-platform keyboard teleop source.
+#[derive(Debug)]
+pub struct KeyboardTeleop {
+    keymap: KeymapConfig,
+    cfg: KeyboardTeleopConfig,
+    vx: f32,
+    vy: f32,
+    wz: f32,
+    raw_mode_enabled: bool,
+}
+
+impl KeyboardTeleop {
+    /// Construct a [`KeyboardTeleop`] with the supplied keymap and config.
+    #[must_use]
+    pub fn with_config(keymap: KeymapConfig, cfg: KeyboardTeleopConfig) -> Self {
+        Self {
+            keymap,
+            cfg,
+            vx: 0.0,
+            vy: 0.0,
+            wz: 0.0,
+            raw_mode_enabled: false,
+        }
+    }
+
+    /// Construct with the default keymap and step/clamp values.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_config(KeymapConfig::default(), KeyboardTeleopConfig::default())
+    }
+
+    /// Current velocity-accumulator snapshot, useful for tests and
+    /// observability tooling.
+    #[must_use]
+    pub fn velocity(&self) -> (f32, f32, f32) {
+        (self.vx, self.vy, self.wz)
+    }
+
+    /// Translate one [`KeyEvent`] into a [`TeleopEvent`], updating any
+    /// internal accumulator state. Returns `None` for keys that are not
+    /// bound to any [`TeleopAction`] in the current keymap, or for non-press
+    /// events on terminals that emit them.
+    ///
+    /// This is the testable seam: callers can drive it from synthetic key
+    /// events without touching the terminal.
+    pub fn handle_key(&mut self, event: KeyEvent) -> Option<TeleopEvent> {
+        // Ignore release/repeat events — only act on Press. On terminals that
+        // do not enable kitty key-protocol, every event has kind Press, so
+        // this is a no-op there.
+        if !matches!(event.kind, KeyEventKind::Press) {
+            return None;
+        }
+        let action = self.keymap.lookup(event)?;
+        Some(self.apply_action(action))
+    }
+
+    fn apply_action(&mut self, action: TeleopAction) -> TeleopEvent {
+        match action {
+            TeleopAction::VelocityForward => {
+                self.vx = clamp_step(
+                    self.vx + self.cfg.linear_step_mps,
+                    self.cfg.linear_clamp_mps,
+                );
+                self.velocity_event()
+            }
+            TeleopAction::VelocityBackward => {
+                self.vx = clamp_step(
+                    self.vx - self.cfg.linear_step_mps,
+                    self.cfg.linear_clamp_mps,
+                );
+                self.velocity_event()
+            }
+            TeleopAction::VelocityLeft => {
+                self.vy = clamp_step(
+                    self.vy + self.cfg.linear_step_mps,
+                    self.cfg.linear_clamp_mps,
+                );
+                self.velocity_event()
+            }
+            TeleopAction::VelocityRight => {
+                self.vy = clamp_step(
+                    self.vy - self.cfg.linear_step_mps,
+                    self.cfg.linear_clamp_mps,
+                );
+                self.velocity_event()
+            }
+            TeleopAction::YawLeft => {
+                self.wz = clamp_step(self.wz + self.cfg.yaw_step_radps, self.cfg.yaw_clamp_radps);
+                self.velocity_event()
+            }
+            TeleopAction::YawRight => {
+                self.wz = clamp_step(self.wz - self.cfg.yaw_step_radps, self.cfg.yaw_clamp_radps);
+                self.velocity_event()
+            }
+            TeleopAction::ZeroCommand => {
+                self.vx = 0.0;
+                self.vy = 0.0;
+                self.wz = 0.0;
+                self.velocity_event()
+            }
+            TeleopAction::EmergencyStop => {
+                // The FSM is responsible for reacting; we still flush our
+                // accumulator so that on resume the operator is not surprised
+                // by stale velocity.
+                self.vx = 0.0;
+                self.vy = 0.0;
+                self.wz = 0.0;
+                TeleopEvent::EmergencyStop
+            }
+            TeleopAction::Engage => TeleopEvent::Engage,
+            TeleopAction::Reset => {
+                self.vx = 0.0;
+                self.vy = 0.0;
+                self.wz = 0.0;
+                TeleopEvent::Reset
+            }
+            TeleopAction::Quit => TeleopEvent::Quit,
+        }
+    }
+
+    fn velocity_event(&self) -> TeleopEvent {
+        TeleopEvent::Velocity {
+            vx: self.vx,
+            vy: self.vy,
+            wz: self.wz,
+        }
+    }
+}
+
+impl Default for KeyboardTeleop {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TeleopSource for KeyboardTeleop {
+    fn enable(&mut self) -> Result<(), TeleopError> {
+        if self.raw_mode_enabled {
+            return Ok(());
+        }
+        enable_raw_mode().map_err(TeleopError::RawMode)?;
+        self.raw_mode_enabled = true;
+        Ok(())
+    }
+
+    fn disable(&mut self) -> Result<(), TeleopError> {
+        if !self.raw_mode_enabled {
+            return Ok(());
+        }
+        disable_raw_mode().map_err(TeleopError::RawMode)?;
+        self.raw_mode_enabled = false;
+        Ok(())
+    }
+
+    fn poll(&mut self) -> Result<Vec<TeleopEvent>, TeleopError> {
+        // Drain everything queued; stop when the next poll says nothing is
+        // ready. Bounded to a generous per-tick cap so an avalanche of input
+        // (e.g. the user mashes a key) cannot starve the FSM tick.
+        let mut events = Vec::new();
+        for _ in 0..MAX_EVENTS_PER_POLL {
+            if !poll(Duration::ZERO).map_err(TeleopError::Read)? {
+                break;
+            }
+            let raw = read().map_err(TeleopError::Read)?;
+            if let Event::Key(key) = raw {
+                if let Some(event) = self.handle_key(key) {
+                    events.push(event);
+                }
+            }
+        }
+        Ok(events)
+    }
+}
+
+impl Drop for KeyboardTeleop {
+    fn drop(&mut self) {
+        // Best-effort cleanup so a panic anywhere in the runtime does not
+        // leave the user's terminal in raw mode.
+        if self.raw_mode_enabled {
+            let _ = disable_raw_mode();
+            self.raw_mode_enabled = false;
+        }
+    }
+}
+
+fn clamp_step(value: f32, clamp: f32) -> f32 {
+    let abs_clamp = clamp.abs();
+    value.clamp(-abs_clamp, abs_clamp)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyCode, KeyEventKind, KeyEventState, KeyModifiers};
+    use std::time::Instant;
+
+    fn key_press(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    #[test]
+    fn forward_keypress_increments_vx() {
+        let mut teleop = KeyboardTeleop::new();
+        let event = teleop
+            .handle_key(key_press(KeyCode::Char('w')))
+            .expect("should produce velocity event");
+        match event {
+            TeleopEvent::Velocity { vx, vy, wz } => {
+                assert!((vx - DEFAULT_LINEAR_STEP_MPS).abs() < 1e-6);
+                assert!(vy.abs() < 1e-6);
+                assert!(wz.abs() < 1e-6);
+            }
+            other => panic!("expected Velocity, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn opposing_keypresses_cancel_to_zero() {
+        let mut teleop = KeyboardTeleop::new();
+        teleop.handle_key(key_press(KeyCode::Char('w')));
+        let after_back = teleop
+            .handle_key(key_press(KeyCode::Char('s')))
+            .expect("event");
+        let TeleopEvent::Velocity { vx, .. } = after_back else {
+            panic!("expected Velocity");
+        };
+        assert!(vx.abs() < 1e-6);
+    }
+
+    #[test]
+    fn space_zeroes_all_axes() {
+        let mut teleop = KeyboardTeleop::new();
+        for _ in 0..3 {
+            teleop.handle_key(key_press(KeyCode::Char('w')));
+            teleop.handle_key(key_press(KeyCode::Char('a')));
+            teleop.handle_key(key_press(KeyCode::Char('q')));
+        }
+        let event = teleop.handle_key(key_press(KeyCode::Char(' '))).unwrap();
+        match event {
+            TeleopEvent::Velocity { vx, vy, wz } => {
+                assert!(vx.abs() < 1e-6);
+                assert!(vy.abs() < 1e-6);
+                assert!(wz.abs() < 1e-6);
+            }
+            other => panic!("expected Velocity, got {other:?}"),
+        }
+        assert_eq!(teleop.velocity(), (0.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn emergency_stop_emits_estop_and_clears_accumulator() {
+        let mut teleop = KeyboardTeleop::new();
+        teleop.handle_key(key_press(KeyCode::Char('w'))); // vx > 0
+        let event = teleop.handle_key(key_press(KeyCode::Char('o'))).unwrap();
+        assert_eq!(event, TeleopEvent::EmergencyStop);
+        assert_eq!(teleop.velocity(), (0.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn engage_does_not_clear_accumulator() {
+        let mut teleop = KeyboardTeleop::new();
+        teleop.handle_key(key_press(KeyCode::Char('w')));
+        let pre = teleop.velocity();
+        let event = teleop.handle_key(key_press(KeyCode::Char(']'))).unwrap();
+        assert_eq!(event, TeleopEvent::Engage);
+        assert_eq!(teleop.velocity(), pre);
+    }
+
+    #[test]
+    fn reset_emits_reset_and_clears_accumulator() {
+        let mut teleop = KeyboardTeleop::new();
+        teleop.handle_key(key_press(KeyCode::Char('a')));
+        let event = teleop.handle_key(key_press(KeyCode::Char('r'))).unwrap();
+        assert_eq!(event, TeleopEvent::Reset);
+        assert_eq!(teleop.velocity(), (0.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn esc_emits_quit() {
+        let mut teleop = KeyboardTeleop::new();
+        let event = teleop.handle_key(key_press(KeyCode::Esc)).unwrap();
+        assert_eq!(event, TeleopEvent::Quit);
+    }
+
+    #[test]
+    fn unbound_keys_are_dropped() {
+        let mut teleop = KeyboardTeleop::new();
+        assert!(teleop.handle_key(key_press(KeyCode::Char('x'))).is_none());
+        assert!(teleop.handle_key(key_press(KeyCode::Tab)).is_none());
+    }
+
+    #[test]
+    fn release_events_are_ignored() {
+        let mut teleop = KeyboardTeleop::new();
+        let release = KeyEvent {
+            code: KeyCode::Char('w'),
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Release,
+            state: KeyEventState::NONE,
+        };
+        assert!(teleop.handle_key(release).is_none());
+        assert_eq!(teleop.velocity(), (0.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn repeated_forward_clamps_to_linear_clamp() {
+        let mut teleop = KeyboardTeleop::with_config(
+            KeymapConfig::default(),
+            KeyboardTeleopConfig {
+                linear_step_mps: 0.5,
+                linear_clamp_mps: 1.0,
+                ..KeyboardTeleopConfig::default()
+            },
+        );
+        for _ in 0..10 {
+            teleop.handle_key(key_press(KeyCode::Char('w')));
+        }
+        let (vx, _, _) = teleop.velocity();
+        assert!(
+            (vx - 1.0).abs() < 1e-6,
+            "vx should clamp to linear_clamp_mps, got {vx}"
+        );
+    }
+
+    #[test]
+    fn yaw_clamp_is_independent_of_linear_clamp() {
+        let mut teleop = KeyboardTeleop::with_config(
+            KeymapConfig::default(),
+            KeyboardTeleopConfig {
+                yaw_step_radps: 0.5,
+                yaw_clamp_radps: 1.0,
+                ..KeyboardTeleopConfig::default()
+            },
+        );
+        for _ in 0..10 {
+            teleop.handle_key(key_press(KeyCode::Char('q')));
+        }
+        let (_, _, wz) = teleop.velocity();
+        assert!((wz - 1.0).abs() < 1e-6, "wz should clamp to 1.0, got {wz}");
+    }
+
+    /// Latency budget: from the issue's acceptance criteria, a keypress must
+    /// yield a teleop event in <30 ms p99. We measure `handle_key` (the only
+    /// non-trivial work in the press → event path; `crossterm::event::read`
+    /// is a syscall on a `pipe(2)`/`read(2)` boundary that is dominated by
+    /// kernel scheduling, not by us). 1024 events × <30 ms p99 should be
+    /// many orders of magnitude under budget.
+    #[test]
+    fn handle_key_latency_is_well_under_30ms() {
+        let mut teleop = KeyboardTeleop::new();
+        let mut samples = Vec::with_capacity(1024);
+        for _ in 0..1024 {
+            let start = Instant::now();
+            teleop.handle_key(key_press(KeyCode::Char('w')));
+            samples.push(start.elapsed());
+        }
+        samples.sort();
+        // p99 = sample[1013] for n=1024.
+        let p99 = samples[1013];
+        assert!(
+            p99 < Duration::from_millis(30),
+            "handle_key p99 {p99:?} exceeds 30 ms budget"
+        );
+    }
+}

--- a/crates/robowbc-teleop/src/keymap.rs
+++ b/crates/robowbc-teleop/src/keymap.rs
@@ -1,0 +1,433 @@
+//! Configurable mapping from physical keys to teleop actions.
+//!
+//! The mapping is loaded as a TOML overlay on the built-in defaults — any
+//! action _not_ specified in the user's `keymap.toml` falls back to its
+//! default key. This matches the `rl_sar` / `GR00T` muscle-memory bindings out of
+//! the box while letting users rebind individual keys (e.g. swap `Esc` →
+//! `Ctrl-C` for users who want to keep `Esc` for VIM-style mode-switch
+//! workflows).
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::path::Path;
+
+/// High-level teleop intents, decoupled from physical keys.
+///
+/// The FSM consumes [`TeleopEvent`](crate::TeleopEvent)s, not actions —
+/// actions are an internal step inside [`KeyboardTeleop`](crate::KeyboardTeleop)
+/// that records "the user wants to nudge vx forward" before the source
+/// folds it into its accumulator.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TeleopAction {
+    /// Increase forward (vx) velocity by [`KeyboardTeleop`](crate::KeyboardTeleop)'s `linear_step_mps`.
+    VelocityForward,
+    /// Decrease forward (vx) velocity (i.e. nudge backward).
+    VelocityBackward,
+    /// Increase left (vy) velocity.
+    VelocityLeft,
+    /// Decrease left (vy) velocity (i.e. nudge right).
+    VelocityRight,
+    /// Increase yaw rate (wz) — rotate left / counter-clockwise from above.
+    YawLeft,
+    /// Decrease yaw rate — rotate right / clockwise from above.
+    YawRight,
+    /// Snap velocity command to zero in all three axes.
+    ZeroCommand,
+    /// Hard emergency stop (FSM goes to damping).
+    EmergencyStop,
+    /// Engage policy: skip the remainder of `RL_Init`.
+    Engage,
+    /// Re-enter `RL_Init` / interpolate back to `default_dof_pos`.
+    Reset,
+    /// Quit the runtime gracefully.
+    Quit,
+}
+
+/// Parse error for [`KeymapConfig::from_toml_str`].
+#[derive(Debug, thiserror::Error)]
+pub enum KeymapError {
+    /// The TOML body could not be parsed.
+    #[error("invalid TOML: {0}")]
+    Toml(#[from] toml::de::Error),
+    /// One of the action → key strings did not resolve to a known
+    /// [`KeyCode`].
+    #[error("unknown key spec '{spec}' for action {action:?}")]
+    UnknownKey {
+        /// The action whose binding could not be resolved.
+        action: TeleopAction,
+        /// The raw spec string the user provided.
+        spec: String,
+    },
+    /// The TOML file could not be read from disk.
+    #[error("failed to read keymap file: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+/// User-facing TOML schema for keymap overlays.
+///
+/// Every field is `Option<String>`; missing fields fall back to the built-in
+/// default. This means a `keymap.toml` containing only the fields the user
+/// wants to change is enough — no need to list every action.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields, default)]
+pub struct KeymapOverlay {
+    /// Spec for [`TeleopAction::VelocityForward`].
+    pub velocity_forward: Option<String>,
+    /// Spec for [`TeleopAction::VelocityBackward`].
+    pub velocity_backward: Option<String>,
+    /// Spec for [`TeleopAction::VelocityLeft`].
+    pub velocity_left: Option<String>,
+    /// Spec for [`TeleopAction::VelocityRight`].
+    pub velocity_right: Option<String>,
+    /// Spec for [`TeleopAction::YawLeft`].
+    pub yaw_left: Option<String>,
+    /// Spec for [`TeleopAction::YawRight`].
+    pub yaw_right: Option<String>,
+    /// Spec for [`TeleopAction::ZeroCommand`].
+    pub zero_command: Option<String>,
+    /// Spec for [`TeleopAction::EmergencyStop`].
+    pub emergency_stop: Option<String>,
+    /// Spec for [`TeleopAction::Engage`].
+    pub engage: Option<String>,
+    /// Spec for [`TeleopAction::Reset`].
+    pub reset: Option<String>,
+    /// Spec for [`TeleopAction::Quit`].
+    pub quit: Option<String>,
+}
+
+/// Resolved key-to-action mapping used by [`KeyboardTeleop`](crate::KeyboardTeleop).
+///
+/// Lookups are case-insensitive on character keys (`Q` and `q` map to the
+/// same action), and `Ctrl`/`Shift`/`Alt` modifiers are ignored so e.g.
+/// holding shift while pressing `W` still triggers
+/// [`TeleopAction::VelocityForward`]. This matches typical robotics-teleop
+/// expectations: the operator should not lose their command because they
+/// accidentally bumped a modifier key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KeymapConfig {
+    bindings: HashMap<NormalizedKey, TeleopAction>,
+}
+
+impl Default for KeymapConfig {
+    fn default() -> Self {
+        let pairs: &[(KeyCode, TeleopAction)] = &[
+            (KeyCode::Char('w'), TeleopAction::VelocityForward),
+            (KeyCode::Char('s'), TeleopAction::VelocityBackward),
+            (KeyCode::Char('a'), TeleopAction::VelocityLeft),
+            (KeyCode::Char('d'), TeleopAction::VelocityRight),
+            (KeyCode::Char('q'), TeleopAction::YawLeft),
+            (KeyCode::Char('e'), TeleopAction::YawRight),
+            (KeyCode::Char(' '), TeleopAction::ZeroCommand),
+            (KeyCode::Char('o'), TeleopAction::EmergencyStop),
+            (KeyCode::Char(']'), TeleopAction::Engage),
+            (KeyCode::Char('r'), TeleopAction::Reset),
+            (KeyCode::Esc, TeleopAction::Quit),
+        ];
+        let mut bindings = HashMap::with_capacity(pairs.len());
+        for (code, action) in pairs {
+            bindings.insert(NormalizedKey::from_code(*code), *action);
+        }
+        Self { bindings }
+    }
+}
+
+impl KeymapConfig {
+    /// Returns the action bound to `event`, if any. Modifiers other than
+    /// `Shift` (which is folded into the character casing) are ignored.
+    #[must_use]
+    pub fn lookup(&self, event: KeyEvent) -> Option<TeleopAction> {
+        self.bindings
+            .get(&NormalizedKey::from_event(event))
+            .copied()
+    }
+
+    /// Apply an overlay on top of the built-in default mapping.
+    ///
+    /// Each `Some` field in `overlay` rebinds that action to the supplied
+    /// key spec; the action's previous binding is removed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KeymapError::UnknownKey`] if any spec in the overlay does
+    /// not resolve to a [`KeyCode`].
+    pub fn with_overlay(mut self, overlay: &KeymapOverlay) -> Result<Self, KeymapError> {
+        let mappings: &[(TeleopAction, &Option<String>)] = &[
+            (TeleopAction::VelocityForward, &overlay.velocity_forward),
+            (TeleopAction::VelocityBackward, &overlay.velocity_backward),
+            (TeleopAction::VelocityLeft, &overlay.velocity_left),
+            (TeleopAction::VelocityRight, &overlay.velocity_right),
+            (TeleopAction::YawLeft, &overlay.yaw_left),
+            (TeleopAction::YawRight, &overlay.yaw_right),
+            (TeleopAction::ZeroCommand, &overlay.zero_command),
+            (TeleopAction::EmergencyStop, &overlay.emergency_stop),
+            (TeleopAction::Engage, &overlay.engage),
+            (TeleopAction::Reset, &overlay.reset),
+            (TeleopAction::Quit, &overlay.quit),
+        ];
+
+        for (action, spec) in mappings {
+            let Some(spec_str) = spec.as_deref() else {
+                continue;
+            };
+            let code = parse_key_spec(spec_str).ok_or_else(|| KeymapError::UnknownKey {
+                action: *action,
+                spec: spec_str.to_owned(),
+            })?;
+            self.bindings.retain(|_, existing| existing != action);
+            self.bindings
+                .insert(NormalizedKey::from_code(code), *action);
+        }
+        Ok(self)
+    }
+
+    /// Parse a TOML overlay and apply it to the default mapping.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KeymapError::Toml`] for malformed TOML or
+    /// [`KeymapError::UnknownKey`] for unrecognized key specs.
+    pub fn from_toml_str(s: &str) -> Result<Self, KeymapError> {
+        let overlay: KeymapOverlay = toml::from_str(s)?;
+        Self::default().with_overlay(&overlay)
+    }
+
+    /// Convenience helper — read TOML from disk and parse via
+    /// [`Self::from_toml_str`].
+    ///
+    /// # Errors
+    ///
+    /// Returns [`KeymapError::Io`] on file-read failure, or any error from
+    /// [`Self::from_toml_str`].
+    pub fn from_toml_file(path: &Path) -> Result<Self, KeymapError> {
+        let body = std::fs::read_to_string(path)?;
+        Self::from_toml_str(&body)
+    }
+}
+
+/// Internal key shape used as a [`HashMap`] key. Folds shift state into the
+/// `KeyCode::Char` casing and discards `Ctrl`/`Alt`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct NormalizedKey {
+    code: KeyCode,
+}
+
+impl NormalizedKey {
+    fn from_code(code: KeyCode) -> Self {
+        Self {
+            code: normalize_code(code),
+        }
+    }
+
+    fn from_event(event: KeyEvent) -> Self {
+        // Crossterm reports `KeyEvent { code: Char('A'), modifiers: SHIFT }`
+        // when the user holds shift. Some terminals report `Char('a')` even
+        // for shifted alpha keys with the SHIFT modifier set — handle both.
+        let code = match (event.code, event.modifiers.contains(KeyModifiers::SHIFT)) {
+            (KeyCode::Char(c), true) => KeyCode::Char(c.to_ascii_lowercase()),
+            (other, _) => other,
+        };
+        Self {
+            code: normalize_code(code),
+        }
+    }
+}
+
+fn normalize_code(code: KeyCode) -> KeyCode {
+    match code {
+        KeyCode::Char(c) => KeyCode::Char(c.to_ascii_lowercase()),
+        other => other,
+    }
+}
+
+/// Parse a TOML string spec into a [`KeyCode`]. Recognizes:
+///
+/// - single printable characters: `"w"`, `"]"`, `" "`, …
+/// - the literal `"space"` (case-insensitive) for the space key
+/// - `"esc"` / `"escape"` for [`KeyCode::Esc`]
+/// - `"enter"` / `"return"` for [`KeyCode::Enter`]
+/// - `"tab"` for [`KeyCode::Tab`]
+/// - `"backspace"` for [`KeyCode::Backspace`]
+fn parse_key_spec(spec: &str) -> Option<KeyCode> {
+    let trimmed = spec.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    match trimmed.to_ascii_lowercase().as_str() {
+        "space" => Some(KeyCode::Char(' ')),
+        "esc" | "escape" => Some(KeyCode::Esc),
+        "enter" | "return" => Some(KeyCode::Enter),
+        "tab" => Some(KeyCode::Tab),
+        "backspace" => Some(KeyCode::Backspace),
+        _ => {
+            let mut chars = trimmed.chars();
+            let first = chars.next()?;
+            if chars.next().is_some() {
+                return None;
+            }
+            Some(KeyCode::Char(first))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crossterm::event::{KeyEventKind, KeyEventState};
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent {
+            code,
+            modifiers: KeyModifiers::NONE,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        }
+    }
+
+    #[test]
+    fn default_mapping_covers_all_actions() {
+        let map = KeymapConfig::default();
+        assert_eq!(
+            map.lookup(key(KeyCode::Char('w'))),
+            Some(TeleopAction::VelocityForward)
+        );
+        assert_eq!(
+            map.lookup(key(KeyCode::Char('s'))),
+            Some(TeleopAction::VelocityBackward)
+        );
+        assert_eq!(
+            map.lookup(key(KeyCode::Char('a'))),
+            Some(TeleopAction::VelocityLeft)
+        );
+        assert_eq!(
+            map.lookup(key(KeyCode::Char('d'))),
+            Some(TeleopAction::VelocityRight)
+        );
+        assert_eq!(
+            map.lookup(key(KeyCode::Char('q'))),
+            Some(TeleopAction::YawLeft)
+        );
+        assert_eq!(
+            map.lookup(key(KeyCode::Char('e'))),
+            Some(TeleopAction::YawRight)
+        );
+        assert_eq!(
+            map.lookup(key(KeyCode::Char(' '))),
+            Some(TeleopAction::ZeroCommand)
+        );
+        assert_eq!(
+            map.lookup(key(KeyCode::Char('o'))),
+            Some(TeleopAction::EmergencyStop)
+        );
+        assert_eq!(
+            map.lookup(key(KeyCode::Char(']'))),
+            Some(TeleopAction::Engage)
+        );
+        assert_eq!(
+            map.lookup(key(KeyCode::Char('r'))),
+            Some(TeleopAction::Reset)
+        );
+        assert_eq!(map.lookup(key(KeyCode::Esc)), Some(TeleopAction::Quit));
+    }
+
+    #[test]
+    fn shifted_alpha_keys_resolve_same_as_lowercase() {
+        let map = KeymapConfig::default();
+        let shifted = KeyEvent {
+            code: KeyCode::Char('W'),
+            modifiers: KeyModifiers::SHIFT,
+            kind: KeyEventKind::Press,
+            state: KeyEventState::NONE,
+        };
+        assert_eq!(map.lookup(shifted), Some(TeleopAction::VelocityForward));
+    }
+
+    #[test]
+    fn unknown_keys_are_unmapped() {
+        let map = KeymapConfig::default();
+        assert_eq!(map.lookup(key(KeyCode::Char('x'))), None);
+        assert_eq!(map.lookup(key(KeyCode::Tab)), None);
+    }
+
+    #[test]
+    fn overlay_rebinds_a_single_action_without_dropping_others() {
+        let overlay = KeymapOverlay {
+            quit: Some("backspace".to_owned()),
+            ..KeymapOverlay::default()
+        };
+        let map = KeymapConfig::default()
+            .with_overlay(&overlay)
+            .expect("overlay should apply");
+        assert_eq!(
+            map.lookup(key(KeyCode::Backspace)),
+            Some(TeleopAction::Quit)
+        );
+        // Esc no longer maps to anything because Quit moved off it.
+        assert_eq!(map.lookup(key(KeyCode::Esc)), None);
+        // Other defaults are intact.
+        assert_eq!(
+            map.lookup(key(KeyCode::Char('w'))),
+            Some(TeleopAction::VelocityForward)
+        );
+    }
+
+    #[test]
+    fn overlay_with_unknown_spec_is_an_error() {
+        let overlay = KeymapOverlay {
+            quit: Some("not-a-key".to_owned()),
+            ..KeymapOverlay::default()
+        };
+        let err = KeymapConfig::default()
+            .with_overlay(&overlay)
+            .expect_err("should fail");
+        match err {
+            KeymapError::UnknownKey { action, spec } => {
+                assert_eq!(action, TeleopAction::Quit);
+                assert_eq!(spec, "not-a-key");
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn from_toml_str_round_trips_a_minimal_overlay() {
+        let toml_body = r#"
+            quit = "q"
+            yaw_left = "["
+        "#;
+        let map = KeymapConfig::from_toml_str(toml_body).expect("toml should parse");
+        // Quit moves to 'q'.
+        assert_eq!(
+            map.lookup(key(KeyCode::Char('q'))),
+            Some(TeleopAction::Quit)
+        );
+        // YawLeft moves to '['.
+        assert_eq!(
+            map.lookup(key(KeyCode::Char('['))),
+            Some(TeleopAction::YawLeft)
+        );
+        // The two old defaults — KeyCode::Esc for Quit and 'q' for YawLeft —
+        // are gone.
+        assert_eq!(map.lookup(key(KeyCode::Esc)), None);
+        // VelocityForward stays on 'w'.
+        assert_eq!(
+            map.lookup(key(KeyCode::Char('w'))),
+            Some(TeleopAction::VelocityForward)
+        );
+    }
+
+    #[test]
+    fn parse_key_spec_handles_named_and_literal_keys() {
+        assert_eq!(parse_key_spec("space"), Some(KeyCode::Char(' ')));
+        assert_eq!(parse_key_spec("SPACE"), Some(KeyCode::Char(' ')));
+        assert_eq!(parse_key_spec("esc"), Some(KeyCode::Esc));
+        assert_eq!(parse_key_spec("escape"), Some(KeyCode::Esc));
+        assert_eq!(parse_key_spec("enter"), Some(KeyCode::Enter));
+        assert_eq!(parse_key_spec("tab"), Some(KeyCode::Tab));
+        assert_eq!(parse_key_spec("w"), Some(KeyCode::Char('w')));
+        assert_eq!(parse_key_spec("]"), Some(KeyCode::Char(']')));
+        assert_eq!(parse_key_spec(""), None);
+        assert_eq!(parse_key_spec("ww"), None);
+    }
+}

--- a/crates/robowbc-teleop/src/lib.rs
+++ b/crates/robowbc-teleop/src/lib.rs
@@ -1,0 +1,165 @@
+//! Teleoperation input sources for `RoboWBC`.
+//!
+//! The runtime FSM (#126) calls a [`TeleopSource`] once per control tick to
+//! drain user-driven events such as velocity-command updates, emergency-stop,
+//! and policy-engage signals. v1 ships exactly one source — [`KeyboardTeleop`]
+//! — backed by [`crossterm`] for cross-platform non-blocking key reads.
+//!
+//! # Architecture
+//!
+//! ```text
+//!  user ──key── crossterm ──> KeyboardTeleop ──TeleopEvent──> FSM
+//!                              ^                              │
+//!                              └────── KeymapConfig ──────────┘
+//! ```
+//!
+//! Adding a new source (gamepad, ROS 2 `cmd_vel`, web teleop) is non-breaking:
+//! implement [`TeleopSource`] and the FSM picks it up unchanged.
+//!
+//! # Tick-driven polling
+//!
+//! Per the issue's acceptance criteria, the source must not spawn a separate
+//! input thread — it polls non-blockingly on the FSM's tick (typically 500 Hz
+//! for the control loop, or whatever runtime frequency is configured). Each
+//! call drains any queued key events and returns them as a `Vec<TeleopEvent>`.
+
+pub mod keyboard;
+pub mod keymap;
+
+use robowbc_core::{Twist, WbcCommand};
+
+pub use keyboard::KeyboardTeleop;
+pub use keymap::{KeymapConfig, KeymapError, TeleopAction};
+
+/// Errors that can be returned by a [`TeleopSource`].
+#[derive(Debug, thiserror::Error)]
+pub enum TeleopError {
+    /// The terminal could not be put into raw mode (typically: not a TTY).
+    #[error("terminal raw-mode setup failed: {0}")]
+    RawMode(#[source] std::io::Error),
+    /// Reading or polling the input device failed.
+    #[error("teleop input read failed: {0}")]
+    Read(#[source] std::io::Error),
+}
+
+/// Single discrete event produced by a [`TeleopSource`].
+///
+/// One physical keypress maps to at most one event. The FSM treats events as
+/// _intents_ — most are advisory (e.g. velocity updates), but
+/// [`TeleopEvent::EmergencyStop`] is a hard signal that must transition the
+/// FSM to its damping state regardless of any other input.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum TeleopEvent {
+    /// Updated absolute velocity command in the robot body frame.
+    ///
+    /// `vx` and `vy` are linear m/s, `wz` is yaw rad/s. The receiver should
+    /// replace its previous velocity command in full — these values are
+    /// snapshots of the source's internal accumulator, not deltas.
+    Velocity {
+        /// Forward (+) / backward (−) linear velocity, m/s.
+        vx: f32,
+        /// Left (+) / right (−) linear velocity, m/s.
+        vy: f32,
+        /// Yaw rate, rad/s (positive = CCW from above).
+        wz: f32,
+    },
+    /// Hard emergency stop. FSM should transition to damping.
+    ///
+    /// Matches GR00T's `O` key convention.
+    EmergencyStop,
+    /// Engage the policy (exit `RL_Init` early).
+    ///
+    /// Matches GR00T's `]` key convention.
+    Engage,
+    /// Return to the configured `default_dof_pos` (re-enter `RL_Init`).
+    Reset,
+    /// Quit the runtime gracefully.
+    Quit,
+}
+
+impl TeleopEvent {
+    /// Convert a velocity event into the [`WbcCommand::Velocity`] payload the
+    /// runtime feeds into [`Observation`](robowbc_core::Observation). Returns
+    /// `None` for non-velocity events (which should be handled by the FSM
+    /// directly, not pushed into observations).
+    #[must_use]
+    pub fn to_wbc_command(self) -> Option<WbcCommand> {
+        match self {
+            Self::Velocity { vx, vy, wz } => Some(WbcCommand::Velocity(Twist {
+                linear: [vx, vy, 0.0],
+                angular: [0.0, 0.0, wz],
+            })),
+            Self::EmergencyStop | Self::Engage | Self::Reset | Self::Quit => None,
+        }
+    }
+}
+
+/// Abstract teleop input source.
+///
+/// Implementations must be [`Send`] so the runtime can move them across
+/// threads at startup, but they do _not_ need to be [`Sync`] — the FSM owns a
+/// single source and calls [`poll`](Self::poll) once per tick.
+pub trait TeleopSource: Send {
+    /// Acquire any OS-level state needed to read inputs (e.g. raw terminal
+    /// mode). Called once at FSM startup.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TeleopError::RawMode`] if the underlying terminal cannot be
+    /// configured (typically because stdin is not a TTY).
+    fn enable(&mut self) -> Result<(), TeleopError>;
+
+    /// Restore the OS state changed by [`enable`](Self::enable). Called once
+    /// at FSM shutdown. Must be idempotent and safe to call from a panic
+    /// handler — implementations should swallow inner I/O errors and only
+    /// return the first one observed.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TeleopError::RawMode`] if disabling raw mode fails.
+    fn disable(&mut self) -> Result<(), TeleopError>;
+
+    /// Drain pending input events and return them in arrival order.
+    ///
+    /// MUST be non-blocking. If no events are pending, returns
+    /// `Ok(Vec::new())` immediately.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`TeleopError::Read`] if reading the input device fails.
+    fn poll(&mut self) -> Result<Vec<TeleopEvent>, TeleopError>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn velocity_event_round_trips_into_wbc_command() {
+        let event = TeleopEvent::Velocity {
+            vx: 0.4,
+            vy: -0.1,
+            wz: 0.3,
+        };
+        let cmd = event.to_wbc_command().expect("velocity should map");
+        match cmd {
+            WbcCommand::Velocity(twist) => {
+                assert!((twist.linear[0] - 0.4).abs() < 1e-6);
+                assert!((twist.linear[1] - (-0.1)).abs() < 1e-6);
+                assert!(twist.linear[2].abs() < 1e-6);
+                assert!(twist.angular[0].abs() < 1e-6);
+                assert!(twist.angular[1].abs() < 1e-6);
+                assert!((twist.angular[2] - 0.3).abs() < 1e-6);
+            }
+            other => panic!("expected Velocity, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn non_velocity_events_do_not_produce_wbc_commands() {
+        assert!(TeleopEvent::EmergencyStop.to_wbc_command().is_none());
+        assert!(TeleopEvent::Engage.to_wbc_command().is_none());
+        assert!(TeleopEvent::Reset.to_wbc_command().is_none());
+        assert!(TeleopEvent::Quit.to_wbc_command().is_none());
+    }
+}


### PR DESCRIPTION
## What

Adds `crates/robowbc-teleop/` — the v1 teleop input crate that the runtime FSM (#126) consumes to drain user-driven velocity / e-stop / engage / reset / quit signals.

Surface:

- **`TeleopSource`** trait with `enable` / `disable` / `poll` (non-blocking, called once per FSM tick — no separate input thread).
- **`TeleopEvent`** enum: `Velocity { vx, vy, wz }`, `EmergencyStop`, `Engage`, `Reset`, `Quit`. `to_wbc_command()` lifts velocity events into the existing `WbcCommand::Velocity(Twist { … })` shape.
- **`KeyboardTeleop`** backed by `crossterm` 0.29: maintains a clamped `(vx, vy, wz)` accumulator, drains queued events bounded at 64 per `poll` so input avalanches cannot starve the FSM tick. `Drop` restores the terminal even on panic.
- **`KeymapConfig` + `KeymapOverlay`**: GR00T-compatible defaults (W/S/A/D/Q/E for velocity, `Space`=zero, `O`=estop, `]`=engage, `R`=reset, `Esc`=quit) with TOML overlay parsing for individual rebinds. Modifiers other than `Shift` (folded into casing) are ignored.
- **`configs/teleop/keymap.toml`** — documented example overlay file.
- **`keyboard_demo`** example — documents the docker `tty: true` + `stdin_open: true` requirement (Caveat #10 in the merged tech report) inline.

## Why

Refs #127. From the issue: *"the first (and for v1, only) teleop input source. Uses `crossterm` for cross-platform non-blocking key reads."* Adding a new source (gamepad, ROS 2 cmd_vel, web teleop) is non-breaking — just a new `TeleopSource` impl.

## Acceptance criteria status

- [x] `TeleopSource` trait with one impl: `KeyboardTeleop`
- [x] Non-blocking poll at the FSM's tick rate, no separate thread for input — `poll(Duration::ZERO)` per call, no `thread::spawn` anywhere in the crate
- [x] Key map configurable via `keymap.toml` (overlay defaults) — `KeymapOverlay` with `Option<String>` per action; missing entries fall back to defaults
- [x] Latency: keypress → cmd update <30 ms p99 (measured by injecting key events) — `handle_key_latency_is_well_under_30ms` test injects 1024 events and asserts p99 < 30 ms
- [x] Works in a `docker run -it` container with `tty: true` + `stdin_open: true` — example doc-comment documents the compose snippet

## Validation performed

Run on this branch:

- `cargo build -p robowbc-teleop` — pass
- `cargo build --workspace` — pass
- `cargo test -p robowbc-teleop --all-targets` — **21 unit tests pass**, latency p99 well under budget
- `cargo clippy -p robowbc-teleop --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

Not validated:

- Live terminal I/O against a real TTY (the sandbox does not provide one). The terminal-touching code paths are confined to `enable` / `disable` / `poll` and are documented; the testable seam is `handle_key`, which is exercised by all 11 keyboard-tests via synthetic `KeyEvent`s.
- Docker `tty: true` + `stdin_open: true` flow — documented in the example, but no compose smoke test in this PR. That belongs to #129 (sim CI) which is the next layer down.

## Notes

- **Pre-existing CI failure on `rust` job (G2 blocker).** `cargo clippy --workspace --all-targets -- -D warnings` fails on `crates/robowbc-core/src/validator.rs:295` with `clippy::needless_raw_string_hashes`, introduced by #138 (PolicyValidator) and unrelated to this PR. Same blocker called out in #139 and #140. Per the auto-pr routine's no-bundling rule, this PR does not include a fix — it deserves a one-line cleanup PR (remove the `#` hashes around the raw string in `validator.rs:295-303`).
- **Foundation-issue / Gate G5.** #127 is referenced as a `Depends on` by #126 (FSM) and #131. The G5 hardware-validation rule applies to runtime code that talks to `unitree_mujoco`; the teleop crate is a pure user-input layer that produces `TeleopEvent` values without touching the wire. Nonetheless, given the unrelated workspace-clippy CI failure above, **this PR is opened as DRAFT / `[deferred]` and should not auto-merge.** Once the validator.rs lint is cleaned up upstream, this should be a clean rebase + un-draft.
- **Crate placement.** New top-level `robowbc-teleop` crate, mirroring the foundation pattern of `robowbc-transport` (#122). Lives outside `robowbc-comm` because comm operates at a different abstraction (wire-level `JointState` / `JointPositionTargets`); teleop is user input that flows into the FSM, not the transport.
- **No changes to `robowbc-cli`.** Wiring teleop into the CLI is FSM-side work (#126) and intentionally not included here.

---
_Generated by [Claude Code](https://claude.ai/code)_


---
_Generated by [Claude Code](https://claude.ai/code/session_01AXzBGWuAWBRtCbBnBfQ8Ws)_