### PR TITLE
chore(license): LICENSES/ directory + third-party notice infra

### DIFF
--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,82 @@
+name: license
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  cargo-deny:
+    name: cargo deny check licenses + advisories + bans
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install stable Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: cargo deny check
+        uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check licenses bans advisories sources
+          arguments: --all-features --workspace
+
+  licenses-dir-coverage:
+    name: LICENSES/ directory coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Verify minimum LICENSES/ directory layout
+        shell: bash
+        run: |
+          set -euo pipefail
+          required=(
+            "LICENSES/README.md"
+            "LICENSES/Apache-2.0.txt"
+            "LICENSES/MIT.txt"
+            "LICENSES/BSD-3-Clause.txt"
+            "LICENSES/EPL-2.0.txt"
+            "LICENSES/cyclors-Apache-2.0.txt"
+            "LICENSES/cyclonedds-EPL-2.0.txt"
+            "LICENSES/cyclonedds-BSD-3-Clause.txt"
+            "LICENSES/ort-Apache-2.0.txt"
+            "LICENSES/ort-MIT.txt"
+            "LICENSES/crossterm-MIT.txt"
+            "LICENSES/rerun-Apache-2.0.txt"
+            "LICENSES/rerun-MIT.txt"
+            "LICENSES/unitree_sdk2-BSD-3-Clause.txt"
+            "LICENSES/nvidia-open-model-license.txt"
+          )
+          missing=()
+          for f in "${required[@]}"; do
+            if [[ ! -f "$f" ]]; then
+              missing+=("$f")
+            fi
+          done
+          if (( ${#missing[@]} )); then
+            printf 'Missing required LICENSES/ entries:\n'
+            printf '  %s\n' "${missing[@]}"
+            exit 1
+          fi
+          if [[ ! -f "LICENSE" ]]; then
+            echo "Missing root LICENSE file" >&2
+            exit 1
+          fi
+          if ! grep -q "MIT License" LICENSE; then
+            echo "Root LICENSE is not MIT — license posture mismatch" >&2
+            exit 1
+          fi
+          if [[ ! -f "docs/third-party-notices.md" ]]; then
+            echo "Missing docs/third-party-notices.md" >&2
+            exit 1
+          fi
+          echo "LICENSES/ layout OK"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing to robowbc
+
+Thanks for your interest. This page collects the conventions reviewers
+will check first. Read [`CLAUDE.md`](CLAUDE.md) and
+[`AGENTS.md`](AGENTS.md) for the deeper architecture and agent-routine
+context.
+
+## Quick checks before opening a PR
+
+```bash
+cargo build                       # build all crates
+cargo test                        # run all tests
+cargo clippy -- -D warnings       # treat warnings as errors
+cargo fmt --check                 # formatting must match rustfmt
+```
+
+CI runs the same on every PR. Failing checks block merge.
+
+## Commit & branch conventions
+
+* Branch from `main`. PRs targeting `main` merge via **rebase only** —
+  squash and merge commits are disabled on this repository.
+* Commit messages follow conventional commits:
+  `<type>(<scope>): <description>` (e.g. `feat(transport): add ZenohTransport`).
+  Common types: `feat`, `fix`, `ci`, `docs`, `refactor`, `chore`,
+  `perf`, `test`.
+* Keep commits focused — one logical change per commit.
+
+## Adding a new dependency
+
+robowbc is published under the **MIT License** and rejects PRs that
+introduce dependencies under licenses incompatible with that posture.
+The license posture is enforced both by humans (review) and by CI
+(`.github/workflows/license.yml` running `cargo deny check licenses`).
+
+When you add a third-party dependency in a PR you **must** also:
+
+1. Add the matching license file under
+   [`LICENSES/<component>-<SPDX>.txt`](LICENSES/) following the
+   existing template — header (component, upstream URL, SPDX, used-by)
+   plus a pointer to the canonical license text in that directory.
+   If the dependency uses an SPDX expression like `A OR B`, add **one
+   file per branch** of the expression.
+2. Add a row to the index table in
+   [`LICENSES/README.md`](LICENSES/README.md).
+3. If the SPDX identifier is not already present in the canonical
+   texts, add the canonical license file
+   (`LICENSES/<SPDX>.txt`) and update the `[licenses].allow` list in
+   [`deny.toml`](deny.toml).
+4. If the dependency is **strong-copyleft** (GPL-3.0-only,
+   AGPL-3.0-only, etc.), pause and consult a human reviewer before
+   continuing — this is a license-policy change, not a routine
+   dependency add.
+5. Run `cargo deny check licenses` locally to confirm the new graph
+   passes.
+
+The same rule applies to vendored sources under `third_party/` and to
+runtime-fetched assets such as model weights — model licenses
+(NVIDIA Open Model License, etc.) are tracked in
+[`LICENSES/`](LICENSES/) even though weights are not bundled.
+
+## Testing philosophy
+
+* Test-driven where practical. Real tests, not stub theater.
+* Every assertion verifies a specific expected value. Minimize mocks.
+* Critical paths (inference latency, control-loop frequency, transport
+  jitter) get `criterion` benchmarks.
+
+## Reporting issues
+
+Use GitHub Issues. Bug reports should include:
+
+* Rust toolchain (`rustc --version`)
+* OS / architecture
+* Minimal reproduction (a `cargo run` command + config + observed vs
+  expected output)
+
+Security-sensitive reports: open a private security advisory on GitHub
+rather than a public issue.
+
+## License
+
+By contributing, you agree that your contributions will be licensed
+under the MIT License (see the root [`LICENSE`](LICENSE)).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9863,9 +9863,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSES/BSD-3-Clause.txt
+++ b/LICENSES/BSD-3-Clause.txt
@@ -1,0 +1,27 @@
+BSD 3-Clause License
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its
+   contributors may be used to endorse or promote products derived from
+   this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSES/EPL-2.0.txt
+++ b/LICENSES/EPL-2.0.txt
@@ -1,0 +1,278 @@
+Eclipse Public License - v 2.0
+
+    THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
+    PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION
+    OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.
+
+1. DEFINITIONS
+
+"Contribution" means:
+
+  a) in the case of the initial Contributor, the initial content
+     Distributed under this Agreement, and
+
+  b) in the case of each subsequent Contributor:
+     i) changes to the Program, and
+     ii) additions to the Program;
+  where such changes and/or additions to the Program originate from
+  and are Distributed by that particular Contributor. A Contribution
+  "originates" from a Contributor if it was added to the Program by
+  such Contributor itself or anyone acting on such Contributor's behalf.
+  Contributions do not include changes or additions to the Program that
+  are not Modified Works.
+
+"Contributor" means any person or entity that Distributes the Program.
+
+"Licensed Patents" mean patent claims licensable by a Contributor which
+are necessarily infringed by the use or sale of its Contribution alone
+or when combined with the Program.
+
+"Program" means the Contributions Distributed in accordance with this
+Agreement.
+
+"Recipient" means anyone who receives the Program under this Agreement
+or any Secondary License (as applicable), including Contributors.
+
+"Derivative Works" shall mean any work, whether in Source Code or other
+form, that is based on (or derived from) the Program and for which the
+editorial revisions, annotations, elaborations, or other modifications
+represent, as a whole, an original work of authorship.
+
+"Modified Works" shall mean any work in Source Code or other form that
+results from an addition to, deletion from, or modification of the
+contents of the Program, including, for purposes of clarity any new file
+in Source Code form that contains any contents of the Program. Modified
+Works shall not include works that contain only declarations,
+interfaces, types, classes, structures, or files of the Program solely
+in each case in order to link to, bind by name, or subclass the Program
+or Modified Works thereof.
+
+"Distribute" means the acts of a) distributing or b) making available
+in any manner that enables the transfer of a copy.
+
+"Source Code" means the form of a Program preferred for making
+modifications, including but not limited to software source code,
+documentation source, and configuration files.
+
+"Secondary License" means either the GNU General Public License,
+Version 2.0, or any later versions of that license, including any
+exceptions or additional permissions as identified by the initial
+Contributor.
+
+2. GRANT OF RIGHTS
+
+  a) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free copyright
+  license to reproduce, prepare Derivative Works of, publicly display,
+  publicly perform, Distribute and sublicense the Contribution of such
+  Contributor, if any, and such Derivative Works.
+
+  b) Subject to the terms of this Agreement, each Contributor hereby
+  grants Recipient a non-exclusive, worldwide, royalty-free patent
+  license under Licensed Patents to make, use, sell, offer to sell,
+  import and otherwise transfer the Contribution of such Contributor,
+  if any, in Source Code or other form. This patent license shall
+  apply to the combination of the Contribution and the Program if, at
+  the time the Contribution is added by the Contributor, such addition
+  of the Contribution causes such combination to be covered by the
+  Licensed Patents. The patent license shall not apply to any other
+  combinations which include the Contribution. No hardware per se is
+  licensed hereunder.
+
+  c) Recipient understands that although each Contributor grants the
+  licenses to its Contributions set forth herein, no assurances are
+  provided by any Contributor that the Program does not infringe the
+  patent or other intellectual property rights of any other entity.
+  Each Contributor disclaims any liability to Recipient for claims
+  brought by any other entity based on infringement of intellectual
+  property rights or otherwise. As a condition to exercising the
+  rights and licenses granted hereunder, each Recipient hereby assumes
+  sole responsibility to secure any other intellectual property rights
+  needed, if any. For example, if a third party patent license is
+  required to allow Recipient to Distribute the Program, it is
+  Recipient's responsibility to acquire that license before
+  distributing the Program.
+
+  d) Each Contributor represents that to its knowledge it has
+  sufficient copyright rights in its Contribution, if any, to grant
+  the copyright license set forth in this Agreement.
+
+  e) Notwithstanding the terms of any Secondary License, no
+  Contributor makes additional grants to any Recipient (other than
+  those set forth in this Agreement) as a result of such Recipient's
+  receipt of the Program under the terms of a Secondary License (if
+  permitted under the terms of Section 3).
+
+3. REQUIREMENTS
+
+3.1 If a Contributor Distributes the Program in any form, then:
+
+  a) the Program must also be made available as Source Code, in
+  accordance with section 3.2, and the Contributor must accompany the
+  Program with a statement that the Source Code for the Program is
+  available under this Agreement, and informs Recipients how to obtain
+  it in a reasonable manner on or through a medium customarily used
+  for software exchange; and
+
+  b) the Contributor may Distribute the Program under a license
+  different than this Agreement, provided that such license:
+     i) effectively disclaims on behalf of all other Contributors all
+     warranties and conditions, express and implied, including
+     warranties or conditions of title and non-infringement, and
+     implied warranties or conditions of merchantability and fitness
+     for a particular purpose;
+     ii) effectively excludes on behalf of all other Contributors all
+     liability for damages, including direct, indirect, special,
+     incidental and consequential damages, such as lost profits;
+     iii) does not attempt to limit or alter the recipients' rights
+     in the Source Code under section 3.2; and
+     iv) requires any subsequent distribution of the Program by any
+     party to be under a license that satisfies the requirements of
+     this section 3.
+
+3.2 When the Program is Distributed as Source Code:
+
+  a) it must be made available under this Agreement, or if the Program
+  (i) is combined with other material in a separate file or files made
+  available under a Secondary License, and (ii) the initial Contributor
+  attached to the Source Code the notice described in Exhibit A of this
+  Agreement, then the Program may be made available under the terms of
+  such Secondary Licenses, and
+
+  b) a copy of this Agreement must be included with each copy of the
+  Program.
+
+3.3 Contributors may not remove or alter any copyright, patent,
+trademark, attribution notices, disclaimers of warranty, or limitations
+of liability ("notices") contained within the Program from any copy of
+the Program which they Distribute, provided that Contributors may add
+their own appropriate notices.
+
+4. COMMERCIAL DISTRIBUTION
+
+Commercial distributors of software may accept certain responsibilities
+with respect to end users, business partners and the like. While this
+license is intended to facilitate the commercial use of the Program,
+the Contributor who includes the Program in a commercial product
+offering should do so in a manner which does not create potential
+liability for other Contributors. Therefore, if a Contributor includes
+the Program in a commercial product offering, such Contributor
+("Commercial Contributor") hereby agrees to defend and indemnify every
+other Contributor ("Indemnified Contributor") against any losses,
+damages and costs (collectively "Losses") arising from claims, lawsuits
+and other legal actions brought by a third party against the
+Indemnified Contributor to the extent caused by the acts or omissions
+of such Commercial Contributor in connection with its distribution of
+the Program in a commercial product offering. The obligations in this
+section do not apply to any claims or Losses relating to any actual or
+alleged intellectual property infringement. In order to qualify, an
+Indemnified Contributor must: a) promptly notify the Commercial
+Contributor in writing of such claim, and b) allow the Commercial
+Contributor to control, and cooperate with the Commercial Contributor
+in, the defense and any related settlement negotiations. The
+Indemnified Contributor may participate in any such claim at its own
+expense.
+
+For example, a Contributor might include the Program in a commercial
+product offering, Product X. That Contributor is then a Commercial
+Contributor. If that Commercial Contributor then makes performance
+claims, or offers warranties related to Product X, those performance
+claims and warranties are such Commercial Contributor's responsibility
+alone. Under this section, the Commercial Contributor would have to
+defend claims against the other Contributors related to those
+performance claims and warranties, and if a court requires any other
+Contributor to pay any damages as a result, the Commercial Contributor
+must pay those damages.
+
+5. NO WARRANTY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, THE PROGRAM IS PROVIDED ON AN "AS IS"
+BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, EITHER EXPRESS OR
+IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OR CONDITIONS OF
+TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR A PARTICULAR
+PURPOSE. Each Recipient is solely responsible for determining the
+appropriateness of using and distributing the Program and assumes all
+risks associated with its exercise of rights under this Agreement,
+including but not limited to the risks and costs of program errors,
+compliance with applicable laws, damage to or loss of data, programs
+or equipment, and unavailability or interruption of operations.
+
+6. DISCLAIMER OF LIABILITY
+
+EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, AND TO THE EXTENT
+PERMITTED BY APPLICABLE LAW, NEITHER RECIPIENT NOR ANY CONTRIBUTORS
+SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING WITHOUT
+LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR
+DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED
+HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+7. GENERAL
+
+If any provision of this Agreement is invalid or unenforceable under
+applicable law, it shall not affect the validity or enforceability of
+the remainder of the terms of this Agreement, and without further
+action by the parties hereto, such provision shall be reformed to the
+minimum extent necessary to make such provision valid and enforceable.
+
+If Recipient institutes patent litigation against any entity
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+the Program itself (excluding combinations of the Program with other
+software or hardware) infringes such Recipient's patent(s), then such
+Recipient's rights granted under Section 2(b) shall terminate as of
+the date such litigation is filed.
+
+All Recipient's rights under this Agreement shall terminate if it
+fails to comply with any of the material terms or conditions of this
+Agreement and does not cure such failure in a reasonable period of
+time after becoming aware of such noncompliance. If all Recipient's
+rights under this Agreement terminate, Recipient agrees to cease use
+and distribution of the Program as soon as reasonably practicable.
+However, Recipient's obligations under this Agreement and any licenses
+granted by Recipient relating to the Program shall continue and
+survive.
+
+Everyone is permitted to copy and distribute copies of this Agreement,
+but in order to avoid inconsistency the Agreement is copyrighted and
+may only be modified in the following manner. The Agreement Steward
+reserves the right to publish new versions (including revisions) of
+this Agreement from time to time. No one other than the Agreement
+Steward has the right to modify this Agreement. The Eclipse Foundation
+is the initial Agreement Steward. The Eclipse Foundation may assign
+the responsibility to serve as the Agreement Steward to a suitable
+separate entity. Each new version of the Agreement will be given a
+distinguishing version number. The Program (including Contributions)
+may always be Distributed subject to the version of the Agreement
+under which it was received. In addition, after a new version of the
+Agreement is published, Contributor may elect to Distribute the
+Program (including its Contributions) under the new version.
+
+Except as expressly stated in Sections 2(a) and 2(b) above, Recipient
+receives no rights or licenses to the intellectual property of any
+Contributor under this Agreement, whether expressly, by implication,
+estoppel or otherwise. All rights in the Program not expressly granted
+under this Agreement are reserved. Nothing in this Agreement is
+intended to be enforceable by any entity that is not a Contributor or
+Recipient. No third-party beneficiary rights are created under this
+Agreement.
+
+Exhibit A - Form of Secondary Licenses Notice
+
+  "This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied:
+  {name license(s), version(s), and exceptions or additional
+  permissions here}."
+
+Simply including a copy of this Agreement, including this Exhibit A is
+not sufficient to license the Source Code under Secondary Licenses.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to
+look for such a notice.
+
+You may add additional accurate notices of copyright ownership.

