### PR TITLE
feat(teleop): keyboard teleop with crossterm

### DIFF
--- a/crates/robowbc-teleop/examples/keyboard_demo.rs
+++ b/crates/robowbc-teleop/examples/keyboard_demo.rs
@@ -16,6 +16,13 @@
 //! and run with `docker compose run --rm robowbc <bin>` so the container
 //! attaches to your terminal. Without `tty: true`, [`enable_raw_mode`] errors
 //! with `Inappropriate ioctl for device`.
+//!
+//! A copy-pasteable reference compose file lives at
+//! `docker/keyboard-teleop.compose.yaml` at the workspace root:
+//!
+//! ```text
+//! docker compose -f docker/keyboard-teleop.compose.yaml run --rm teleop
+//! ```
 
 use robowbc_teleop::{KeyboardTeleop, TeleopEvent, TeleopSource};
 use std::time::{Duration, Instant};

--- a/docker/keyboard-teleop.compose.yaml
+++ b/docker/keyboard-teleop.compose.yaml
@@ -1,0 +1,39 @@
+version: "3.9"
+
+# Reference compose snippet for the keyboard teleop demo (issue #127).
+#
+# Caveat #10 of docs/research/2026-05-merged-tech-report.md: crossterm's
+# `enable_raw_mode` requires a real TTY. Without `tty: true` + `stdin_open: true`
+# the demo errors out with `Inappropriate ioctl for device` and the FSM never
+# sees any keystrokes.
+#
+# Usage:
+#   docker compose -f docker/keyboard-teleop.compose.yaml run --rm teleop
+#
+# The image is intentionally a generic Rust toolchain rather than a published
+# robowbc image — this file is the seed compose snippet operators can copy
+# into their own deployment compose files. The runtime CLI (#126) will ship a
+# proper image once the FSM is in place.
+
+services:
+  teleop:
+    image: rust:1.82-slim
+    working_dir: /workspace
+    volumes:
+      - ..:/workspace:ro
+      - cargo-cache:/usr/local/cargo/registry
+    # Both flags are required. `tty: true` allocates a pty so crossterm sees
+    # a TTY; `stdin_open: true` keeps stdin attached so keystrokes flow
+    # through to the container.
+    tty: true
+    stdin_open: true
+    command:
+      - cargo
+      - run
+      - -p
+      - robowbc-teleop
+      - --example
+      - keyboard_demo
+
+volumes:
+  cargo-cache:


### PR DESCRIPTION
## What

Closes out the keyboard-teleop work. The `crates/robowbc-teleop/` crate (`TeleopSource` trait, `KeyboardTeleop`, `KeymapConfig` overlay loader, 21 unit tests including the issue's <30 ms p99 latency check) already landed via #141. The remaining gap was acceptance criterion #5 — *"Works in a `docker run -it` container with `tty: true` + `stdin_open: true` — document the compose snippet"* — which previously lived only as an inline doc comment in `keyboard_demo.rs`.

This PR adds:

- `docker/keyboard-teleop.compose.yaml` — a real, runnable reference compose file with `tty: true` + `stdin_open: true` set, mounting the workspace into a `rust:1.82-slim` image and running `cargo run -p robowbc-teleop --example keyboard_demo`. Matches the `docker/` tree anticipated by the merged tech report (Section 3.1).
- A pointer in `keyboard_demo.rs`'s module doc-comment so operators see the canonical compose path: `docker compose -f docker/keyboard-teleop.compose.yaml run --rm teleop`.

## Why

Closes #127. The issue's last acceptance criterion called for a documented compose snippet specifically because of Caveat #10 in `docs/research/2026-05-merged-tech-report.md`: crossterm's `enable_raw_mode` errors with `Inappropriate ioctl for device` when stdin is not a TTY, which is the default in a non-interactive `docker compose` invocation. A copy-pasteable file is stronger documentation than an inline snippet — operators can `cp` it into their deployment compose stacks instead of retyping from a doc comment.

## Acceptance criteria status

- [x] `TeleopSource` trait with one impl: `KeyboardTeleop` — landed via #141 (`crates/robowbc-teleop/src/lib.rs`, `keyboard.rs`).
- [x] Non-blocking poll at the FSM's tick rate, no separate thread for input — `poll(Duration::ZERO)` in `keyboard.rs`, no `thread::spawn`. Verified via the example loop (`keyboard_demo.rs`) which polls on a 50 Hz tick.
- [x] Key map configurable via `keymap.toml` (overlay defaults) — `KeymapOverlay` + `KeymapConfig::from_toml_str` / `from_toml_file` in `keymap.rs`. `configs/teleop/keymap.toml` ships as the documented example.
- [x] Latency: keypress → cmd update <30 ms p99 (measured by injecting key events) — `keyboard::tests::handle_key_latency_is_well_under_30ms` injects 1024 synthetic events and asserts p99 < 30 ms.
- [x] Works in a `docker run -it` container with `tty: true` + `stdin_open: true` — documented inline in `keyboard_demo.rs` AND now shipped as `docker/keyboard-teleop.compose.yaml`, runnable with `docker compose -f docker/keyboard-teleop.compose.yaml run --rm teleop`.

## Validation performed

On this branch:

- `cargo build --workspace --all-targets` — pass (2m 18s)
- `cargo test -p robowbc-teleop --all-targets` — **21 tests pass** (incl. p99 latency check)
- `cargo clippy -p robowbc-teleop --all-targets -- -D warnings` — clean
- `cargo fmt --check` — clean

Not validated in this sandbox (no Docker daemon available):

- An actual `docker compose -f docker/keyboard-teleop.compose.yaml run --rm teleop` smoke test against a real TTY. The compose file is structurally a literal materialization of the snippet that was already documented in `keyboard_demo.rs` and in Caveat #10 of the tech report; runtime exercise of the docker path belongs to #129 (sim CI).

## Notes

- **Foundation-issue / Gate G5.** #127 is `Depends on`'d by #126 (FSM) and #131 — formally a foundation issue per G5. Teleop is a pure user-input layer that produces `TeleopEvent` values without driving any joints; it does not require `unitree_mujoco` integration. The earlier-merged code (PR #141) already covers all 5 acceptance criteria; this PR is a small documentation completion, not new runtime code.
- **Why ship a docker image base instead of a robowbc-specific one?** This file is meant to be a starting-point snippet operators copy into their own compose stacks. The runtime CLI's own image (with `unitree_mujoco`, ONNX runtime, etc.) is the responsibility of #129 / a future deployment issue, not the teleop crate.

---
_Generated by [Claude Code](https://claude.ai/code)_

---
_Generated by [Claude Code](https://claude.ai/code/session_01AGbCyLGUdfKTqX28xFeuSR)_