### PR TITLE
fix(core): drop needless raw-string hashes in validator test

### DIFF
--- a/crates/robowbc-core/src/validator.rs
+++ b/crates/robowbc-core/src/validator.rs
@@ -292,7 +292,7 @@ mod tests {
     #[test]
     fn per_joint_override_applied_correctly() {
         let config = SafetyLimitsConfig::from_toml_str(
-            r#"
+            r"
 [defaults]
 max_dq_per_step = 0.01
 divergence_threshold = 0.5
@@ -300,7 +300,7 @@ divergence_threshold = 0.5
 [[joint_overrides]]
 index = 1
 divergence_threshold = 0.1
-"#,
+",
         )
         .expect("valid TOML");
 


### PR DESCRIPTION
## What

One-line cleanup: in `crates/robowbc-core/src/validator.rs:295` the TOML literal passed to `SafetyLimitsConfig::from_toml_str` is wrapped in `r#"..."#` but contains no `"` characters, so the surrounding `#` hashes are needless. Drop them — `r"..."` is equivalent and clears the lint.

## Why

This is the workspace-level `clippy::needless_raw_string_hashes` warning that has been blocking `cargo clippy --workspace --all-targets -- -D warnings` ever since #138 merged. Five subsequent draft PRs (#140, #141, #142, #143, plus the now-merged #139) all called it out as the gate-G2 blocker keeping them from satisfying auto-merge.

The auto-pr routine's "no bundling" rule prevents any single feature PR from including this cleanup; it deliberately needs its own one-line PR. This is that PR.

## Validation performed

- `cargo clippy -p robowbc-core --all-targets -- -D warnings` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean (whole workspace, including the previously-failing target)
- `cargo test -p robowbc-core --lib` — **30 tests pass**, including `per_joint_override_applied_correctly` (the test that owns the changed literal) and `safety_limits_config_round_trips_toml`
- `cargo fmt --check` — clean

## Notes

After this lands, #140 / #141 / #142 / #143 should rebase cleanly and their `rust` job will go green, unblocking gate G2 and letting the auto-pr routine flip them out of `[deferred]`.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_0185w4f86C2VjpsVAXeLen1v)_