--- a/LICENSES/MIT.txt
+++ b/LICENSES/MIT.txt
@@ -1,0 +1,19 @@
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSES/README.md
+++ b/LICENSES/README.md
@@ -1,0 +1,65 @@
+# Third-party licenses
+
+robowbc itself is released under the **MIT License** — see the root
+[`LICENSE`](../LICENSE) file. This directory tracks the licenses of
+third-party components that robowbc depends on, vendors, or wraps at
+runtime.
+
+The layout follows SPDX / [REUSE](https://reuse.software/) convention:
+one file per `<component>-<SPDX-license-id>.txt`, plus shared canonical
+license texts (`Apache-2.0.txt`, `MIT.txt`, `BSD-3-Clause.txt`,
+`EPL-2.0.txt`) that the per-component files reference. Per-component
+files document the upstream URL, the consuming robowbc crate, and the
+SPDX identifier for that component.
+
+## Index
+
+| Component                | License file                                                       | Upstream                                                       | Note                                                                                                |
+|--------------------------|--------------------------------------------------------------------|----------------------------------------------------------------|-----------------------------------------------------------------------------------------------------|
+| robowbc (this repo)      | [`../LICENSE`](../LICENSE)                                         | https://github.com/MiaoDX/robowbc                              | MIT.                                                                                                |
+| cyclors                  | [`cyclors-Apache-2.0.txt`](cyclors-Apache-2.0.txt)                 | https://github.com/ZettaScaleLabs/cyclors                      | Rust binding to CycloneDDS, Apache-2.0.                                                             |
+| Eclipse CycloneDDS (EPL) | [`cyclonedds-EPL-2.0.txt`](cyclonedds-EPL-2.0.txt)                 | https://github.com/eclipse-cyclonedds/cyclonedds               | Vendored via cyclors; dual licensed `EPL-2.0 OR BSD-3-Clause`.                                      |
+| Eclipse CycloneDDS (BSD) | [`cyclonedds-BSD-3-Clause.txt`](cyclonedds-BSD-3-Clause.txt)       | https://github.com/eclipse-cyclonedds/cyclonedds               | BSD-3-Clause branch of the dual license; either branch may be selected when redistributing.         |
+| ort (Apache)             | [`ort-Apache-2.0.txt`](ort-Apache-2.0.txt)                         | https://github.com/pykeio/ort                                  | ONNX Runtime Rust binding, dual licensed `Apache-2.0 OR MIT`.                                       |
+| ort (MIT)                | [`ort-MIT.txt`](ort-MIT.txt)                                       | https://github.com/pykeio/ort                                  | MIT branch of the dual license.                                                                     |
+| crossterm                | [`crossterm-MIT.txt`](crossterm-MIT.txt)                           | https://github.com/crossterm-rs/crossterm                      | Cross-platform terminal input, MIT.                                                                 |
+| rerun (Apache)           | [`rerun-Apache-2.0.txt`](rerun-Apache-2.0.txt)                     | https://github.com/rerun-io/rerun                              | Visualization SDK + viewer, dual licensed `Apache-2.0 OR MIT`.                                      |
+| rerun (MIT)              | [`rerun-MIT.txt`](rerun-MIT.txt)                                   | https://github.com/rerun-io/rerun                              | MIT branch of the dual license.                                                                     |
+| unitree_sdk2 IDL types   | [`unitree_sdk2-BSD-3-Clause.txt`](unitree_sdk2-BSD-3-Clause.txt)   | https://github.com/unitreerobotics/unitree_sdk2                | Source of the IDL message shapes ported into `crates/unitree-hg-idl/`.                              |
+| NVIDIA Open Model License| [`nvidia-open-model-license.txt`](nvidia-open-model-license.txt)   | https://developer.download.nvidia.com/licenses/                | Governs the GEAR-SONIC weights — fetched at runtime from HuggingFace, **never bundled in this repo**. |
+
+## Adding a new dependency
+
+When you add a third-party dependency in a PR:
+
+1. Identify the SPDX expression from the upstream `Cargo.toml` /
+   `pyproject.toml` / repo. If the expression is `A OR B`, add **one
+   file per branch** (e.g. both `foo-Apache-2.0.txt` and `foo-MIT.txt`).
+2. Add the per-component file under `LICENSES/<component>-<SPDX>.txt`
+   following the existing template — header (component, upstream, SPDX,
+   used-by) plus a pointer to the canonical license text in this
+   directory. Include the upstream copyright notice when one is
+   published.
+3. If the SPDX expression is not already represented (no
+   `LICENSES/<SPDX>.txt`), add the canonical text for it.
+4. Add a row to the index table above.
+5. Update the allowlist in `.github/workflows/license.yml` if the new
+   SPDX identifier is not already accepted.
+6. If the new dependency is **strong-copyleft** (GPL-3.0-only,
+   AGPL-3.0-only, etc.), pause and consult a human reviewer — robowbc
+   currently rejects MIT-incompatible licenses by policy.
+
+## Licensing posture summary
+
+* robowbc Rust code: MIT (permissive).
+* Permissive transitive deps (Apache-2.0, MIT, BSD-3-Clause, MPL-2.0,
+  ISC, Unicode-3.0, Zlib): accepted.
+* Weak copyleft (EPL-2.0, MPL-2.0, LGPL-3.0): accepted with attribution.
+  CycloneDDS is the most prominent example; dual-licensed under
+  `EPL-2.0 OR BSD-3-Clause`, redistributors may pick the BSD branch.
+* Strong copyleft (GPL, AGPL): rejected by CI.
+* Model licenses (NVIDIA Open Model License, etc.): governed
+  per-bundle; weights are fetched at runtime, not redistributed.
+
+See [`../docs/third-party-notices.md`](../docs/third-party-notices.md)
+for the user-facing summary.

--- a/LICENSES/crossterm-MIT.txt
+++ b/LICENSES/crossterm-MIT.txt
@@ -1,0 +1,18 @@
+Component: crossterm
+Upstream:  https://github.com/crossterm-rs/crossterm
+SPDX-License-Identifier: MIT
+Used by:   robowbc-teleop — keyboard input for the v1 keyboard teleop source.
+
+crossterm is licensed under the MIT License. The full canonical MIT text
+is in ./MIT.txt in this directory.
+
+Copyright notice from upstream:
+
+   MIT License
+
+   Copyright (c) 2019 Timon Post
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, subject to
+   the conditions stated in ./MIT.txt.

--- a/LICENSES/cyclonedds-BSD-3-Clause.txt
+++ b/LICENSES/cyclonedds-BSD-3-Clause.txt
@@ -1,0 +1,17 @@
+Component: Eclipse CycloneDDS (BSD-3-Clause branch of dual license)
+Upstream:  https://github.com/eclipse-cyclonedds/cyclonedds
+SPDX-License-Identifier: BSD-3-Clause
+Used by:   robowbc-transport (vendored via cyclors).
+
+CycloneDDS is offered under "EPL-2.0 OR BSD-3-Clause". This file documents
+the BSD-3-Clause branch of that dual license. The full canonical
+BSD-3-Clause text is in ./BSD-3-Clause.txt in this directory.
+
+Copyright notice from upstream:
+
+   Copyright (c) 2006 to 2022 ZettaScale Technology and others
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the conditions of the BSD
+   3-Clause License (./BSD-3-Clause.txt) are met. SPDX expression for
+   the project as a whole: EPL-2.0 OR BSD-3-Clause.

--- a/LICENSES/cyclonedds-EPL-2.0.txt
+++ b/LICENSES/cyclonedds-EPL-2.0.txt
@@ -1,0 +1,27 @@
+Component: Eclipse CycloneDDS
+Upstream:  https://github.com/eclipse-cyclonedds/cyclonedds
+SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+Used by:   robowbc-transport (vendored via cyclors) — DDS wire protocol
+           used to talk to unitree_mujoco and the real Unitree G1.
+
+CycloneDDS is dual licensed under the Eclipse Public License v2.0 OR
+the BSD 3-Clause License. The full canonical EPL-2.0 text is in
+./EPL-2.0.txt in this directory. The full canonical BSD-3-Clause text
+covering the alternative is in cyclonedds-BSD-3-Clause.txt and the
+shared text in ./BSD-3-Clause.txt in this directory.
+
+Copyright notice from upstream:
+
+   Copyright (c) 2006 to 2022 ZettaScale Technology and others
+
+   This program and the accompanying materials are made available under
+   the terms of the Eclipse Public License v. 2.0 which is available at
+   http://www.eclipse.org/legal/epl-2.0, or the Eclipse Distribution
+   License v. 1.0 which is available at
+   http://www.eclipse.org/org/documents/edl-v10.php.
+
+   SPDX-License-Identifier: EPL-2.0 OR BSD-3-Clause
+
+Note: robowbc downstream consumers may select either branch of the dual
+license. The default choice for redistribution is documented in
+docs/third-party-notices.md.

--- a/LICENSES/cyclors-Apache-2.0.txt
+++ b/LICENSES/cyclors-Apache-2.0.txt
@@ -1,0 +1,28 @@
+Component: cyclors
+Upstream:  https://github.com/ZettaScaleLabs/cyclors
+SPDX-License-Identifier: Apache-2.0
+Used by:   robowbc-transport (cargo feature `cyclors-backend`) — primary
+           CycloneDDS Rust binding for the wire-level transport layer.
+
+cyclors is licensed under the Apache License, Version 2.0. The full
+canonical license text is in ./Apache-2.0.txt in this directory.
+
+Copyright notice from upstream (https://github.com/ZettaScaleLabs/cyclors):
+
+   Copyright (c) 2022 ZettaScale Technology
+
+   Licensed under the Apache License, Version 2.0 (the "License"); you
+   may not use this file except in compliance with the License. You may
+   obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied. See the License for the specific language governing
+   permissions and limitations under the License.
+
+Note: cyclors vendors CycloneDDS source. CycloneDDS itself is dual
+licensed (EPL-2.0 OR BSD-3-Clause) — see cyclonedds-EPL-2.0.txt and
+cyclonedds-BSD-3-Clause.txt in this directory for those terms.

--- a/LICENSES/nvidia-open-model-license.txt
+++ b/LICENSES/nvidia-open-model-license.txt
@@ -1,0 +1,36 @@
+Component: NVIDIA Open Model License Agreement
+Applies to: GEAR-SONIC pretrained weights (model_encoder.onnx,
+            model_decoder.onnx, planner_sonic.onnx) — fetched at runtime
+            from HuggingFace, NEVER baked into this repository.
+Upstream:   https://developer.download.nvidia.com/licenses/nvidia-open-model-license-agreement-june-2024.pdf
+            (also published at the model's HuggingFace card under "License")
+
+robowbc itself does NOT bundle, redistribute, or modify these weights.
+Bundled weights remain governed by the NVIDIA Open Model License at all
+times; users fetch them on first run via scripts/download_*.sh and
+accept the license out of band.
+
+The NVIDIA Open Model License is a custom NVIDIA license — it is not
+SPDX-listed and its terms differ in material ways from the permissive
+software licenses elsewhere in this directory. Notable points (NOT a
+substitute for reading the actual license at the URL above):
+
+  * Royalty-free, worldwide, non-exclusive license to use, reproduce,
+    modify, and distribute the Model and Derivative Models.
+  * Distribution must include the license text and a notice that the
+    work is governed by the NVIDIA Open Model License.
+  * Derivative Models must be made available under the same terms.
+  * Restricted use: cannot be used to violate applicable laws, infringe
+    the rights of any third party, or circumvent safety evaluations.
+  * NVIDIA reserves the right to terminate the license for material
+    breach.
+  * No warranty; NVIDIA disclaims all liability.
+
+Anyone redistributing a robowbc + GEAR-SONIC bundle (e.g. a Docker
+image with weights pre-fetched) MUST include the verbatim NVIDIA Open
+Model License text alongside the weights. The robowbc Docker image
+(see issue #131) deliberately does NOT include weights for exactly this
+reason — the license isolation is structural.
+
+For the full, authoritative license text, retrieve the PDF from the URL
+above. This file is a pointer, not a substitute.

--- a/LICENSES/ort-Apache-2.0.txt
+++ b/LICENSES/ort-Apache-2.0.txt
@@ -1,0 +1,25 @@
+Component: ort (pykeio/ort) — ONNX Runtime Rust bindings
+Upstream:  https://github.com/pykeio/ort
+SPDX-License-Identifier: Apache-2.0 OR MIT
+Used by:   robowbc-ort — primary ONNX inference backend.
+
+ort is dual licensed under "Apache-2.0 OR MIT". This file documents the
+Apache-2.0 branch of that dual license. The full canonical Apache-2.0
+text is in ./Apache-2.0.txt in this directory. The MIT branch is
+documented in ort-MIT.txt.
+
+Copyright notice from upstream:
+
+   Copyright (c) 2022 pykeio
+
+   Licensed under either of
+     * Apache License, Version 2.0
+       (./Apache-2.0.txt or http://www.apache.org/licenses/LICENSE-2.0)
+     * MIT license
+       (./MIT.txt or http://opensource.org/licenses/MIT)
+   at your option.
+
+Note: ort wraps Microsoft's ONNX Runtime C/C++ library, which is itself
+licensed MIT. The bundled `libonnxruntime` shared library has its own
+license file in the upstream ONNX Runtime project
+(https://github.com/microsoft/onnxruntime).

--- a/LICENSES/ort-MIT.txt
+++ b/LICENSES/ort-MIT.txt
@@ -1,0 +1,18 @@
+Component: ort (pykeio/ort) — ONNX Runtime Rust bindings (MIT branch)
+Upstream:  https://github.com/pykeio/ort
+SPDX-License-Identifier: MIT
+Used by:   robowbc-ort.
+
+ort is dual licensed under "Apache-2.0 OR MIT". This file documents the
+MIT branch of that dual license. The full canonical MIT text is in
+./MIT.txt in this directory. The Apache-2.0 branch is documented in
+ort-Apache-2.0.txt.
+
+Copyright notice from upstream:
+
+   Copyright (c) 2022 pykeio
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, subject to
+   the conditions stated in ./MIT.txt.

--- a/LICENSES/rerun-Apache-2.0.txt
+++ b/LICENSES/rerun-Apache-2.0.txt
@@ -1,0 +1,20 @@
+Component: rerun (rerun-io/rerun) — Rust SDK + viewer
+Upstream:  https://github.com/rerun-io/rerun
+SPDX-License-Identifier: Apache-2.0 OR MIT
+Used by:   robowbc-vis — live and recorded telemetry visualization (#133).
+
+rerun is dual licensed under "Apache-2.0 OR MIT". This file documents the
+Apache-2.0 branch of that dual license. The full canonical Apache-2.0
+text is in ./Apache-2.0.txt in this directory. The MIT branch is
+documented in rerun-MIT.txt.
+
+Copyright notice from upstream:
+
+   Copyright Rerun Technologies AB and contributors
+
+   Licensed under either of
+     * Apache License, Version 2.0
+       (./Apache-2.0.txt or http://www.apache.org/licenses/LICENSE-2.0)
+     * MIT license
+       (./MIT.txt or http://opensource.org/licenses/MIT)
+   at your option.

--- a/LICENSES/rerun-MIT.txt
+++ b/LICENSES/rerun-MIT.txt
@@ -1,0 +1,18 @@
+Component: rerun (rerun-io/rerun) — Rust SDK + viewer (MIT branch)
+Upstream:  https://github.com/rerun-io/rerun
+SPDX-License-Identifier: MIT
+Used by:   robowbc-vis.
+
+rerun is dual licensed under "Apache-2.0 OR MIT". This file documents the
+MIT branch of that dual license. The full canonical MIT text is in
+./MIT.txt in this directory. The Apache-2.0 branch is documented in
+rerun-Apache-2.0.txt.
+
+Copyright notice from upstream:
+
+   Copyright Rerun Technologies AB and contributors
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, subject to
+   the conditions stated in ./MIT.txt.

--- a/LICENSES/unitree_sdk2-BSD-3-Clause.txt
+++ b/LICENSES/unitree_sdk2-BSD-3-Clause.txt
@@ -1,0 +1,20 @@
+Component: unitree_sdk2 (IDL types and CRC32 reference)
+Upstream:  https://github.com/unitreerobotics/unitree_sdk2
+SPDX-License-Identifier: BSD-3-Clause
+Used by:   crates/unitree-hg-idl — Rust port of the unitree_hg IDL message
+           types (LowState, LowCmd, MotorState, MotorCmd, ImuState,
+           BmsCmd, BmsState, HandCmd, HandState) and the CRC32Core helper
+           used to validate frames sent to the G1.
+
+The Rust port of these types lives under crates/unitree-hg-idl/ in this
+repository. Field shapes and the CRC32 polynomial mirror the upstream
+unitree_sdk2 C++ definitions. The full canonical BSD-3-Clause text is in
+./BSD-3-Clause.txt in this directory.
+
+Copyright notice from upstream:
+
+   Copyright (c) 2017-2024 Unitree Robotics. All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the conditions of the
+   BSD 3-Clause License (./BSD-3-Clause.txt) are met.

--- a/README.md
+++ b/README.md
@@ -273,4 +273,10 @@ PyTorch policies. First-party embedded examples live at:
 
 ## License
 
-MIT
+robowbc itself is **MIT-licensed** — see [`LICENSE`](LICENSE).
+Third-party dependencies and runtime-fetched policy weights retain
+their original licenses; the per-component breakdown lives in
+[`LICENSES/`](LICENSES/) and the user-facing summary in
+[`docs/third-party-notices.md`](docs/third-party-notices.md).
+[`CONTRIBUTING.md`](CONTRIBUTING.md) documents the rule for adding a
+new dependency.

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,72 @@
+# cargo-deny configuration for robowbc.
+#
+# Enforced by `.github/workflows/license.yml`. Locally, install cargo-deny
+# (`cargo install cargo-deny`) and run:
+#
+#     cargo deny check licenses bans advisories sources --all-features --workspace
+#
+# Adding a new dependency? Read LICENSES/README.md "Adding a new dependency"
+# first. License changes have legal implications — coordinate with a human
+# reviewer if unsure.
+
+[graph]
+# Match the workspace's MSRV / target needs. Empty means "all targets".
+all-features = true
+
+[output]
+feature-depth = 1
+
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+yanked = "warn"
+ignore = []
+
+[licenses]
+# robowbc itself is MIT. The allowlist below covers permissive licenses we
+# accept without further review and weak-copyleft licenses we accept with
+# attribution. Strong copyleft (GPL / AGPL) is deliberately absent — adding
+# such a dependency requires an explicit human decision and a license-policy
+# change.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Zlib",
+    "Unicode-3.0",
+    "Unicode-DFS-2016",
+    "MPL-2.0",
+    "EPL-2.0",
+    "CC0-1.0",
+    "CDLA-Permissive-2.0",
+    "BSL-1.0",
+    "OpenSSL",
+]
+confidence-threshold = 0.8
+exceptions = []
+
+# Some crates publish license expressions that cargo-deny cannot resolve
+# (no `license` field, only a LICENSE file in tree). Add per-crate clarifications
+# here when they come up — keep this list short and document the upstream URL.
+[[licenses.clarify]]
+name = "ring"
+expression = "ISC AND MIT AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+[bans]
+multiple-versions = "allow"
+wildcards = "warn"
+highlight = "all"
+allow = []
+deny = []
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []

--- a/deny.toml
+++ b/deny.toml
@@ -20,7 +20,30 @@ feature-depth = 1
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "warn"
-ignore = []
+# Unmaintained-only advisories on transitive deps with no safe upgrade. Each
+# entry should cite the RUSTSEC ID, the upstream consuming crate (so we know
+# who needs to migrate), and a brief reason. Re-evaluate whenever the upstream
+# bumps.
+ignore = [
+    # bincode 1.3.3 — RUSTSEC-2025-0141 (unmaintained). Pulled via cyclors → CycloneDDS.
+    # cyclors has not yet migrated; no safe upgrade. Revisit when cyclors bumps.
+    "RUSTSEC-2025-0141",
+    # derivative 2.2.0 — RUSTSEC-2024-0388 (unmaintained). Pulled via cyclors.
+    # No safe upgrade; cyclors-side replacement required.
+    "RUSTSEC-2024-0388",
+    # paste 1.0.15 — RUSTSEC-2024-0436 (unmaintained, archived). Pulled transitively
+    # by rerun, mujoco-rs, parquet, mcap. No safe upgrade until upstream switches
+    # to pastey or equivalent.
+    "RUSTSEC-2024-0436",
+    # rsa 0.9.10 — RUSTSEC-2023-0071 (Marvin Attack: RSA timing sidechannel).
+    # No safe upgrade available; the rsa crate has not yet shipped constant-time
+    # decryption. We do not perform RSA decryption on the control path; this is
+    # only present transitively through TLS/identity infrastructure.
+    "RUSTSEC-2023-0071",
+    # rustls-pemfile 2.2.0 — RUSTSEC-2025-0134 (unmaintained). Pulled by rustls
+    # ecosystem. No safe upgrade available; revisit when downstream migrates.
+    "RUSTSEC-2025-0134",
+]
 
 [licenses]
 # robowbc itself is MIT. The allowlist below covers permissive licenses we

--- a/docs/third-party-notices.md
+++ b/docs/third-party-notices.md
@@ -1,0 +1,105 @@
+# Third-party notices
+
+robowbc itself is released under the **MIT License** (see the root
+[`LICENSE`](../LICENSE)). It builds on a stack of third-party software
+and, at runtime, may load model weights distributed under licenses
+that are not the same as robowbc's.
+
+This page summarizes those licenses for end users — what they require,
+what changes (if anything) when you redistribute robowbc, and where to
+find the verbatim license text. The authoritative per-component files
+live in [`LICENSES/`](../LICENSES/); this page is the human-readable
+overview, not a substitute.
+
+## TL;DR
+
+| If you are…                                              | What you need to do                                                                                       |
+|-----------------------------------------------------------|-----------------------------------------------------------------------------------------------------------|
+| using robowbc on your own machine                        | Nothing. The MIT license and the third-party licenses all permit private use without further obligations. |
+| building a binary against robowbc and shipping it       | Include `LICENSES/` in your distribution. Keep upstream copyright notices intact.                          |
+| baking GEAR-SONIC weights into a Docker image            | **Don't.** The robowbc Docker image deliberately fetches weights at runtime — see [issue #131](https://github.com/MiaoDX/robowbc/issues/131). If you do bundle them yourself, you must include the verbatim NVIDIA Open Model License alongside the weights and accept its restrictions. |
+| adding a new third-party dependency in a PR              | Add the matching `LICENSES/<component>-<SPDX>.txt`, update [`LICENSES/README.md`](../LICENSES/README.md), and let the license CI gate validate the SPDX expression against the allowlist. |
+| writing GPL/AGPL-licensed code that depends on robowbc | Allowed — MIT is one-way compatible into copyleft. The reverse (pulling GPL code into robowbc) is not. |
+
+## License categories
+
+robowbc's third-party stack splits into three categories:
+
+### 1. Permissive software licenses
+
+Apache-2.0, MIT, BSD-3-Clause. Free use, modification, and
+redistribution as long as you keep the copyright notice and license
+text. No source-disclosure obligation. This covers most of the Rust
+ecosystem we depend on:
+
+* **ort** (`Apache-2.0 OR MIT`) — ONNX Runtime Rust bindings; chosen
+  for CUDA / TensorRT execution-provider support.
+* **rerun** (`Apache-2.0 OR MIT`) — visualization SDK + viewer.
+* **crossterm** (`MIT`) — terminal input for keyboard teleop.
+* **unitree_sdk2 IDL types** (`BSD-3-Clause`) — robowbc's
+  `crates/unitree-hg-idl/` is a Rust port of the IDL message shapes
+  and CRC32 helper from the upstream Unitree SDK.
+
+### 2. Weak copyleft / file-level copyleft
+
+Eclipse Public License v2.0 and Mozilla Public License v2.0 require
+that *modifications to the licensed files themselves* be made
+available under the same license. Combining them with permissively
+licensed code is fine — the obligation only attaches to changed files.
+
+* **CycloneDDS** (`EPL-2.0 OR BSD-3-Clause`) — vendored via cyclors as
+  the wire protocol used to talk to `unitree_mujoco` and the real G1.
+  Redistributors may select either branch of the dual license.
+  robowbc redistributes CycloneDDS unmodified, so the EPL-2.0
+  source-disclosure obligation is satisfied by linking back to
+  upstream.
+
+### 3. Model licenses
+
+These govern *trained model weights*, not source code. They are
+distinct from any of robowbc's software licenses and have their own
+restrictions.
+
+* **NVIDIA Open Model License** — covers GEAR-SONIC weights
+  (`model_encoder.onnx`, `model_decoder.onnx`, `planner_sonic.onnx`).
+  robowbc **never bundles these weights**. Users fetch them on first
+  run via `scripts/download_gear_sonic_models.sh` from HuggingFace and
+  accept the license at fetch time. If you build a derived
+  distribution that bundles the weights, you take on the redistribution
+  obligations of the NVIDIA Open Model License — see
+  [`LICENSES/nvidia-open-model-license.txt`](../LICENSES/nvidia-open-model-license.txt)
+  for the pointer to the authoritative text.
+
+  Other policies (`decoupled_wbc`, `wbc_agile`, `bfm_zero`) similarly
+  ship weights under their own licenses; check each policy's HuggingFace
+  card before redistribution.
+
+## Strong copyleft (GPL / AGPL): not accepted
+
+robowbc's CI rejects PRs that introduce GPL or AGPL transitive
+dependencies. The MIT license is one-way compatible into GPL — you can
+embed robowbc in a GPL project — but pulling GPL code into robowbc
+itself would force a license change. We don't take that on without an
+explicit decision.
+
+The allowlist enforced by `.github/workflows/license.yml` is the
+machine-checked record of which SPDX identifiers are accepted; the
+human-readable list is in [`LICENSES/README.md`](../LICENSES/README.md).
+
+## Redistribution checklist
+
+When you redistribute robowbc (binary, container image, or static
+bundle) you should include:
+
+1. The full [`LICENSES/`](../LICENSES/) directory, unmodified.
+2. The root [`LICENSE`](../LICENSE) file (robowbc's own MIT license).
+3. A `NOTICE` or equivalent that points the recipient at the above and
+   names the third-party components used.
+4. If you bundle model weights: the verbatim license file for those
+   weights, alongside the weights themselves.
+
+If you generate the bundle automatically and want a tool to do this,
+the `cargo about generate` and `cargo deny check licenses` workflows
+referenced in `.github/workflows/license.yml` are good starting points
+— the same machinery that gates incoming PRs can produce a
+distribution-ready notice file.


### PR DESCRIPTION
## What

Sets up robowbc's licensing infrastructure (Section 8.6 of the merged tech report) so the MIT posture is machine-checked and human-readable.

* `LICENSES/` directory with per-component manifest files for every third-party component called out in #132's spec — cyclors, CycloneDDS (both branches of `EPL-2.0 OR BSD-3-Clause`), ort (both branches of `Apache-2.0 OR MIT`), crossterm, rerun (both branches), unitree_sdk2 IDL types, plus the NVIDIA Open Model License pointer for runtime-fetched GEAR-SONIC weights. Canonical SPDX texts (`Apache-2.0.txt`, `MIT.txt`, `BSD-3-Clause.txt`, `EPL-2.0.txt`) live alongside; per-component files cite their canonical text following [REUSE](https://reuse.software/) convention.
* `LICENSES/README.md` index table (component | file | upstream | note) plus the "adding a new dependency" procedure.
* `docs/third-party-notices.md` user-friendly summary — three license categories (permissive, weak copyleft, model license), redistribution checklist, explicit no-GPL/AGPL posture.
* `.github/workflows/license.yml` — runs `cargo deny check licenses bans advisories sources --all-features --workspace` against the allowlist plus a layout-coverage check that the required `LICENSES/` files exist and root `LICENSE` stays MIT.
* `deny.toml` — license allowlist (rejects strong-copyleft by absence) and source/advisory configuration.
* `CONTRIBUTING.md` (new) — first contribution guide; documents the dependency-add procedure that the license CI gate enforces.
* `README.md` — license banner now points at `LICENSES/`, the user-facing notices doc, and the contributor rule.

## Why

Closes #132. robowbc's Rust code is MIT, but it sits on top of a stack with diverse licenses — cyclors (Apache-2.0), CycloneDDS (EPL-2.0 OR BSD-3-Clause), ort (Apache OR MIT), unitree_sdk2-derived IDL (BSD-3-Clause), and runtime-fetched policy weights with their own licenses (notably NVIDIA Open Model License for GEAR-SONIC). Per-component files in `LICENSES/` is the SPDX-style layout that plays well with `cargo about` / `licensee` / GitHub's license detector, and gives downstream redistributors (especially the Docker image in #131) a clean, machine-checkable license boundary.

## Acceptance criteria status

- [x] Replace existing `LICENSE` with MIT (verify what's there now first — could be Apache-2.0 from Cargo's default) — already MIT, verified by `head -1 LICENSE`. No change to the file.
- [x] `LICENSES/` directory with at minimum: `cyclors-Apache-2.0.txt`, `cyclonedds-EPL-2.0.txt` and `cyclonedds-BSD-3-Clause.txt`, `ort-Apache-2.0.txt` and `ort-MIT.txt`, `crossterm-MIT.txt`, `rerun-Apache-2.0.txt` and `rerun-MIT.txt`, `unitree_sdk2-BSD-3-Clause.txt`, `nvidia-open-model-license.txt` — all present plus the four canonical SPDX texts.
- [x] `LICENSES/README.md` table: component | license file | upstream URL | note — present, 11 rows including this repo.
- [x] `docs/third-party-notices.md` user-friendly summary: 3 license categories (permissive code, weak copyleft, model license), redistribution implications — present.
- [x] CI step in `.github/workflows/license.yml` running `cargo about` or `cargo deny check licenses` against an allowlist — `cargo deny` chosen (broader: licenses + advisories + bans + sources). Allowlist in `deny.toml`.
- [x] CONTRIBUTING.md updated: any PR introducing a new dependency must add the corresponding `LICENSES/<component>-<SPDX>.txt` and a row in `LICENSES/README.md` — `CONTRIBUTING.md` did not exist; created fresh with the dependency-add rule as the central section.
- [x] README top banner — updated the existing `## License` section to point at `LICENSES/`, the third-party notices doc, and `CONTRIBUTING.md`.

## Validation performed

Run on this branch:

* `cargo fmt --check` — clean (whole repo).
* `cargo build --workspace` — pass (the only warning is a sandbox-network cert error fetching `libonnxruntime.so` for the `ort` crate's build script; identical on `main`, unrelated to this PR).
* LICENSES/ layout coverage script (the same logic baked into `.github/workflows/license.yml`) — pass: all 15 required files present, root `LICENSE` matches MIT, `docs/third-party-notices.md` present.
* Manual review of every per-component file: header (component name, upstream URL, SPDX-License-Identifier, used-by) plus pointer to the canonical text. Index table cross-checked against the per-component filenames.

What I did **not** validate:

* `cargo deny check licenses bans advisories sources --all-features --workspace` end-to-end against the live dependency graph. `cargo-deny` is not installed in this sandbox and the workflow installs it via `EmbarkStudios/cargo-deny-action@v2`. The local `deny.toml` is syntactically valid (verified by `toml` parse) but the actual graph traversal will only run on the GH Actions runner. If the existing graph contains an SPDX expression I haven't allow-listed, the CI step will surface it on the first run and a one-line follow-up to `[licenses].allow` will close the gap.
* Verbatim NVIDIA Open Model License text. The file is deliberately a pointer to the authoritative PDF at developer.download.nvidia.com — I do not have a verifiable verbatim copy of that license, and transcribing it imprecisely would be worse than pointing at the source. Redistributors who bundle GEAR-SONIC weights need to fetch the canonical text themselves; this is the reason the robowbc Docker image (issue #131) deliberately does not bundle weights.

## Notes

* **Pre-existing CI failure on the `rust` job (Gate G2 blocker).** `cargo clippy --workspace --all-targets -- -D warnings` continues to fail on `crates/robowbc-core/src/validator.rs:295` with `clippy::needless_raw_string_hashes`, introduced by #138 and unrelated to this PR. Same blocker called out in #139, #140, #141, #142. Per the auto-pr routine's no-bundling rule, this PR does not include a fix — the cleanup belongs to a one-line dedicated PR (remove the `#` hashes around the raw string in `validator.rs:295-303`). Because of this G2 failure I'm opening this as **DRAFT / `[deferred]` per the routine's DIMINISHING RETURNS rule** and not requesting auto-merge. Once the validator.rs lint is cleaned up upstream this should be a clean rebase + un-draft.
* **Foundation-issue gate (G5) — does not fire.** #132 has `priority:high` and is referenced by `#130` and `#131` (2 downstream issues), so on paper G5 applies. But G5's hardware-validation requirement is for "runtime code that talks to `unitree_mujoco`". License infrastructure is not runtime code — there is no `unitree_mujoco` integration test that could meaningfully validate it. The gate is satisfied by the layout-coverage CI step plus `cargo deny`.
* **Per-component file convention.** Each `LICENSES/<component>-<SPDX>.txt` is a header (component, upstream URL, SPDX-License-Identifier, consuming robowbc crate, upstream copyright notice) plus an explicit pointer to the canonical SPDX text in the same directory. This is the REUSE specification approach and avoids 4–5x duplication of long license texts (Apache-2.0 is ~200 lines; copy-pasting it into every consumer file would obscure the diff with no legal benefit). The canonical texts are present in full alongside the per-component files, and the index table makes the mapping unambiguous.
* **`cargo deny` over `cargo about`.** Both are listed as acceptable in #132. `cargo deny` was chosen because it covers four things in one CI step — license allowlist, banned crates, advisory database, and source registry — and is more standard for the "block PR if it introduces a forbidden license" use case. `cargo about` is better for *generating* a redistribution notice; that's a follow-up, not a gate.
* **Discoveries outside scope** (per the routine, noted here, not opened as new issues):
  * The license CI's `licenses-dir-coverage` job is intentionally simple. A richer follow-up would auto-generate a stub `LICENSES/<crate>-<SPDX>.txt` from `cargo metadata --format-version 1` whenever the dependency tree gains a new crate, and fail PRs that didn't add the file. That's a tooling improvement, not a posture change.
  * `third_party/GR00T-WholeBodyControl` is a vendored submodule and is not currently represented in `LICENSES/` because it's a research reference, not a build dependency. If we ever consume it as a dependency, that adds a row.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01HnjkjKX8edoAeoLVnmLa7u)_