### PR TITLE
feat: add interactive MuJoCo keyboard demo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,22 @@ If a check cannot run because of environment limits, report the exact blocker.
 4. **Small, verifiable steps**: build → check → test → lint.
 5. **No dependency drift in fixes**: avoid ad-hoc single-crate installs unless doing triage.
 
+### 4.1 Keyboard demo guardrail
+
+`make demo-keyboard` is the "git clone and see it work" path. Keep
+`configs/demo/gear_sonic_keyboard_mujoco.toml` on the GR00T scene wrapper and
+the explicit `[sim.elastic_band]` support band unless replacing them with an
+equally verified upstream-style startup path. For MuJoCo demo changes, run the
+targeted stability test:
+
+```bash
+MUJOCO_DOWNLOAD_DIR="$(pwd)/.cache/mujoco" \
+MUJOCO_DYNAMIC_LINK_DIR="$(pwd)/.cache/mujoco/mujoco-3.6.0/lib" \
+LD_LIBRARY_PATH="$(pwd)/.cache/mujoco/mujoco-3.6.0/lib:${LD_LIBRARY_PATH:-}" \
+cargo test -p robowbc-sim --features mujoco-auto-download \
+  gear_sonic_demo_model_holds_default_pose_for_startup_window
+```
+
 ---
 
 ## 5) Quick command checklist (copy/paste)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,9 +119,12 @@ If a check cannot run because of environment limits, report the exact blocker.
 
 `make demo-keyboard` is the "git clone and see it work" path. Keep
 `configs/demo/gear_sonic_keyboard_mujoco.toml` on the GR00T scene wrapper and
-the explicit `[sim.elastic_band]` support band unless replacing them with an
-equally verified upstream-style startup path. For MuJoCo demo changes, run the
-targeted stability test:
+the explicit `[sim.elastic_band]` support band anchored from the initialized
+pose unless replacing them with an equally verified upstream-style startup
+path. Keep `[runtime].require_engage = true` and `[runtime].init_pose_secs`
+enabled so `]` engages policy only after the robot settles. Keep the demo
+scene visibly lit enough to inspect foot contact in the MuJoCo viewer. For
+MuJoCo demo changes, run the targeted stability test:
 
 ```bash
 MUJOCO_DOWNLOAD_DIR="$(pwd)/.cache/mujoco" \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,22 @@ If instructions conflict, priority is:
 
 ---
 
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs are tracked in GitHub Issues for `MiaoDX/robowbc` using GitHub MCP tools. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Use the default five-label triage vocabulary. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context repo; read the root project docs as the canonical domain context. See `docs/agents/domain.md`.
+
+---
+
 ## 1) Environment preflight (mandatory before tests)
 
 Do not run tests immediately on a fresh environment.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,20 @@ When a CI check fails, **always read the actual logs/error messages** before dia
 - Rust toolchain: stable (1.75+)
 - Key crates: `ort`, `zenoh`, `pyo3`, `inventory`, `serde`, `toml`
 
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs are tracked in GitHub Issues for `MiaoDX/robowbc` using GitHub MCP tools. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Use the default five-label triage vocabulary. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context repo; read the root project docs as the canonical domain context. See `docs/agents/domain.md`.
+
 ## Subagent strategy
 
 - **Maximize parallelism.** Run independent tasks as concurrent subagents.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b5ace29ee3216de37c0546865ad08edef58b0f9e76838ed8959a84a990e58c5"
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01c0457472c38ea5bd1c3b5ada5e368271cb550be7a4ca4a0b4634e9913f6cc2"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
+
+[[package]]
 name = "accesskit"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5331,12 +5347,14 @@ dependencies = [
  "bytemuck",
  "flate2",
  "glutin",
+ "glutin-winit",
  "paste",
  "pkg-config",
  "png 0.18.1",
  "sha2",
  "tar",
  "ureq",
+ "winit",
  "zip 6.0.0",
 ]
 
@@ -6230,6 +6248,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
 dependencies = [
  "ureq",
+]
+
+[[package]]
+name = "owned_ttf_parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36820e9051aca1014ddc75770aab4d68bc1e9e632f0f5627c4086bc216fb583b"
+dependencies = [
+ "ttf-parser",
 ]
 
 [[package]]
@@ -9610,6 +9637,7 @@ dependencies = [
  "robowbc-ort",
  "robowbc-registry",
  "robowbc-sim",
+ "robowbc-teleop",
  "robowbc-vis",
  "serde",
  "serde_json",
@@ -10012,6 +10040,19 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sctk-adwaita"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6277f0217056f77f1d8f49f2950ac6c278c0d607c45f5ee99328d792ede24ec"
+dependencies = [
+ "ab_glyph",
+ "log",
+ "memmap2 0.9.10",
+ "smithay-client-toolkit 0.19.2",
+ "tiny-skia",
+]
 
 [[package]]
 name = "scuffle-av1"
@@ -11499,6 +11540,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+
+[[package]]
 name = "tungstenite"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12837,6 +12884,7 @@ dependencies = [
  "raw-window-handle",
  "redox_syscall 0.4.1",
  "rustix 0.38.44",
+ "sctk-adwaita",
  "smithay-client-toolkit 0.19.2",
  "smol_str",
  "tracing",

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ PYTHON_SDK_TARGET_DIR ?= $(CURDIR)/target/python-sdk-wheel
 
 .DEFAULT_GOAL := help
 
-.PHONY: help toolchain build build-release check test sim-feature-test clippy fmt fmt-check rust-doc mdbook-install docs-book docs verify smoke models-public site-python-deps site-render-check benchmark-robowbc benchmark-official benchmark-summary benchmark-nvidia site showcase-verify site-smoke site-browser-smoke site-serve-check site-serve python-sdk-deps python-sdk-build python-sdk-install python-sdk-smoke python-sdk-verify ci
+.PHONY: help toolchain build build-release check test sim-feature-test clippy fmt fmt-check rust-doc mdbook-install docs-book docs verify smoke demo-keyboard models-public site-python-deps site-render-check benchmark-robowbc benchmark-official benchmark-summary benchmark-nvidia site showcase-verify site-smoke site-browser-smoke site-serve-check site-serve python-sdk-deps python-sdk-build python-sdk-install python-sdk-smoke python-sdk-verify ci
 
 help: ## Show available targets and useful variables.
 	@awk 'BEGIN {FS = ":.*## "; print "Targets:"} /^[a-zA-Z0-9_.-]+:.*## / {printf "  %-20s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -105,6 +105,18 @@ verify: check test clippy fmt-check ## Run the standard Rust validation suite.
 
 smoke: ## Run the no-download local decoupled_wbc smoke config.
 	$(CARGO) run --bin robowbc -- run --config configs/decoupled_smoke.toml
+
+demo-keyboard: ## Run the interactive GEAR-Sonic + MuJoCo keyboard demo.
+	bash scripts/download_gear_sonic_models.sh models/gear-sonic
+	download_dir="$(abspath $(MUJOCO_DOWNLOAD_DIR))"; \
+	"$(PYTHON)" scripts/ensure_mujoco_runtime.py --download-dir "$$download_dir" >/dev/null; \
+	link_dir="$(MUJOCO_DYNAMIC_LINK_DIR)"; \
+	MUJOCO_DOWNLOAD_DIR="$$download_dir" \
+	MUJOCO_DYNAMIC_LINK_DIR="$$link_dir" \
+	LD_LIBRARY_PATH="$$link_dir:$${LD_LIBRARY_PATH:-}" \
+	$(CARGO) run --release -p robowbc-cli \
+		--features robowbc-cli/sim-auto-download,robowbc-cli/sim-viewer \
+		-- run --config configs/demo/gear_sonic_keyboard_mujoco.toml --teleop keyboard
 
 models-public: ## Download the public policy checkpoints used by the site and benchmarks.
 	bash scripts/download_gear_sonic_models.sh models/gear-sonic

--- a/README.md
+++ b/README.md
@@ -143,11 +143,12 @@ make demo-keyboard
 The target downloads the public GEAR-Sonic ONNX files and the MuJoCo runtime
 on first run, starts the local MuJoCo transport with a live viewer, and runs
 `robowbc` with keyboard teleop. The checked-in demo uses the GR00T scene
-wrapper plus its virtual support band so the robot stays recoverable while you
-drive it. Keep the terminal focused for input and watch the MuJoCo window:
-`WASD` changes linear velocity, `QE` changes yaw, `Space` zeroes velocity,
-`O` sends a zero-velocity emergency-stop tick, and `Esc` quits. The underlying
-manual command is:
+wrapper plus a neutral-height virtual support band so the robot stays
+recoverable without being lifted off the ground. Keep the terminal focused for
+input and watch the MuJoCo window: `]` engages the policy after the init pose
+settles, `WASD` changes linear velocity, `QE` changes yaw, `Space` zeroes
+velocity, `9` toggles the support band, `O` sends a zero-velocity emergency-stop
+tick, and `Esc` quits. The underlying manual command is:
 
 ```bash
 MUJOCO_DOWNLOAD_DIR="$(pwd)/.cache/mujoco" \

--- a/README.md
+++ b/README.md
@@ -130,6 +130,31 @@ fixture, so it is the intended no-download local smoke path. `make ci` runs
 the same repo entry points that GitHub CI uses for Rust validation, docs,
 Python SDK verification, and the generated HTML site bundle.
 
+### I Just Want To See It Move
+
+On Linux with a display and OpenGL available:
+
+```bash
+git clone https://github.com/MiaoDX/robowbc
+cd robowbc
+make demo-keyboard
+```
+
+The target downloads the public GEAR-Sonic ONNX files on first run, starts the
+local MuJoCo transport with a live viewer, and runs `robowbc` with keyboard
+teleop. Keep the terminal focused for input and watch the MuJoCo window:
+`WASD` changes linear velocity, `QE` changes yaw, `Space` zeroes velocity,
+`O` sends a zero-velocity emergency-stop tick, and `Esc` quits. The underlying
+manual command is:
+
+```bash
+MUJOCO_DOWNLOAD_DIR="$(pwd)/.cache/mujoco" \
+LD_LIBRARY_PATH="$(pwd)/.cache/mujoco/mujoco-3.6.0/lib:${LD_LIBRARY_PATH:-}" \
+cargo run --release -p robowbc-cli \
+  --features robowbc-cli/sim-auto-download,robowbc-cli/sim-viewer \
+  -- run --config configs/demo/gear_sonic_keyboard_mujoco.toml --teleop keyboard
+```
+
 <details>
 <summary><strong>Run the live public policies</strong></summary>
 

--- a/README.md
+++ b/README.md
@@ -140,9 +140,11 @@ cd robowbc
 make demo-keyboard
 ```
 
-The target downloads the public GEAR-Sonic ONNX files on first run, starts the
-local MuJoCo transport with a live viewer, and runs `robowbc` with keyboard
-teleop. Keep the terminal focused for input and watch the MuJoCo window:
+The target downloads the public GEAR-Sonic ONNX files and the MuJoCo runtime
+on first run, starts the local MuJoCo transport with a live viewer, and runs
+`robowbc` with keyboard teleop. The checked-in demo uses the GR00T scene
+wrapper plus its virtual support band so the robot stays recoverable while you
+drive it. Keep the terminal focused for input and watch the MuJoCo window:
 `WASD` changes linear velocity, `QE` changes yaw, `Space` zeroes velocity,
 `O` sends a zero-velocity emergency-stop tick, and `Esc` quits. The underlying
 manual command is:

--- a/assets/robots/groot_g1_gear_sonic/scene_29dof.xml
+++ b/assets/robots/groot_g1_gear_sonic/scene_29dof.xml
@@ -1,0 +1,29 @@
+<mujoco model="g1_29dof scene">
+  <include file="g1_29dof_old.xml"/>
+
+  <statistic center="0 0 0.5" extent="2.0"/>
+
+  <visual>
+    <headlight diffuse="0.9 0.9 0.9" ambient="0.55 0.55 0.55" specular="0.1 0.1 0.1"/>
+    <rgba haze="0.35 0.45 0.55 1"/>
+    <global azimuth="-130" elevation="-20"/>
+  </visual>
+
+  <asset>
+    <texture type="skybox" builtin="gradient" rgb1="0.55 0.70 0.85" rgb2="0.85 0.90 0.95" width="512" height="3072"/>
+    <texture type="2d" name="groundplane" builtin="checker" mark="edge" rgb1="0.58 0.62 0.66" rgb2="0.72 0.75 0.78"
+      markrgb="0.25 0.25 0.25" width="300" height="300"/>
+    <material name="groundplane" texture="groundplane" texuniform="true" texrepeat="5 5" reflectance="0.25"/>
+  </asset>
+
+  <worldbody>
+    <light pos="0 0 2.5" dir="0 0 -1" directional="true" diffuse="0.8 0.8 0.8" ambient="0.2 0.2 0.2"/>
+    <geom name="floor" size="0 0 0.05" type="plane" material="groundplane"/>
+    <site name="com_marker" pos="0.1 0 0" size="0.05" rgba="1 0 0 1" type="sphere"/>
+    <camera name="global_view" pos="2.910 -5.040 3.860" xyaxes="0.866 0.500 0.000 -0.250 0.433 0.866"/>
+  </worldbody>
+
+  <default>
+    <geom friction="0.5"/>
+  </default>
+</mujoco>

--- a/configs/demo/gear_sonic_keyboard_mujoco.toml
+++ b/configs/demo/gear_sonic_keyboard_mujoco.toml
@@ -40,11 +40,22 @@ num_threads = 1
 config_path = "configs/robots/unitree_g1_gear_sonic.toml"
 
 [sim]
-model_path = "assets/robots/groot_g1_gear_sonic/g1_29dof_old.xml"
+model_path = "assets/robots/groot_g1_gear_sonic/scene_29dof.xml"
 timestep = 0.002
 substeps = 10
 gain_profile = "simulation_pd"
 viewer = true
+
+[sim.elastic_band]
+# Matches GR00T's MuJoCo teleop support band. It keeps the humanoid recoverable
+# while a new user starts the keyboard demo and then drives with WASD/QE.
+body_name = "pelvis"
+anchor = [0.0, 0.0, 1.0]
+length = 0.0
+kp_pos = 10000.0
+kd_pos = 1000.0
+kp_ang = 1000.0
+kd_ang = 10.0
 
 [comm]
 frequency_hz = 50

--- a/configs/demo/gear_sonic_keyboard_mujoco.toml
+++ b/configs/demo/gear_sonic_keyboard_mujoco.toml
@@ -1,0 +1,62 @@
+# Interactive GEAR-Sonic keyboard demo on the local MuJoCo transport.
+#
+# Run through the repo-level shortcut:
+#
+#   make demo-keyboard
+#
+# Or manually:
+#
+#   bash scripts/download_gear_sonic_models.sh
+#   MUJOCO_DOWNLOAD_DIR="$(pwd)/.cache/mujoco" \
+#   LD_LIBRARY_PATH="$(pwd)/.cache/mujoco/mujoco-3.6.0/lib:${LD_LIBRARY_PATH:-}" \
+#   cargo run --release -p robowbc-cli \
+#     --features robowbc-cli/sim-auto-download,robowbc-cli/sim-viewer \
+#     -- run --config configs/demo/gear_sonic_keyboard_mujoco.toml --teleop keyboard
+#
+# Keep your terminal focused for keyboard input and watch the MuJoCo window.
+
+[policy]
+name = "gear_sonic"
+
+[policy.config.encoder]
+model_path = "models/gear-sonic/model_encoder.onnx"
+execution_provider = { type = "cpu" }
+optimization_level = "extended"
+num_threads = 1
+
+[policy.config.decoder]
+model_path = "models/gear-sonic/model_decoder.onnx"
+execution_provider = { type = "cpu" }
+optimization_level = "extended"
+num_threads = 1
+
+[policy.config.planner]
+model_path = "models/gear-sonic/planner_sonic.onnx"
+execution_provider = { type = "cpu" }
+optimization_level = "extended"
+num_threads = 1
+
+[robot]
+config_path = "configs/robots/unitree_g1_gear_sonic.toml"
+
+[sim]
+model_path = "assets/robots/groot_g1_gear_sonic/g1_29dof_old.xml"
+timestep = 0.002
+substeps = 10
+gain_profile = "simulation_pd"
+viewer = true
+
+[comm]
+frequency_hz = 50
+topics = { joint_state = "unitree/g1/joint_state", imu = "unitree/g1/imu", joint_target_command = "unitree/g1/command/joint_position" }
+
+[inference]
+backend = "ort"
+device = "cpu"
+
+[runtime]
+# Keyboard teleop requires an initial velocity command. `--teleop keyboard`
+# then owns the command stream: WASD updates vx/vy, QE updates yaw, Space
+# zeroes velocity, O sends a zero-velocity e-stop tick, and Esc quits.
+velocity = [0.0, 0.0, 0.0]
+max_ticks = 200

--- a/configs/demo/gear_sonic_keyboard_mujoco.toml
+++ b/configs/demo/gear_sonic_keyboard_mujoco.toml
@@ -70,8 +70,8 @@ device = "cpu"
 
 [runtime]
 # Keyboard teleop starts in an init pose. Press `]` to engage the policy, then
-# use WASD/QE to drive. Press `9` to toggle the elastic support band.
+# use WASD/QE to drive. Press `9` to toggle the elastic support band. Live
+# teleop runs until Esc or Ctrl-C.
 velocity = [0.0, 0.0, 0.0]
 init_pose_secs = 3.0
 require_engage = true
-max_ticks = 200

--- a/configs/demo/gear_sonic_keyboard_mujoco.toml
+++ b/configs/demo/gear_sonic_keyboard_mujoco.toml
@@ -13,7 +13,8 @@
 #     --features robowbc-cli/sim-auto-download,robowbc-cli/sim-viewer \
 #     -- run --config configs/demo/gear_sonic_keyboard_mujoco.toml --teleop keyboard
 #
-# Keep your terminal focused for keyboard input and watch the MuJoCo window.
+# Keep your terminal focused for keyboard input and watch the MuJoCo window:
+# `]` engages policy, WASD/QE drive, `9` toggles the support band.
 
 [policy]
 name = "gear_sonic"
@@ -47,10 +48,12 @@ gain_profile = "simulation_pd"
 viewer = true
 
 [sim.elastic_band]
-# Matches GR00T's MuJoCo teleop support band. It keeps the humanoid recoverable
-# while a new user starts the keyboard demo and then drives with WASD/QE.
+# GR00T-style MuJoCo teleop support band. We anchor it to the initialized
+# pelvis pose so it catches a fall without lifting the feet off the ground.
+enabled = true
 body_name = "pelvis"
 anchor = [0.0, 0.0, 1.0]
+anchor_from_initial_pose = true
 length = 0.0
 kp_pos = 10000.0
 kd_pos = 1000.0
@@ -66,8 +69,9 @@ backend = "ort"
 device = "cpu"
 
 [runtime]
-# Keyboard teleop requires an initial velocity command. `--teleop keyboard`
-# then owns the command stream: WASD updates vx/vy, QE updates yaw, Space
-# zeroes velocity, O sends a zero-velocity e-stop tick, and Esc quits.
+# Keyboard teleop starts in an init pose. Press `]` to engage the policy, then
+# use WASD/QE to drive. Press `9` to toggle the elastic support band.
 velocity = [0.0, 0.0, 0.0]
+init_pose_secs = 3.0
+require_engage = true
 max_ticks = 200

--- a/configs/robots/unitree_g1_gear_sonic.toml
+++ b/configs/robots/unitree_g1_gear_sonic.toml
@@ -76,39 +76,40 @@ pd_gains = [
     { kp = 16.778327, kd = 1.068142 },  # right_wrist_yaw
 ]
 
-# MuJoCo needs a slightly stiffer lower body/waist than the official q_target
-# path to keep the showcase turn dynamics aligned. Keep the upper-body gains
-# unchanged so only the simulated plant compensation differs.
+# MuJoCo/raw-torque gains from the official GR00T G1 sim config
+# (`MOTOR_KP` / `MOTOR_KD` in g1_29dof_gear_wbc.yaml). These are intentionally
+# much stiffer than the hardware-side q_target gains above and are only used by
+# the simulation transport.
 sim_pd_gains = [
-    { kp = 123.873035, kd = 7.8860025 },  # left_hip_pitch
-    { kp = 123.873035, kd = 7.8860025 },  # left_hip_roll
-    { kp = 50.2240475, kd = 3.1973625 },  # left_hip_yaw
-    { kp = 123.873035, kd = 7.8860025 },  # left_knee
-    { kp = 35.6265575, kd = 2.2680575 },  # left_ankle_pitch
-    { kp = 35.6265575, kd = 2.2680575 },  # left_ankle_roll
-    { kp = 123.873035, kd = 7.8860025 },  # right_hip_pitch
-    { kp = 123.873035, kd = 7.8860025 },  # right_hip_roll
-    { kp = 50.2240475, kd = 3.1973625 },  # right_hip_yaw
-    { kp = 123.873035, kd = 7.8860025 },  # right_knee
-    { kp = 35.6265575, kd = 2.2680575 },  # right_ankle_pitch
-    { kp = 35.6265575, kd = 2.2680575 },  # right_ankle_roll
-    { kp = 50.2240475, kd = 3.1973625 },  # waist_yaw
-    { kp = 35.6265575, kd = 2.2680575 },  # waist_roll
-    { kp = 35.6265575, kd = 2.2680575 },  # waist_pitch
-    { kp = 14.250623, kd = 0.907223 },  # left_shoulder_pitch
-    { kp = 14.250623, kd = 0.907223 },  # left_shoulder_roll
-    { kp = 14.250623, kd = 0.907223 },  # left_shoulder_yaw
-    { kp = 14.250623, kd = 0.907223 },  # left_elbow
-    { kp = 14.250623, kd = 0.907223 },  # left_wrist_roll
-    { kp = 16.778327, kd = 1.068142 },  # left_wrist_pitch
-    { kp = 16.778327, kd = 1.068142 },  # left_wrist_yaw
-    { kp = 14.250623, kd = 0.907223 },  # right_shoulder_pitch
-    { kp = 14.250623, kd = 0.907223 },  # right_shoulder_roll
-    { kp = 14.250623, kd = 0.907223 },  # right_shoulder_yaw
-    { kp = 14.250623, kd = 0.907223 },  # right_elbow
-    { kp = 14.250623, kd = 0.907223 },  # right_wrist_roll
-    { kp = 16.778327, kd = 1.068142 },  # right_wrist_pitch
-    { kp = 16.778327, kd = 1.068142 },  # right_wrist_yaw
+    { kp = 150.0, kd = 2.0 },  # left_hip_pitch
+    { kp = 150.0, kd = 2.0 },  # left_hip_roll
+    { kp = 150.0, kd = 2.0 },  # left_hip_yaw
+    { kp = 200.0, kd = 4.0 },  # left_knee
+    { kp =  40.0, kd = 2.0 },  # left_ankle_pitch
+    { kp =  40.0, kd = 2.0 },  # left_ankle_roll
+    { kp = 150.0, kd = 2.0 },  # right_hip_pitch
+    { kp = 150.0, kd = 2.0 },  # right_hip_roll
+    { kp = 150.0, kd = 2.0 },  # right_hip_yaw
+    { kp = 200.0, kd = 4.0 },  # right_knee
+    { kp =  40.0, kd = 2.0 },  # right_ankle_pitch
+    { kp =  40.0, kd = 2.0 },  # right_ankle_roll
+    { kp = 250.0, kd = 5.0 },  # waist_yaw
+    { kp = 250.0, kd = 5.0 },  # waist_roll
+    { kp = 250.0, kd = 5.0 },  # waist_pitch
+    { kp = 100.0, kd = 5.0 },  # left_shoulder_pitch
+    { kp = 100.0, kd = 5.0 },  # left_shoulder_roll
+    { kp =  40.0, kd = 2.0 },  # left_shoulder_yaw
+    { kp =  40.0, kd = 2.0 },  # left_elbow
+    { kp =  20.0, kd = 2.0 },  # left_wrist_roll
+    { kp =  20.0, kd = 2.0 },  # left_wrist_pitch
+    { kp =  20.0, kd = 2.0 },  # left_wrist_yaw
+    { kp = 100.0, kd = 5.0 },  # right_shoulder_pitch
+    { kp = 100.0, kd = 5.0 },  # right_shoulder_roll
+    { kp =  40.0, kd = 2.0 },  # right_shoulder_yaw
+    { kp =  40.0, kd = 2.0 },  # right_elbow
+    { kp =  20.0, kd = 2.0 },  # right_wrist_roll
+    { kp =  20.0, kd = 2.0 },  # right_wrist_pitch
+    { kp =  20.0, kd = 2.0 },  # right_wrist_yaw
 ]
 
 # Joint limits from g1_29dof.xml MuJoCo model (radians).

--- a/crates/robowbc-cli/Cargo.toml
+++ b/crates/robowbc-cli/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/main.rs"
 [features]
 default = []
 sim = ["dep:robowbc-sim", "robowbc-sim/mujoco"]
+sim-viewer = ["sim", "robowbc-sim/mujoco-viewer"]
 sim-auto-download = ["sim", "robowbc-sim/mujoco-auto-download"]
 vis = ["dep:robowbc-vis", "robowbc-vis/rerun"]
 
@@ -23,6 +24,7 @@ robowbc-core = { path = "../robowbc-core" }
 robowbc-ort = { path = "../robowbc-ort" }
 robowbc-registry = { path = "../robowbc-registry" }
 robowbc-sim = { path = "../robowbc-sim", optional = true }
+robowbc-teleop = { path = "../robowbc-teleop" }
 robowbc-vis = { path = "../robowbc-vis", optional = true }
 serde.workspace = true
 serde_json = "1"

--- a/crates/robowbc-cli/src/main.rs
+++ b/crates/robowbc-cli/src/main.rs
@@ -2063,6 +2063,33 @@ mod tests {
         }
     }
 
+    #[cfg(feature = "sim")]
+    #[test]
+    fn keyboard_demo_config_keeps_scene_wrapper_and_elastic_band() {
+        let workspace_root = Path::new(env!("CARGO_MANIFEST_DIR")).join("..").join("..");
+        let raw = std::fs::read_to_string(
+            workspace_root.join("configs/demo/gear_sonic_keyboard_mujoco.toml"),
+        )
+        .expect("keyboard demo config should be readable");
+        let parsed: AppConfig = toml::from_str(&raw).expect("keyboard demo config should parse");
+        let sim = parsed.sim.expect("keyboard demo must configure MuJoCo");
+        assert_eq!(
+            sim.model_path,
+            PathBuf::from("assets/robots/groot_g1_gear_sonic/scene_29dof.xml")
+        );
+
+        let band = sim
+            .elastic_band
+            .expect("keyboard demo must keep the upstream-style support band");
+        assert_eq!(band.body_name, "pelvis");
+        assert_eq!(band.anchor, [0.0, 0.0, 1.0]);
+        assert_eq!(band.length, 0.0);
+        assert_eq!(band.kp_pos, 10_000.0);
+        assert_eq!(band.kd_pos, 1_000.0);
+        assert_eq!(band.kp_ang, 1_000.0);
+        assert_eq!(band.kd_ang, 10.0);
+    }
+
     #[test]
     fn teleop_velocity_event_updates_live_command() {
         let mut velocity = [0.0, 0.0, 0.0];

--- a/crates/robowbc-cli/src/main.rs
+++ b/crates/robowbc-cli/src/main.rs
@@ -295,6 +295,13 @@ struct RuntimeConfig {
     /// requires `[policy.config.reference_motion]` to select the official clip.
     #[serde(default)]
     reference_motion_tracking: bool,
+    /// Seconds spent interpolating from the observed pose to the configured
+    /// robot default pose before policy output is allowed.
+    #[serde(default)]
+    init_pose_secs: f32,
+    /// When true, hold the init pose until teleop sends `]`.
+    #[serde(default)]
+    require_engage: bool,
     #[serde(default)]
     max_ticks: Option<usize>,
 }
@@ -312,9 +319,61 @@ impl Default for RuntimeConfig {
             kinematic_pose: None,
             standing_placeholder_tracking: false,
             reference_motion_tracking: false,
+            init_pose_secs: 0.0,
+            require_engage: false,
             max_ticks: Some(200),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct RuntimeStartupConfig {
+    init_pose_secs: f32,
+    require_engage: bool,
+}
+
+impl RuntimeStartupConfig {
+    #[cfg(test)]
+    const fn disabled() -> Self {
+        Self {
+            init_pose_secs: 0.0,
+            require_engage: false,
+        }
+    }
+
+    const fn enabled(self) -> bool {
+        self.require_engage || self.init_pose_secs > 0.0
+    }
+}
+
+fn startup_config_from_runtime(runtime: &RuntimeConfig) -> RuntimeStartupConfig {
+    RuntimeStartupConfig {
+        init_pose_secs: runtime.init_pose_secs,
+        require_engage: runtime.require_engage,
+    }
+}
+
+fn smoothstep(t: f32) -> f32 {
+    let t = t.clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
+}
+
+fn init_pose_positions(
+    start_positions: &[f32],
+    default_pose: &[f32],
+    elapsed: Duration,
+    duration_secs: f32,
+) -> Vec<f32> {
+    if duration_secs <= 0.0 {
+        return default_pose.to_vec();
+    }
+    let alpha = (elapsed.as_secs_f32() / duration_secs).clamp(0.0, 1.0);
+    let s = smoothstep(alpha);
+    start_positions
+        .iter()
+        .zip(default_pose.iter())
+        .map(|(&start, &target)| start + (target - start) * s)
+        .collect()
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -867,8 +926,16 @@ impl TeleopMode {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]
+enum TeleopControlRequest {
+    Engage,
+    Reset,
+    ToggleElasticBand,
+}
+
+#[derive(Debug, Clone, PartialEq)]
 struct TeleopPollOutcome {
     velocity: [f32; 3],
+    requests: Vec<TeleopControlRequest>,
     stop_after_tick: bool,
 }
 
@@ -877,6 +944,7 @@ fn apply_teleop_events(
     events: &[TeleopEvent],
 ) -> TeleopPollOutcome {
     let mut stop_after_tick = false;
+    let mut requests = Vec::new();
     for event in events {
         match *event {
             TeleopEvent::Velocity { vx, vy, wz } => {
@@ -893,17 +961,23 @@ fn apply_teleop_events(
                 println!("teleop quit requested");
             }
             TeleopEvent::Engage => {
+                requests.push(TeleopControlRequest::Engage);
                 println!("teleop engage requested");
             }
             TeleopEvent::Reset => {
+                requests.push(TeleopControlRequest::Reset);
                 *current_velocity = [0.0, 0.0, 0.0];
                 println!("teleop reset requested: velocity zeroed");
+            }
+            TeleopEvent::ToggleElasticBand => {
+                requests.push(TeleopControlRequest::ToggleElasticBand);
             }
         }
     }
 
     TeleopPollOutcome {
         velocity: *current_velocity,
+        requests,
         stop_after_tick,
     }
 }
@@ -919,7 +993,9 @@ impl LiveTeleop {
         source
             .enable()
             .map_err(|err| format!("failed to enable keyboard teleop: {err}"))?;
-        println!("keyboard teleop active: WASD move, QE yaw, Space zeroes velocity, O e-stops, Esc quits");
+        println!(
+            "keyboard teleop active: ] engages policy, WASD move, QE yaw, Space zeroes velocity, 9 toggles support band, O e-stops, Esc quits"
+        );
         Ok(Self {
             source,
             current_velocity: initial_velocity,
@@ -1054,6 +1130,9 @@ fn validate_config(config: &AppConfig) -> Result<ParsedRuntimeCommand, String> {
     }
     if config.inference.device.trim().is_empty() {
         return Err("inference.device must not be empty".to_owned());
+    }
+    if !config.runtime.init_pose_secs.is_finite() || config.runtime.init_pose_secs < 0.0 {
+        return Err("runtime.init_pose_secs must be a finite value >= 0".to_owned());
     }
     if let Some(schedule) = &config.runtime.velocity_schedule {
         schedule.validate_for_frequency(config.comm.frequency_hz)?;
@@ -1437,8 +1516,10 @@ fn world_to_body_planar_delta(
 fn run_control_loop_inner<T: RobotTransport + ReportTelemetryProvider>(
     transport: &mut T,
     policy: &dyn WbcPolicy,
+    robot: &RobotConfig,
     comm: &CommConfig,
     runtime_command: &ParsedRuntimeCommand,
+    startup_config: RuntimeStartupConfig,
     live_teleop: &mut Option<LiveTeleop>,
     max_ticks: Option<usize>,
     running: &AtomicBool,
@@ -1452,6 +1533,12 @@ fn run_control_loop_inner<T: RobotTransport + ReportTelemetryProvider>(
     let mut ticks: usize = 0;
     let mut dropped_frames: usize = 0;
     let mut inference_total = Duration::ZERO;
+    let mut policy_engaged = !startup_config.enabled();
+    let mut init_pose_start: Option<(Instant, Vec<f32>)> = None;
+
+    if startup_config.require_engage {
+        println!("startup init pose active: press ] to engage policy after the robot settles");
+    }
 
     while running.load(Ordering::SeqCst) {
         if let Some(max_ticks) = max_ticks {
@@ -1465,6 +1552,40 @@ fn run_control_loop_inner<T: RobotTransport + ReportTelemetryProvider>(
         let mut stop_after_tick = false;
         let (command, tick_command_data) = if let Some(teleop) = live_teleop.as_mut() {
             let outcome = teleop.poll()?;
+            for request in &outcome.requests {
+                match request {
+                    TeleopControlRequest::Reset => {
+                        policy.reset();
+                        policy_engaged = false;
+                        init_pose_start = None;
+                        println!("startup init pose reset: press ] to re-engage policy");
+                    }
+                    TeleopControlRequest::Engage => {
+                        policy.reset();
+                        policy_engaged = true;
+                        init_pose_start = None;
+                        println!("policy engaged");
+                    }
+                    TeleopControlRequest::ToggleElasticBand => {
+                        match transport.toggle_elastic_band() {
+                            Ok(Some(enabled)) => {
+                                println!(
+                                    "elastic support band {}",
+                                    if enabled { "enabled" } else { "disabled" }
+                                );
+                            }
+                            Ok(None) => {
+                                println!("elastic support band unavailable for this transport");
+                            }
+                            Err(err) => {
+                                return Err(format!(
+                                    "failed to toggle elastic support band: {err}"
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
             stop_after_tick = outcome.stop_after_tick;
             (
                 velocity_command(outcome.velocity),
@@ -1483,7 +1604,29 @@ fn run_control_loop_inner<T: RobotTransport + ReportTelemetryProvider>(
 
         run_control_tick(transport, command.clone(), |obs| {
             let infer_start = Instant::now();
-            let output = policy.predict(&obs);
+            let output = if policy_engaged {
+                policy.predict(&obs)
+            } else {
+                let (start_time, start_positions) = init_pose_start
+                    .get_or_insert_with(|| (obs.timestamp, obs.joint_positions.clone()));
+                let elapsed = obs.timestamp.saturating_duration_since(*start_time);
+                if !startup_config.require_engage
+                    && elapsed.as_secs_f32() >= startup_config.init_pose_secs
+                {
+                    policy_engaged = true;
+                    policy.predict(&obs)
+                } else {
+                    Ok(JointPositionTargets {
+                        positions: init_pose_positions(
+                            start_positions,
+                            &robot.default_pose,
+                            elapsed,
+                            startup_config.init_pose_secs,
+                        ),
+                        timestamp: obs.timestamp,
+                    })
+                }
+            };
             let elapsed = infer_start.elapsed();
             inference_total += elapsed;
 
@@ -1569,6 +1712,7 @@ fn run_control_loop(
     robot: &RobotConfig,
     comm: &CommConfig,
     runtime_command: &ParsedRuntimeCommand,
+    startup_config: RuntimeStartupConfig,
     live_teleop: &mut Option<LiveTeleop>,
     requested_max_ticks: Option<usize>,
     report_config: Option<&ReportConfig>,
@@ -1616,8 +1760,10 @@ fn run_control_loop(
             let (ticks, dropped, inf) = run_control_loop_inner(
                 &mut transport,
                 policy,
+                robot,
                 comm,
                 runtime_command,
+                startup_config,
                 live_teleop,
                 requested_max_ticks,
                 running,
@@ -1649,8 +1795,10 @@ fn run_control_loop(
             let (ticks, dropped, inf) = run_control_loop_inner(
                 &mut transport,
                 policy,
+                robot,
                 comm,
                 runtime_command,
+                startup_config,
                 live_teleop,
                 requested_max_ticks,
                 running,
@@ -1681,8 +1829,10 @@ fn run_control_loop(
             let (ticks, dropped, inf) = run_control_loop_inner(
                 &mut transport,
                 policy,
+                robot,
                 comm,
                 runtime_command,
+                startup_config,
                 live_teleop,
                 requested_max_ticks,
                 running,
@@ -1712,8 +1862,10 @@ fn run_control_loop(
             let (ticks, dropped, inf) = run_control_loop_inner(
                 &mut transport,
                 policy,
+                robot,
                 comm,
                 runtime_command,
+                startup_config,
                 live_teleop,
                 requested_max_ticks,
                 running,
@@ -1735,8 +1887,10 @@ fn run_control_loop(
             let (ticks, dropped, inf) = run_control_loop_inner(
                 &mut transport,
                 policy,
+                robot,
                 comm,
                 runtime_command,
+                startup_config,
                 live_teleop,
                 requested_max_ticks,
                 running,
@@ -1865,6 +2019,11 @@ fn run_with_config(config_path: &Path, teleop_mode: Option<TeleopMode>) -> anyho
         .with_context(|| format!("while building policy {policy_name:?}"))?;
     let mut live_teleop = validate_teleop_mode(teleop_mode, &runtime_command, &*policy)
         .map_err(|err| anyhow!("invalid teleop setup: {err}"))?;
+    if app.runtime.require_engage && live_teleop.is_none() {
+        return Err(anyhow!(
+            "runtime.require_engage = true requires a live teleop mode such as `--teleop keyboard`"
+        ));
+    }
 
     let running = Arc::new(AtomicBool::new(true));
     install_ctrlc_handler(&running)?;
@@ -1881,6 +2040,7 @@ fn run_with_config(config_path: &Path, teleop_mode: Option<TeleopMode>) -> anyho
         &robot,
         &app.comm,
         &runtime_command,
+        startup_config_from_runtime(&app.runtime),
         &mut live_teleop,
         requested_max_ticks,
         report_config.as_ref(),
@@ -1965,6 +2125,54 @@ fn main() {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::AtomicUsize;
+
+    struct CountingPolicy {
+        calls: AtomicUsize,
+        robot: Vec<RobotConfig>,
+        output_positions: Vec<f32>,
+    }
+
+    impl CountingPolicy {
+        fn new(robot: RobotConfig, output_positions: Vec<f32>) -> Self {
+            Self {
+                calls: AtomicUsize::new(0),
+                robot: vec![robot],
+                output_positions,
+            }
+        }
+
+        fn calls(&self) -> usize {
+            self.calls.load(Ordering::SeqCst)
+        }
+    }
+
+    impl WbcPolicy for CountingPolicy {
+        fn predict(
+            &self,
+            obs: &robowbc_core::Observation,
+        ) -> robowbc_core::Result<JointPositionTargets> {
+            self.calls.fetch_add(1, Ordering::SeqCst);
+            Ok(JointPositionTargets {
+                positions: self.output_positions.clone(),
+                timestamp: obs.timestamp,
+            })
+        }
+
+        fn capabilities(&self) -> robowbc_core::PolicyCapabilities {
+            robowbc_core::PolicyCapabilities::new([WbcCommandKind::Velocity])
+        }
+
+        fn control_frequency_hz(&self) -> u32 {
+            50
+        }
+
+        fn supported_robots(&self) -> &[RobotConfig] {
+            &self.robot
+        }
+    }
+
+    impl ReportTelemetryProvider for robowbc_comm::InMemoryTransport {}
 
     fn replay_frame(
         tick: usize,
@@ -2010,6 +2218,61 @@ mod tests {
             .join("tests")
             .join("fixtures")
             .join(path)
+    }
+
+    fn startup_test_robot() -> RobotConfig {
+        RobotConfig {
+            name: "startup_test".to_owned(),
+            joint_count: 2,
+            joint_names: vec!["left_joint".to_owned(), "right_joint".to_owned()],
+            pd_gains: vec![
+                robowbc_core::PdGains { kp: 1.0, kd: 0.1 },
+                robowbc_core::PdGains { kp: 1.0, kd: 0.1 },
+            ],
+            sim_pd_gains: None,
+            sim_joint_limits: None,
+            joint_limits: vec![
+                robowbc_core::JointLimit {
+                    min: -2.0,
+                    max: 2.0,
+                },
+                robowbc_core::JointLimit {
+                    min: -2.0,
+                    max: 2.0,
+                },
+            ],
+            default_pose: vec![1.0, 1.0],
+            model_path: None,
+            joint_velocity_limits: None,
+        }
+    }
+
+    fn push_startup_sample(
+        transport: &mut robowbc_comm::InMemoryTransport,
+        timestamp: Instant,
+        positions: Vec<f32>,
+    ) {
+        transport.push_joint_state(JointState {
+            velocities: vec![0.0; positions.len()],
+            positions,
+            timestamp,
+        });
+        transport.push_imu(ImuSample {
+            gravity_vector: [0.0, 0.0, -1.0],
+            angular_velocity: [0.0; 3],
+            base_pose: None,
+            timestamp,
+        });
+    }
+
+    fn assert_slice_approx_eq(actual: &[f32], expected: &[f32]) {
+        assert_eq!(actual.len(), expected.len());
+        for (actual, expected) in actual.iter().zip(expected.iter()) {
+            assert!(
+                (actual - expected).abs() <= 1e-5,
+                "expected {expected}, got {actual}"
+            );
+        }
     }
 
     #[test]
@@ -2081,13 +2344,17 @@ mod tests {
         let band = sim
             .elastic_band
             .expect("keyboard demo must keep the upstream-style support band");
+        assert!(band.enabled);
         assert_eq!(band.body_name, "pelvis");
         assert_eq!(band.anchor, [0.0, 0.0, 1.0]);
+        assert!(band.anchor_from_initial_pose);
         assert_eq!(band.length, 0.0);
         assert_eq!(band.kp_pos, 10_000.0);
         assert_eq!(band.kd_pos, 1_000.0);
         assert_eq!(band.kp_ang, 1_000.0);
         assert_eq!(band.kd_ang, 10.0);
+        assert_eq!(parsed.runtime.init_pose_secs, 3.0);
+        assert!(parsed.runtime.require_engage);
     }
 
     #[test]
@@ -2104,6 +2371,7 @@ mod tests {
 
         assert_velocity_close(outcome.velocity, [0.3, -0.1, 0.2]);
         assert!(!outcome.stop_after_tick);
+        assert!(outcome.requests.is_empty());
     }
 
     #[test]
@@ -2113,6 +2381,139 @@ mod tests {
 
         assert_velocity_close(outcome.velocity, [0.0, 0.0, 0.0]);
         assert!(outcome.stop_after_tick);
+    }
+
+    #[test]
+    fn teleop_engage_reset_and_band_toggle_are_reported() {
+        let mut velocity = [0.3, 0.1, -0.2];
+        let outcome = apply_teleop_events(
+            &mut velocity,
+            &[
+                TeleopEvent::Engage,
+                TeleopEvent::ToggleElasticBand,
+                TeleopEvent::Reset,
+            ],
+        );
+
+        assert_velocity_close(outcome.velocity, [0.0, 0.0, 0.0]);
+        assert_eq!(
+            outcome.requests,
+            vec![
+                TeleopControlRequest::Engage,
+                TeleopControlRequest::ToggleElasticBand,
+                TeleopControlRequest::Reset,
+            ]
+        );
+        assert!(!outcome.stop_after_tick);
+    }
+
+    #[test]
+    fn startup_init_pose_interpolates_before_policy_runs() {
+        let robot = startup_test_robot();
+        let policy = CountingPolicy::new(robot.clone(), vec![9.0, 9.0]);
+        let mut transport = robowbc_comm::InMemoryTransport::new();
+        let start = Instant::now();
+        for tick in 0..4 {
+            push_startup_sample(
+                &mut transport,
+                start + Duration::from_millis(tick * 100),
+                vec![0.0, 2.0],
+            );
+        }
+
+        let comm = CommConfig {
+            frequency_hz: 1_000,
+            ..CommConfig::default()
+        };
+        let runtime_command = ParsedRuntimeCommand::Velocity([0.0, 0.0, 0.0]);
+        let mut live_teleop = None;
+        let mut replay_frames = Vec::new();
+        let mut report_frames = Vec::new();
+        #[cfg(feature = "vis")]
+        let mut visualizer = None;
+
+        let metrics = run_control_loop_inner(
+            &mut transport,
+            &policy,
+            &robot,
+            &comm,
+            &runtime_command,
+            RuntimeStartupConfig {
+                init_pose_secs: 0.2,
+                require_engage: false,
+            },
+            &mut live_teleop,
+            Some(4),
+            &AtomicBool::new(true),
+            &mut replay_frames,
+            &mut report_frames,
+            None,
+            #[cfg(feature = "vis")]
+            &mut visualizer,
+        )
+        .expect("startup loop should run");
+
+        assert_eq!(metrics.0, 4);
+        assert_eq!(policy.calls(), 2);
+        let sent = transport.sent_commands();
+        assert_slice_approx_eq(&sent[0].positions, &[0.0, 2.0]);
+        assert_slice_approx_eq(&sent[1].positions, &[0.5, 1.5]);
+        assert_slice_approx_eq(&sent[2].positions, &[9.0, 9.0]);
+        assert_slice_approx_eq(&sent[3].positions, &[9.0, 9.0]);
+    }
+
+    #[test]
+    fn startup_require_engage_holds_init_pose_without_policy_output() {
+        let robot = startup_test_robot();
+        let policy = CountingPolicy::new(robot.clone(), vec![9.0, 9.0]);
+        let mut transport = robowbc_comm::InMemoryTransport::new();
+        let start = Instant::now();
+        for tick in 0..3 {
+            push_startup_sample(
+                &mut transport,
+                start + Duration::from_millis(tick * 100),
+                vec![0.0, 2.0],
+            );
+        }
+
+        let comm = CommConfig {
+            frequency_hz: 1_000,
+            ..CommConfig::default()
+        };
+        let runtime_command = ParsedRuntimeCommand::Velocity([0.0, 0.0, 0.0]);
+        let mut live_teleop = None;
+        let mut replay_frames = Vec::new();
+        let mut report_frames = Vec::new();
+        #[cfg(feature = "vis")]
+        let mut visualizer = None;
+
+        let metrics = run_control_loop_inner(
+            &mut transport,
+            &policy,
+            &robot,
+            &comm,
+            &runtime_command,
+            RuntimeStartupConfig {
+                init_pose_secs: 0.2,
+                require_engage: true,
+            },
+            &mut live_teleop,
+            Some(3),
+            &AtomicBool::new(true),
+            &mut replay_frames,
+            &mut report_frames,
+            None,
+            #[cfg(feature = "vis")]
+            &mut visualizer,
+        )
+        .expect("startup loop should run");
+
+        assert_eq!(metrics.0, 3);
+        assert_eq!(policy.calls(), 0);
+        let sent = transport.sent_commands();
+        assert_slice_approx_eq(&sent[0].positions, &[0.0, 2.0]);
+        assert_slice_approx_eq(&sent[1].positions, &[0.5, 1.5]);
+        assert_slice_approx_eq(&sent[2].positions, &[1.0, 1.0]);
     }
 
     fn assert_velocity_close(actual: [f32; 3], expected: [f32; 3]) {
@@ -2584,6 +2985,8 @@ motion_tokens = []
                 kinematic_pose: None,
                 reference_motion_tracking: false,
                 standing_placeholder_tracking: false,
+                init_pose_secs: 0.0,
+                require_engage: false,
                 max_ticks: Some(1),
             },
             report: None,
@@ -3017,6 +3420,8 @@ standing_placeholder_tracking = true
             kinematic_pose: None,
             reference_motion_tracking: false,
             standing_placeholder_tracking: false,
+            init_pose_secs: 0.0,
+            require_engage: false,
             max_ticks: Some(1),
         };
         let runtime_command = ParsedRuntimeCommand::from_app_config(&AppConfig {
@@ -3046,6 +3451,7 @@ standing_placeholder_tracking = true
             &robot,
             &comm,
             &runtime_command,
+            RuntimeStartupConfig::disabled(),
             &mut live_teleop,
             runtime.max_ticks,
             None,

--- a/crates/robowbc-cli/src/main.rs
+++ b/crates/robowbc-cli/src/main.rs
@@ -1996,6 +1996,14 @@ fn run_init_command(output_path: &Path) -> anyhow::Result<()> {
     Ok(())
 }
 
+fn max_ticks_for_run(runtime: &RuntimeConfig, teleop_enabled: bool) -> Option<usize> {
+    if teleop_enabled {
+        None
+    } else {
+        runtime.max_ticks
+    }
+}
+
 fn install_ctrlc_handler(running: &Arc<AtomicBool>) -> anyhow::Result<()> {
     let signal = Arc::clone(running);
     ctrlc::set_handler(move || {
@@ -2029,11 +2037,7 @@ fn run_with_config(config_path: &Path, teleop_mode: Option<TeleopMode>) -> anyho
     install_ctrlc_handler(&running)?;
 
     let report_config = app.report.clone();
-    let requested_max_ticks = if live_teleop.is_some() {
-        None
-    } else {
-        app.runtime.max_ticks
-    };
+    let requested_max_ticks = max_ticks_for_run(&app.runtime, live_teleop.is_some());
     let metrics = run_control_loop(
         &*policy,
         &policy_name,
@@ -2355,6 +2359,17 @@ mod tests {
         assert_eq!(band.kd_ang, 10.0);
         assert_eq!(parsed.runtime.init_pose_secs, 3.0);
         assert!(parsed.runtime.require_engage);
+    }
+
+    #[test]
+    fn live_teleop_runs_until_user_exit_even_when_runtime_has_max_ticks() {
+        let runtime = RuntimeConfig {
+            max_ticks: Some(200),
+            ..RuntimeConfig::default()
+        };
+
+        assert_eq!(max_ticks_for_run(&runtime, false), Some(200));
+        assert_eq!(max_ticks_for_run(&runtime, true), None);
     }
 
     #[test]

--- a/crates/robowbc-cli/src/main.rs
+++ b/crates/robowbc-cli/src/main.rs
@@ -18,9 +18,11 @@ use robowbc_comm::{
     UnitreeG1Config, UnitreeG1Transport,
 };
 use robowbc_core::{
-    BodyPose, JointPositionTargets, LinkPose, RobotConfig, Twist, WbcCommand, WbcPolicy, SE3,
+    BodyPose, JointPositionTargets, LinkPose, RobotConfig, Twist, WbcCommand, WbcCommandKind,
+    WbcPolicy, SE3,
 };
 use robowbc_registry::{RegistryError, WbcRegistry};
+use robowbc_teleop::{KeyboardTeleop, TeleopEvent, TeleopSource};
 use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
@@ -254,6 +256,18 @@ fn elapsed_secs_for_tick(tick: usize, frequency_hz: u32) -> f32 {
     tick as f32 / frequency_hz as f32
 }
 
+fn velocity_command([vx, vy, yaw]: [f32; 3]) -> WbcCommand {
+    WbcCommand::Velocity(Twist {
+        linear: [vx, vy, 0.0],
+        angular: [0.0, 0.0, yaw],
+    })
+}
+
+#[cfg(feature = "vis")]
+fn velocity_from_command_data(command_data: &[f32]) -> Option<[f32; 3]> {
+    (command_data.len() == 3).then(|| [command_data[0], command_data[1], command_data[2]])
+}
+
 #[derive(Debug, Clone, Deserialize)]
 struct RuntimeConfig {
     #[serde(default)]
@@ -464,7 +478,7 @@ impl ParsedRuntimeCommand {
         }
     }
 
-    #[cfg(any(feature = "vis", test))]
+    #[cfg(test)]
     fn velocity_for_tick(&self, tick: usize, frequency_hz: u32) -> Option<[f32; 3]> {
         match self {
             Self::Velocity(velocity) => Some(*velocity),
@@ -836,10 +850,102 @@ struct ReplayTrace {
     frames: Vec<ReplayFrame>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TeleopMode {
+    Keyboard,
+}
+
+impl TeleopMode {
+    fn parse(raw: &str) -> Result<Self, String> {
+        match raw {
+            "keyboard" => Ok(Self::Keyboard),
+            other => Err(format!(
+                "unsupported teleop mode {other:?}; expected \"keyboard\""
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct TeleopPollOutcome {
+    velocity: [f32; 3],
+    stop_after_tick: bool,
+}
+
+fn apply_teleop_events(
+    current_velocity: &mut [f32; 3],
+    events: &[TeleopEvent],
+) -> TeleopPollOutcome {
+    let mut stop_after_tick = false;
+    for event in events {
+        match *event {
+            TeleopEvent::Velocity { vx, vy, wz } => {
+                *current_velocity = [vx, vy, wz];
+                println!("teleop velocity: vx={vx:.2} m/s, vy={vy:.2} m/s, yaw={wz:.2} rad/s");
+            }
+            TeleopEvent::EmergencyStop => {
+                *current_velocity = [0.0, 0.0, 0.0];
+                stop_after_tick = true;
+                println!("teleop emergency stop: sending zero velocity before shutdown");
+            }
+            TeleopEvent::Quit => {
+                stop_after_tick = true;
+                println!("teleop quit requested");
+            }
+            TeleopEvent::Engage => {
+                println!("teleop engage requested");
+            }
+            TeleopEvent::Reset => {
+                *current_velocity = [0.0, 0.0, 0.0];
+                println!("teleop reset requested: velocity zeroed");
+            }
+        }
+    }
+
+    TeleopPollOutcome {
+        velocity: *current_velocity,
+        stop_after_tick,
+    }
+}
+
+struct LiveTeleop {
+    source: KeyboardTeleop,
+    current_velocity: [f32; 3],
+}
+
+impl LiveTeleop {
+    fn keyboard(initial_velocity: [f32; 3]) -> Result<Self, String> {
+        let mut source = KeyboardTeleop::new();
+        source
+            .enable()
+            .map_err(|err| format!("failed to enable keyboard teleop: {err}"))?;
+        println!("keyboard teleop active: WASD move, QE yaw, Space zeroes velocity, O e-stops, Esc quits");
+        Ok(Self {
+            source,
+            current_velocity: initial_velocity,
+        })
+    }
+
+    fn poll(&mut self) -> Result<TeleopPollOutcome, String> {
+        let events = self
+            .source
+            .poll()
+            .map_err(|err| format!("failed to poll keyboard teleop: {err}"))?;
+        Ok(apply_teleop_events(&mut self.current_velocity, &events))
+    }
+}
+
+impl Drop for LiveTeleop {
+    fn drop(&mut self) {
+        let _ = self.source.disable();
+    }
+}
+
 #[derive(Debug)]
 enum CliCommand {
     Run {
         config_path: PathBuf,
+        teleop_mode: Option<TeleopMode>,
     },
     Init {
         output_path: PathBuf,
@@ -855,10 +961,35 @@ enum CliCommand {
 }
 
 fn parse_args(args: &[String]) -> Result<CliCommand, String> {
-    if args.len() == 4 && args[1] == "run" && args[2] == "--config" {
-        return Ok(CliCommand::Run {
-            config_path: PathBuf::from(&args[3]),
-        });
+    if args.len() >= 2 && args[1] == "run" {
+        let mut config_path: Option<PathBuf> = None;
+        let mut teleop_mode: Option<TeleopMode> = None;
+        let mut idx = 2;
+        while idx < args.len() {
+            if idx + 1 >= args.len() {
+                return Err(format!("missing value for flag {}", args[idx]));
+            }
+            match args[idx].as_str() {
+                "--config" => config_path = Some(PathBuf::from(&args[idx + 1])),
+                "--teleop" => teleop_mode = Some(TeleopMode::parse(&args[idx + 1])?),
+                other => return Err(format!("unknown flag for `run`: {other}")),
+            }
+            idx += 2;
+        }
+        return config_path.map_or_else(
+            || {
+                Err(
+                    "usage: robowbc run --config <path/to/config.toml> [--teleop keyboard]"
+                        .to_owned(),
+                )
+            },
+            |path| {
+                Ok(CliCommand::Run {
+                    config_path: path,
+                    teleop_mode,
+                })
+            },
+        );
     }
 
     if args.len() == 2 && args[1] == "init" {
@@ -896,7 +1027,7 @@ fn parse_args(args: &[String]) -> Result<CliCommand, String> {
     }
 
     Err(
-        "usage: robowbc run --config <path/to/config.toml>\n       robowbc init [--output <path/to/template.toml>]\n       robowbc policy --robot <name> --config <policy_name>"
+        "usage: robowbc run --config <path/to/config.toml> [--teleop keyboard]\n       robowbc init [--output <path/to/template.toml>]\n       robowbc policy --robot <name> --config <policy_name>"
             .to_owned(),
     )
 }
@@ -1071,6 +1202,31 @@ fn build_policy(app: &AppConfig) -> Result<(Box<dyn WbcPolicy>, RobotConfig), St
         .map_err(|e: RegistryError| format!("failed to build policy '{}': {e}", app.policy.name))?;
 
     Ok((policy, robot))
+}
+
+fn validate_teleop_mode(
+    teleop_mode: Option<TeleopMode>,
+    runtime_command: &ParsedRuntimeCommand,
+    policy: &dyn WbcPolicy,
+) -> Result<Option<LiveTeleop>, String> {
+    let Some(mode) = teleop_mode else {
+        return Ok(None);
+    };
+
+    if !policy.capabilities().supports(WbcCommandKind::Velocity) {
+        return Err("keyboard teleop requires a policy that supports velocity commands".to_owned());
+    }
+
+    let ParsedRuntimeCommand::Velocity(initial_velocity) = runtime_command else {
+        return Err(
+            "keyboard teleop requires `[runtime] velocity = [0.0, 0.0, 0.0]` as the initial command"
+                .to_owned(),
+        );
+    };
+
+    match mode {
+        TeleopMode::Keyboard => LiveTeleop::keyboard(*initial_velocity).map(Some),
+    }
 }
 
 trait ReportTelemetryProvider {
@@ -1277,12 +1433,13 @@ fn world_to_body_planar_delta(
     ]
 }
 
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
 fn run_control_loop_inner<T: RobotTransport + ReportTelemetryProvider>(
     transport: &mut T,
     policy: &dyn WbcPolicy,
     comm: &CommConfig,
     runtime_command: &ParsedRuntimeCommand,
+    live_teleop: &mut Option<LiveTeleop>,
     max_ticks: Option<usize>,
     running: &AtomicBool,
     replay_frames: &mut Vec<ReplayFrame>,
@@ -1305,7 +1462,20 @@ fn run_control_loop_inner<T: RobotTransport + ReportTelemetryProvider>(
 
         let cycle_start = Instant::now();
         let tick_index = ticks;
-        let command = runtime_command.command_for_tick(tick_index, comm.frequency_hz);
+        let mut stop_after_tick = false;
+        let (command, tick_command_data) = if let Some(teleop) = live_teleop.as_mut() {
+            let outcome = teleop.poll()?;
+            stop_after_tick = outcome.stop_after_tick;
+            (
+                velocity_command(outcome.velocity),
+                outcome.velocity.to_vec(),
+            )
+        } else {
+            (
+                runtime_command.command_for_tick(tick_index, comm.frequency_hz),
+                runtime_command.command_data_for_tick(tick_index, comm.frequency_hz),
+            )
+        };
         let base_pose = transport.report_base_pose();
         let sim_time_secs = transport.report_sim_time_secs(tick_index, comm.frequency_hz);
         let replay_state = transport.report_mujoco_state();
@@ -1320,7 +1490,7 @@ fn run_control_loop_inner<T: RobotTransport + ReportTelemetryProvider>(
             captured_tick = Some(ReplayFrame {
                 tick: tick_index,
                 sim_time_secs,
-                command_data: runtime_command.command_data_for_tick(tick_index, comm.frequency_hz),
+                command_data: tick_command_data.clone(),
                 phase_name: runtime_command.phase_name_for_tick(tick_index, comm.frequency_hz),
                 base_pose,
                 actual_positions: obs.joint_positions.clone(),
@@ -1351,9 +1521,7 @@ fn run_control_loop_inner<T: RobotTransport + ReportTelemetryProvider>(
                 #[allow(clippy::cast_precision_loss)]
                 let freq = 1.0_f64 / cycle_elapsed.as_secs_f64().max(f64::EPSILON);
                 let _ = vis.log_control_frequency(freq);
-                if let Some([vx, vy, yaw]) =
-                    runtime_command.velocity_for_tick(tick_index, comm.frequency_hz)
-                {
+                if let Some([vx, vy, yaw]) = velocity_from_command_data(&tick_command_data) {
                     let _ = vis.log_velocity_command(vx, vy, yaw);
                 } else {
                     match runtime_command {
@@ -1380,6 +1548,9 @@ fn run_control_loop_inner<T: RobotTransport + ReportTelemetryProvider>(
         }
 
         ticks = ticks.saturating_add(1);
+        if stop_after_tick {
+            running.store(false, Ordering::SeqCst);
+        }
 
         if cycle_elapsed > period {
             dropped_frames = dropped_frames.saturating_add(1);
@@ -1398,6 +1569,7 @@ fn run_control_loop(
     robot: &RobotConfig,
     comm: &CommConfig,
     runtime_command: &ParsedRuntimeCommand,
+    live_teleop: &mut Option<LiveTeleop>,
     requested_max_ticks: Option<usize>,
     report_config: Option<&ReportConfig>,
     running: &AtomicBool,
@@ -1446,6 +1618,7 @@ fn run_control_loop(
                 policy,
                 comm,
                 runtime_command,
+                live_teleop,
                 requested_max_ticks,
                 running,
                 &mut replay_frames,
@@ -1478,6 +1651,7 @@ fn run_control_loop(
                 policy,
                 comm,
                 runtime_command,
+                live_teleop,
                 requested_max_ticks,
                 running,
                 &mut replay_frames,
@@ -1509,6 +1683,7 @@ fn run_control_loop(
                 policy,
                 comm,
                 runtime_command,
+                live_teleop,
                 requested_max_ticks,
                 running,
                 &mut replay_frames,
@@ -1539,6 +1714,7 @@ fn run_control_loop(
                 policy,
                 comm,
                 runtime_command,
+                live_teleop,
                 requested_max_ticks,
                 running,
                 &mut replay_frames,
@@ -1561,6 +1737,7 @@ fn run_control_loop(
                 policy,
                 comm,
                 runtime_command,
+                live_teleop,
                 requested_max_ticks,
                 running,
                 &mut replay_frames,
@@ -1673,7 +1850,7 @@ fn install_ctrlc_handler(running: &Arc<AtomicBool>) -> anyhow::Result<()> {
     .context("failed to install Ctrl+C handler")
 }
 
-fn run_with_config(config_path: &Path) -> anyhow::Result<()> {
+fn run_with_config(config_path: &Path, teleop_mode: Option<TeleopMode>) -> anyhow::Result<()> {
     let app = load_app_config(config_path)
         .map_err(anyhow::Error::msg)
         .with_context(|| format!("while loading config {}", config_path.display()))?;
@@ -1686,18 +1863,26 @@ fn run_with_config(config_path: &Path) -> anyhow::Result<()> {
     let (policy, robot) = build_policy(&app)
         .map_err(anyhow::Error::msg)
         .with_context(|| format!("while building policy {policy_name:?}"))?;
+    let mut live_teleop = validate_teleop_mode(teleop_mode, &runtime_command, &*policy)
+        .map_err(|err| anyhow!("invalid teleop setup: {err}"))?;
 
     let running = Arc::new(AtomicBool::new(true));
     install_ctrlc_handler(&running)?;
 
     let report_config = app.report.clone();
+    let requested_max_ticks = if live_teleop.is_some() {
+        None
+    } else {
+        app.runtime.max_ticks
+    };
     let metrics = run_control_loop(
         &*policy,
         &policy_name,
         &robot,
         &app.comm,
         &runtime_command,
-        app.runtime.max_ticks,
+        &mut live_teleop,
+        requested_max_ticks,
         report_config.as_ref(),
         &running,
         app.hardware,
@@ -1764,7 +1949,10 @@ fn main() {
 
     let result = match command {
         CliCommand::Init { output_path } => run_init_command(&output_path),
-        CliCommand::Run { config_path } => run_with_config(&config_path),
+        CliCommand::Run {
+            config_path,
+            teleop_mode,
+        } => run_with_config(&config_path, teleop_mode),
         CliCommand::Policy { robot, policy } => run_policy_command(&robot, &policy),
     };
 
@@ -1835,12 +2023,74 @@ mod tests {
 
         let parsed = parse_args(&args).expect("args should parse");
         match parsed {
-            CliCommand::Run { config_path } => {
+            CliCommand::Run {
+                config_path,
+                teleop_mode,
+            } => {
                 assert_eq!(config_path, PathBuf::from("configs/sonic_g1.toml"));
+                assert_eq!(teleop_mode, None);
             }
             CliCommand::Init { .. } | CliCommand::Policy { .. } => {
                 panic!("expected run command");
             }
+        }
+    }
+
+    #[test]
+    fn args_parse_run_config_with_keyboard_teleop() {
+        let args = vec![
+            "robowbc".to_owned(),
+            "run".to_owned(),
+            "--config".to_owned(),
+            "configs/demo/gear_sonic_keyboard_mujoco.toml".to_owned(),
+            "--teleop".to_owned(),
+            "keyboard".to_owned(),
+        ];
+
+        let parsed = parse_args(&args).expect("args should parse");
+        match parsed {
+            CliCommand::Run {
+                config_path,
+                teleop_mode,
+            } => {
+                assert_eq!(
+                    config_path,
+                    PathBuf::from("configs/demo/gear_sonic_keyboard_mujoco.toml")
+                );
+                assert_eq!(teleop_mode, Some(TeleopMode::Keyboard));
+            }
+            other => panic!("expected run command, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn teleop_velocity_event_updates_live_command() {
+        let mut velocity = [0.0, 0.0, 0.0];
+        let outcome = apply_teleop_events(
+            &mut velocity,
+            &[TeleopEvent::Velocity {
+                vx: 0.3,
+                vy: -0.1,
+                wz: 0.2,
+            }],
+        );
+
+        assert_velocity_close(outcome.velocity, [0.3, -0.1, 0.2]);
+        assert!(!outcome.stop_after_tick);
+    }
+
+    #[test]
+    fn teleop_emergency_stop_zeroes_command_and_stops_after_tick() {
+        let mut velocity = [0.3, 0.1, -0.2];
+        let outcome = apply_teleop_events(&mut velocity, &[TeleopEvent::EmergencyStop]);
+
+        assert_velocity_close(outcome.velocity, [0.0, 0.0, 0.0]);
+        assert!(outcome.stop_after_tick);
+    }
+
+    fn assert_velocity_close(actual: [f32; 3], expected: [f32; 3]) {
+        for (actual, expected) in actual.iter().zip(expected) {
+            assert!((*actual - expected).abs() < f32::EPSILON);
         }
     }
 
@@ -2762,12 +3012,14 @@ standing_placeholder_tracking = true
         })
         .expect("runtime should parse");
 
+        let mut live_teleop = None;
         let metrics = run_control_loop(
             &*policy,
             "decoupled_wbc",
             &robot,
             &comm,
             &runtime_command,
+            &mut live_teleop,
             runtime.max_ticks,
             None,
             &AtomicBool::new(true),

--- a/crates/robowbc-comm/src/lib.rs
+++ b/crates/robowbc-comm/src/lib.rs
@@ -148,6 +148,18 @@ pub trait RobotTransport {
     ///
     /// Returns [`CommError`] if the command cannot be sent.
     fn send_joint_targets(&mut self, targets: &JointPositionTargets) -> Result<(), CommError>;
+
+    /// Toggles an optional simulator support band.
+    ///
+    /// Real hardware and transports without this concept return `Ok(None)`.
+    /// Simulators that implement it return the new enabled state.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`CommError`] if the transport cannot update the support band.
+    fn toggle_elastic_band(&mut self) -> Result<Option<bool>, CommError> {
+        Ok(None)
+    }
 }
 
 /// A test-friendly in-memory transport.

--- a/crates/robowbc-core/src/lib.rs
+++ b/crates/robowbc-core/src/lib.rs
@@ -562,10 +562,10 @@ mod tests {
         assert_eq!(config.joint_names[0], "left_hip_pitch_joint");
         assert!((config.pd_gains[0].kp - 99.098).abs() < 1e-3);
         assert!((config.pd_gains[0].kd - 6.309).abs() < 1e-3);
-        assert!((config.simulation_pd_gains()[0].kp - 123.873).abs() < 1e-3);
-        assert!((config.simulation_pd_gains()[0].kd - 7.886).abs() < 1e-3);
-        assert!((config.simulation_pd_gains()[15].kp - 14.251).abs() < 1e-3);
-        assert!((config.simulation_pd_gains()[15].kd - 0.907).abs() < 1e-3);
+        assert!((config.simulation_pd_gains()[0].kp - 150.0).abs() < 1e-3);
+        assert!((config.simulation_pd_gains()[0].kd - 2.0).abs() < 1e-3);
+        assert!((config.simulation_pd_gains()[15].kp - 100.0).abs() < 1e-3);
+        assert!((config.simulation_pd_gains()[15].kd - 5.0).abs() < 1e-3);
         assert!((config.default_pose[0] - (-0.312)).abs() < 1e-3);
     }
 

--- a/crates/robowbc-runtime/src/lib.rs
+++ b/crates/robowbc-runtime/src/lib.rs
@@ -342,7 +342,10 @@ impl<P: WbcPolicy> Fsm<P> {
                         self.transition_to_running(TransitionReason::EngageRequested, obs);
                     }
                 }
-                TeleopEvent::EmergencyStop | TeleopEvent::Velocity { .. } | TeleopEvent::Quit => {}
+                TeleopEvent::EmergencyStop
+                | TeleopEvent::Velocity { .. }
+                | TeleopEvent::ToggleElasticBand
+                | TeleopEvent::Quit => {}
             }
         }
 

--- a/crates/robowbc-sim/Cargo.toml
+++ b/crates/robowbc-sim/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 [features]
 default = []
 mujoco = ["dep:mujoco-rs", "mujoco-rs/renderer"]
+mujoco-viewer = ["mujoco", "mujoco-rs/viewer"]
 mujoco-auto-download = ["mujoco", "mujoco-rs/auto-download-mujoco"]
 
 [dependencies]

--- a/crates/robowbc-sim/src/lib.rs
+++ b/crates/robowbc-sim/src/lib.rs
@@ -75,6 +75,10 @@ pub struct MujocoConfig {
     /// for local "I just want to see it move" demos, not headless CI.
     #[serde(default)]
     pub viewer: bool,
+    /// Optional upstream-style virtual support band applied as Cartesian
+    /// force/torque to one body before every physics substep.
+    #[serde(default)]
+    pub elastic_band: Option<MujocoElasticBandConfig>,
 }
 
 fn default_timestep() -> f64 {
@@ -89,6 +93,75 @@ const fn default_gain_profile() -> MujocoGainProfile {
     MujocoGainProfile::SimulationPd
 }
 
+/// Upstream-style `MuJoCo` virtual support band.
+///
+/// GR00T's G1 `MuJoCo` simulator enables this for the teleop path to keep the
+/// humanoid recoverable while the policy and operator settle. When configured,
+/// `RoboWBC` applies the same Cartesian spring-damper to `body_name`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MujocoElasticBandConfig {
+    /// Body that receives the support force. GR00T uses `pelvis` when waist is
+    /// enabled and `torso_link` otherwise.
+    #[serde(default = "default_elastic_body_name")]
+    pub body_name: String,
+    /// World-space spring anchor point in meters.
+    #[serde(default = "default_elastic_anchor")]
+    pub anchor: [f64; 3],
+    /// Additional vertical rest length added to the spring error.
+    #[serde(default)]
+    pub length: f64,
+    /// Translational spring gain.
+    #[serde(default = "default_elastic_kp_pos")]
+    pub kp_pos: f64,
+    /// Translational damping gain.
+    #[serde(default = "default_elastic_kd_pos")]
+    pub kd_pos: f64,
+    /// Orientation spring gain.
+    #[serde(default = "default_elastic_kp_ang")]
+    pub kp_ang: f64,
+    /// Orientation damping gain.
+    #[serde(default = "default_elastic_kd_ang")]
+    pub kd_ang: f64,
+}
+
+impl Default for MujocoElasticBandConfig {
+    fn default() -> Self {
+        Self {
+            body_name: default_elastic_body_name(),
+            anchor: default_elastic_anchor(),
+            length: 0.0,
+            kp_pos: default_elastic_kp_pos(),
+            kd_pos: default_elastic_kd_pos(),
+            kp_ang: default_elastic_kp_ang(),
+            kd_ang: default_elastic_kd_ang(),
+        }
+    }
+}
+
+fn default_elastic_body_name() -> String {
+    "pelvis".to_owned()
+}
+
+const fn default_elastic_anchor() -> [f64; 3] {
+    [0.0, 0.0, 1.0]
+}
+
+const fn default_elastic_kp_pos() -> f64 {
+    10_000.0
+}
+
+const fn default_elastic_kd_pos() -> f64 {
+    1_000.0
+}
+
+const fn default_elastic_kp_ang() -> f64 {
+    1_000.0
+}
+
+const fn default_elastic_kd_ang() -> f64 {
+    10.0
+}
+
 impl Default for MujocoConfig {
     fn default() -> Self {
         Self {
@@ -97,6 +170,7 @@ impl Default for MujocoConfig {
             substeps: default_substeps(),
             gain_profile: default_gain_profile(),
             viewer: false,
+            elastic_band: None,
         }
     }
 }
@@ -203,6 +277,7 @@ mod tests {
             substeps: 20,
             gain_profile: MujocoGainProfile::DefaultPd,
             viewer: true,
+            elastic_band: Some(MujocoElasticBandConfig::default()),
         };
         let toml_str = toml::to_string(&cfg).expect("serialization should succeed");
         let loaded: MujocoConfig =

--- a/crates/robowbc-sim/src/lib.rs
+++ b/crates/robowbc-sim/src/lib.rs
@@ -9,6 +9,8 @@
 //!
 //! - **`mujoco`** — enables the `MuJoCo` backend via the `mujoco-rs` crate.
 //!   Requires the `MuJoCo` C library (v3.0+) to be installed on the host.
+//! - **`mujoco-viewer`** — enables the live Rust-native `MuJoCo` viewer for
+//!   keyboard-driven local demos.
 //! - **`mujoco-auto-download`** — Linux/Windows convenience feature that
 //!   enables `mujoco-rs`' automatic runtime download path. Requires
 //!   `MUJOCO_DOWNLOAD_DIR` to point at an absolute extraction directory.
@@ -67,6 +69,12 @@ pub struct MujocoConfig {
     /// when present.
     #[serde(default = "default_gain_profile")]
     pub gain_profile: MujocoGainProfile,
+    /// Open a live `MuJoCo` viewer and sync it after each control tick.
+    ///
+    /// Requires building with the `mujoco-viewer` feature. This is intended
+    /// for local "I just want to see it move" demos, not headless CI.
+    #[serde(default)]
+    pub viewer: bool,
 }
 
 fn default_timestep() -> f64 {
@@ -88,6 +96,7 @@ impl Default for MujocoConfig {
             timestep: default_timestep(),
             substeps: default_substeps(),
             gain_profile: default_gain_profile(),
+            viewer: false,
         }
     }
 }
@@ -122,6 +131,12 @@ pub enum SimError {
     /// Camera rendering failed.
     #[error("simulation render failed: {reason}")]
     RenderFailed {
+        /// Human-readable failure reason.
+        reason: String,
+    },
+    /// Live viewer failed to initialize or render.
+    #[error("simulation viewer failed: {reason}")]
+    ViewerFailed {
         /// Human-readable failure reason.
         reason: String,
     },
@@ -187,6 +202,7 @@ mod tests {
             timestep: 0.001,
             substeps: 20,
             gain_profile: MujocoGainProfile::DefaultPd,
+            viewer: true,
         };
         let toml_str = toml::to_string(&cfg).expect("serialization should succeed");
         let loaded: MujocoConfig =

--- a/crates/robowbc-sim/src/lib.rs
+++ b/crates/robowbc-sim/src/lib.rs
@@ -100,6 +100,9 @@ const fn default_gain_profile() -> MujocoGainProfile {
 /// `RoboWBC` applies the same Cartesian spring-damper to `body_name`.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct MujocoElasticBandConfig {
+    /// Whether the support band starts enabled.
+    #[serde(default = "default_elastic_enabled")]
+    pub enabled: bool,
     /// Body that receives the support force. GR00T uses `pelvis` when waist is
     /// enabled and `torso_link` otherwise.
     #[serde(default = "default_elastic_body_name")]
@@ -107,6 +110,12 @@ pub struct MujocoElasticBandConfig {
     /// World-space spring anchor point in meters.
     #[serde(default = "default_elastic_anchor")]
     pub anchor: [f64; 3],
+    /// Replace `anchor` with the selected body's initialized world position.
+    ///
+    /// This preserves the standing height for local demos while still letting
+    /// the band catch the humanoid if it starts to fall.
+    #[serde(default)]
+    pub anchor_from_initial_pose: bool,
     /// Additional vertical rest length added to the spring error.
     #[serde(default)]
     pub length: f64,
@@ -127,8 +136,10 @@ pub struct MujocoElasticBandConfig {
 impl Default for MujocoElasticBandConfig {
     fn default() -> Self {
         Self {
+            enabled: default_elastic_enabled(),
             body_name: default_elastic_body_name(),
             anchor: default_elastic_anchor(),
+            anchor_from_initial_pose: false,
             length: 0.0,
             kp_pos: default_elastic_kp_pos(),
             kd_pos: default_elastic_kd_pos(),
@@ -136,6 +147,10 @@ impl Default for MujocoElasticBandConfig {
             kd_ang: default_elastic_kd_ang(),
         }
     }
+}
+
+const fn default_elastic_enabled() -> bool {
+    true
 }
 
 fn default_elastic_body_name() -> String {

--- a/crates/robowbc-sim/src/transport.rs
+++ b/crates/robowbc-sim/src/transport.rs
@@ -1,6 +1,6 @@
 //! `MuJoCo`-backed [`RobotTransport`] implementation.
 
-use crate::{MujocoConfig, MujocoGainProfile, SimError};
+use crate::{MujocoConfig, MujocoElasticBandConfig, MujocoGainProfile, SimError};
 use mujoco_rs::renderer::MjRenderer;
 #[cfg(feature = "mujoco-viewer")]
 use mujoco_rs::viewer::MjViewer;
@@ -45,6 +45,12 @@ struct FloatingBaseMapping {
 struct LoadedModel {
     model: MjModel,
     model_variant: &'static str,
+}
+
+#[derive(Debug, Clone)]
+struct ElasticBand {
+    body_id: usize,
+    config: MujocoElasticBandConfig,
 }
 
 /// Serializable snapshot of the current live `MuJoCo` state.
@@ -103,6 +109,7 @@ pub struct MujocoTransport {
     floating_base: Option<FloatingBaseMapping>,
     gyro_sensor: SensorSpan,
     accel_sensor: SensorSpan,
+    elastic_band: Option<ElasticBand>,
     model_variant: &'static str,
     prev_positions: Vec<f32>,
     #[cfg(feature = "mujoco-viewer")]
@@ -165,6 +172,7 @@ impl MujocoTransport {
             3,
             "accelerometer",
         )?;
+        let elastic_band = resolve_elastic_band(&model, config.elastic_band.clone())?;
 
         let mut data = MjData::new(Box::new(model));
         initialize_state(&mut data, &robot_config, &joint_mappings);
@@ -198,6 +206,7 @@ impl MujocoTransport {
             floating_base,
             gyro_sensor,
             accel_sensor,
+            elastic_band,
             model_variant,
             prev_positions,
             #[cfg(feature = "mujoco-viewer")]
@@ -501,6 +510,34 @@ impl MujocoTransport {
         camera.lookat = [0.0, 0.0, 0.8];
         camera
     }
+
+    fn apply_elastic_band_force(&mut self) {
+        let Some(band) = &self.elastic_band else {
+            return;
+        };
+
+        let body_id = band.body_id;
+        let config = &band.config;
+        let position = self.data.xpos()[body_id];
+        let quaternion_wxyz = self.data.xquat()[body_id];
+        let velocity = self.data.cvel()[body_id];
+        let angular_velocity = [velocity[0], velocity[1], velocity[2]];
+        let linear_velocity = [velocity[3], velocity[4], velocity[5]];
+        let rotation_vector = quat_wxyz_to_rotation_vector(quaternion_wxyz);
+
+        let force = [
+            config.kp_pos * (config.anchor[0] - position[0]) - config.kd_pos * linear_velocity[0],
+            config.kp_pos * (config.anchor[1] - position[1]) - config.kd_pos * linear_velocity[1],
+            config.kp_pos * (config.anchor[2] - position[2] + config.length)
+                - config.kd_pos * linear_velocity[2],
+            -config.kp_ang * rotation_vector[0] - config.kd_ang * angular_velocity[0],
+            -config.kp_ang * rotation_vector[1] - config.kd_ang * angular_velocity[1],
+            -config.kp_ang * rotation_vector[2] - config.kd_ang * angular_velocity[2],
+        ];
+
+        self.data.xfrc_applied_mut().fill([0.0; 6]);
+        self.data.xfrc_applied_mut()[body_id] = force;
+    }
 }
 
 impl RobotTransport for MujocoTransport {
@@ -551,10 +588,7 @@ impl RobotTransport for MujocoTransport {
         };
         self.prev_positions.clone_from(&safe_targets.positions);
 
-        let pd_gains = match self.config.gain_profile {
-            MujocoGainProfile::DefaultPd => &self.robot_config.pd_gains,
-            MujocoGainProfile::SimulationPd => self.robot_config.simulation_pd_gains(),
-        };
+        let gain_profile = self.config.gain_profile;
 
         for _ in 0..self.config.substeps {
             let commanded_ctrls = {
@@ -570,7 +604,12 @@ impl RobotTransport for MujocoTransport {
                             |adr| qpos[adr],
                         );
                         let current_velocity = mapping.qvel_adr.map_or(0.0, |adr| qvel[adr]);
-                        let gains = pd_gains[joint_index];
+                        let gains = match gain_profile {
+                            MujocoGainProfile::DefaultPd => self.robot_config.pd_gains[joint_index],
+                            MujocoGainProfile::SimulationPd => {
+                                self.robot_config.simulation_pd_gains()[joint_index]
+                            }
+                        };
                         Some((
                             actuator_id,
                             compute_pd_control(
@@ -594,6 +633,7 @@ impl RobotTransport for MujocoTransport {
                 ctrl[actuator_id] = command;
             }
 
+            self.apply_elastic_band_force();
             self.data.step();
         }
 
@@ -979,6 +1019,25 @@ fn floating_base_mapping(model: &MjModel) -> Option<FloatingBaseMapping> {
         })
 }
 
+fn resolve_elastic_band(
+    model: &MjModel,
+    config: Option<MujocoElasticBandConfig>,
+) -> Result<Option<ElasticBand>, SimError> {
+    let Some(config) = config else {
+        return Ok(None);
+    };
+    let body_id = model
+        .name_to_id(MjtObj::mjOBJ_BODY, &config.body_name)
+        .ok_or_else(|| SimError::ModelLoadFailed {
+            reason: format!(
+                "sim.elastic_band.body_name {:?} does not exist in MJCF model",
+                config.body_name
+            ),
+        })?;
+
+    Ok(Some(ElasticBand { body_id, config }))
+}
+
 fn joint_mapping(model: &MjModel, joint_name: &str) -> Result<JointMapping, SimError> {
     let Some(joint_info) = model.joint(joint_name) else {
         return Ok(JointMapping::default());
@@ -1046,6 +1105,38 @@ fn gravity_from_free_joint_quaternion(quat_wxyz: [f64; 4]) -> [f32; 3] {
     } else {
         [0.0, 0.0, -1.0]
     }
+}
+
+fn quat_wxyz_to_rotation_vector(quat_wxyz: [f64; 4]) -> [f64; 3] {
+    let norm = (quat_wxyz[0] * quat_wxyz[0]
+        + quat_wxyz[1] * quat_wxyz[1]
+        + quat_wxyz[2] * quat_wxyz[2]
+        + quat_wxyz[3] * quat_wxyz[3])
+        .sqrt();
+    if norm <= f64::EPSILON {
+        return [0.0, 0.0, 0.0];
+    }
+
+    let mut w = quat_wxyz[0] / norm;
+    let mut x = quat_wxyz[1] / norm;
+    let mut y = quat_wxyz[2] / norm;
+    let mut z = quat_wxyz[3] / norm;
+    if w < 0.0 {
+        w = -w;
+        x = -x;
+        y = -y;
+        z = -z;
+    }
+
+    let w_clamped = w.clamp(-1.0, 1.0);
+    let angle = 2.0 * w_clamped.acos();
+    let axis_scale = (1.0 - w_clamped * w_clamped).sqrt();
+    if axis_scale <= 1e-9 {
+        return [2.0 * x, 2.0 * y, 2.0 * z];
+    }
+
+    let scale = angle / axis_scale;
+    [x * scale, y * scale, z * scale]
 }
 
 fn compute_pd_control(
@@ -1208,6 +1299,10 @@ mod tests {
         repo_root().join("assets/robots/unitree_g1/g1_29dof.xml")
     }
 
+    fn gear_sonic_scene_path() -> PathBuf {
+        repo_root().join("assets/robots/groot_g1_gear_sonic/scene_29dof.xml")
+    }
+
     #[test]
     fn new_applies_timestep_and_maps_full_g1_robot() {
         let robot = load_robot_config("configs/robots/unitree_g1.toml");
@@ -1346,6 +1441,40 @@ mod tests {
     }
 
     #[test]
+    fn gear_sonic_demo_model_holds_default_pose_for_startup_window() {
+        let robot = load_robot_config("configs/robots/unitree_g1_gear_sonic.toml");
+        let mut transport = MujocoTransport::new(
+            MujocoConfig {
+                model_path: gear_sonic_scene_path(),
+                timestep: 0.002,
+                substeps: 10,
+                elastic_band: Some(MujocoElasticBandConfig::default()),
+                ..MujocoConfig::default()
+            },
+            robot.clone(),
+        )
+        .expect("GEAR-Sonic demo transport should initialize");
+
+        for _ in 0..250 {
+            transport
+                .send_joint_targets(&JointPositionTargets {
+                    positions: robot.default_pose.clone(),
+                    timestamp: Instant::now(),
+                })
+                .expect("default pose command should hold the demo model");
+        }
+
+        let (position, _) = transport
+            .floating_base_pose()
+            .expect("GEAR-Sonic G1 model should expose a floating base");
+        assert!(
+            position[2] > 0.65,
+            "GEAR-Sonic demo model fell during startup hold: base z={}",
+            position[2]
+        );
+    }
+
+    #[test]
     fn send_joint_targets_computes_pd_control_from_position_error() {
         let mut robot = load_robot_config("configs/robots/unitree_g1.toml");
         robot.joint_velocity_limits = None;
@@ -1392,6 +1521,8 @@ mod tests {
                 timestep: 0.002,
                 substeps: 1,
                 gain_profile: MujocoGainProfile::DefaultPd,
+                viewer: false,
+                elastic_band: None,
             },
             robot.clone(),
         )

--- a/crates/robowbc-sim/src/transport.rs
+++ b/crates/robowbc-sim/src/transport.rs
@@ -51,6 +51,7 @@ struct LoadedModel {
 struct ElasticBand {
     body_id: usize,
     config: MujocoElasticBandConfig,
+    enabled: bool,
 }
 
 /// Serializable snapshot of the current live `MuJoCo` state.
@@ -172,10 +173,12 @@ impl MujocoTransport {
             3,
             "accelerometer",
         )?;
-        let elastic_band = resolve_elastic_band(&model, config.elastic_band.clone())?;
+        let elastic_band_body_id = resolve_elastic_band_body(&model, config.elastic_band.as_ref())?;
 
         let mut data = MjData::new(Box::new(model));
         initialize_state(&mut data, &robot_config, &joint_mappings);
+        let elastic_band =
+            build_elastic_band(&data, elastic_band_body_id, config.elastic_band.clone());
         let prev_positions = robot_config.default_pose.clone();
         #[cfg(feature = "mujoco-viewer")]
         let viewer = if config.viewer {
@@ -299,6 +302,19 @@ impl MujocoTransport {
         initialize_state(&mut self.data, &self.robot_config, &self.joint_mappings);
         self.prev_positions
             .clone_from(&self.robot_config.default_pose);
+    }
+
+    /// Returns whether the optional elastic support band is currently enabled.
+    #[must_use]
+    pub fn elastic_band_enabled(&self) -> Option<bool> {
+        self.elastic_band.as_ref().map(|band| band.enabled)
+    }
+
+    /// Toggles the optional elastic support band and returns its new state.
+    pub fn toggle_elastic_band_enabled(&mut self) -> Option<bool> {
+        let band = self.elastic_band.as_mut()?;
+        band.enabled = !band.enabled;
+        Some(band.enabled)
     }
 
     /// Saves the current full `MuJoCo` physics state.
@@ -516,6 +532,11 @@ impl MujocoTransport {
             return;
         };
 
+        self.data.xfrc_applied_mut().fill([0.0; 6]);
+        if !band.enabled {
+            return;
+        }
+
         let body_id = band.body_id;
         let config = &band.config;
         let position = self.data.xpos()[body_id];
@@ -535,7 +556,6 @@ impl MujocoTransport {
             -config.kp_ang * rotation_vector[2] - config.kd_ang * angular_velocity[2],
         ];
 
-        self.data.xfrc_applied_mut().fill([0.0; 6]);
         self.data.xfrc_applied_mut()[body_id] = force;
     }
 }
@@ -644,6 +664,10 @@ impl RobotTransport for MujocoTransport {
             })?;
 
         Ok(())
+    }
+
+    fn toggle_elastic_band(&mut self) -> Result<Option<bool>, CommError> {
+        Ok(self.toggle_elastic_band_enabled())
     }
 }
 
@@ -1019,10 +1043,10 @@ fn floating_base_mapping(model: &MjModel) -> Option<FloatingBaseMapping> {
         })
 }
 
-fn resolve_elastic_band(
+fn resolve_elastic_band_body(
     model: &MjModel,
-    config: Option<MujocoElasticBandConfig>,
-) -> Result<Option<ElasticBand>, SimError> {
+    config: Option<&MujocoElasticBandConfig>,
+) -> Result<Option<usize>, SimError> {
     let Some(config) = config else {
         return Ok(None);
     };
@@ -1035,7 +1059,25 @@ fn resolve_elastic_band(
             ),
         })?;
 
-    Ok(Some(ElasticBand { body_id, config }))
+    Ok(Some(body_id))
+}
+
+fn build_elastic_band(
+    data: &MjData<Box<MjModel>>,
+    body_id: Option<usize>,
+    config: Option<MujocoElasticBandConfig>,
+) -> Option<ElasticBand> {
+    let body_id = body_id?;
+    let mut config = config?;
+    if config.anchor_from_initial_pose {
+        config.anchor = data.xpos()[body_id];
+    }
+    let enabled = config.enabled;
+    Some(ElasticBand {
+        body_id,
+        config,
+        enabled,
+    })
 }
 
 fn joint_mapping(model: &MjModel, joint_name: &str) -> Result<JointMapping, SimError> {
@@ -1448,7 +1490,10 @@ mod tests {
                 model_path: gear_sonic_scene_path(),
                 timestep: 0.002,
                 substeps: 10,
-                elastic_band: Some(MujocoElasticBandConfig::default()),
+                elastic_band: Some(MujocoElasticBandConfig {
+                    anchor_from_initial_pose: true,
+                    ..MujocoElasticBandConfig::default()
+                }),
                 ..MujocoConfig::default()
             },
             robot.clone(),
@@ -1472,6 +1517,36 @@ mod tests {
             "GEAR-Sonic demo model fell during startup hold: base z={}",
             position[2]
         );
+        assert!(
+            position[2] < 0.86,
+            "GEAR-Sonic demo model was lifted off its standing pose: base z={}",
+            position[2]
+        );
+    }
+
+    #[test]
+    fn elastic_band_can_be_toggled_at_runtime() {
+        let robot = load_robot_config("configs/robots/unitree_g1_gear_sonic.toml");
+        let mut transport = MujocoTransport::new(
+            MujocoConfig {
+                model_path: gear_sonic_scene_path(),
+                timestep: 0.002,
+                substeps: 1,
+                elastic_band: Some(MujocoElasticBandConfig {
+                    anchor_from_initial_pose: true,
+                    ..MujocoElasticBandConfig::default()
+                }),
+                ..MujocoConfig::default()
+            },
+            robot,
+        )
+        .expect("GEAR-Sonic demo transport should initialize");
+
+        assert_eq!(transport.elastic_band_enabled(), Some(true));
+        assert_eq!(transport.toggle_elastic_band_enabled(), Some(false));
+        assert_eq!(transport.elastic_band_enabled(), Some(false));
+        assert_eq!(transport.toggle_elastic_band_enabled(), Some(true));
+        assert_eq!(transport.elastic_band_enabled(), Some(true));
     }
 
     #[test]

--- a/crates/robowbc-sim/src/transport.rs
+++ b/crates/robowbc-sim/src/transport.rs
@@ -2,6 +2,8 @@
 
 use crate::{MujocoConfig, MujocoGainProfile, SimError};
 use mujoco_rs::renderer::MjRenderer;
+#[cfg(feature = "mujoco-viewer")]
+use mujoco_rs::viewer::MjViewer;
 use mujoco_rs::wrappers::mj_plugin::load_all_plugin_libraries;
 use mujoco_rs::wrappers::{
     MjData, MjModel, MjtJoint, MjtObj, MjtSensor, MjtState, MjtTrn, MjvCamera,
@@ -45,7 +47,7 @@ struct LoadedModel {
     model_variant: &'static str,
 }
 
-/// Serializable snapshot of the current live MuJoCo state.
+/// Serializable snapshot of the current live `MuJoCo` state.
 #[derive(Debug, Clone)]
 pub struct MujocoLiveState {
     /// Simulation time in seconds.
@@ -60,9 +62,9 @@ pub struct MujocoLiveState {
     pub angular_velocity: [f32; 3],
     /// Optional floating-base pose in world coordinates.
     pub base_pose: Option<BasePose>,
-    /// Raw MuJoCo generalized coordinates.
+    /// Raw `MuJoCo` generalized coordinates.
     pub qpos: Vec<f32>,
-    /// Raw MuJoCo generalized velocities.
+    /// Raw `MuJoCo` generalized velocities.
     pub qvel: Vec<f32>,
 }
 
@@ -103,6 +105,8 @@ pub struct MujocoTransport {
     accel_sensor: SensorSpan,
     model_variant: &'static str,
     prev_positions: Vec<f32>,
+    #[cfg(feature = "mujoco-viewer")]
+    viewer: Option<MjViewer>,
 }
 
 impl MujocoTransport {
@@ -165,6 +169,25 @@ impl MujocoTransport {
         let mut data = MjData::new(Box::new(model));
         initialize_state(&mut data, &robot_config, &joint_mappings);
         let prev_positions = robot_config.default_pose.clone();
+        #[cfg(feature = "mujoco-viewer")]
+        let viewer = if config.viewer {
+            Some(
+                MjViewer::builder()
+                    .window_name("RoboWBC MuJoCo keyboard demo")
+                    .build_passive(data.model())
+                    .map_err(|error| SimError::ViewerFailed {
+                        reason: error.to_string(),
+                    })?,
+            )
+        } else {
+            None
+        };
+        #[cfg(not(feature = "mujoco-viewer"))]
+        if config.viewer {
+            return Err(SimError::ViewerFailed {
+                reason: "build with feature `robowbc-cli/sim-viewer` or `robowbc-sim/mujoco-viewer` to enable [sim].viewer".to_owned(),
+            });
+        }
 
         Ok(Self {
             data,
@@ -177,6 +200,8 @@ impl MujocoTransport {
             accel_sensor,
             model_variant,
             prev_positions,
+            #[cfg(feature = "mujoco-viewer")]
+            viewer,
         })
     }
 
@@ -239,7 +264,7 @@ impl MujocoTransport {
         self.data.time()
     }
 
-    /// Returns a snapshot of the current MuJoCo `qpos` state as `f32`.
+    /// Returns a snapshot of the current `MuJoCo` `qpos` state as `f32`.
     #[must_use]
     pub fn qpos_snapshot(&self) -> Vec<f32> {
         self.data
@@ -249,7 +274,7 @@ impl MujocoTransport {
             .collect()
     }
 
-    /// Returns a snapshot of the current MuJoCo `qvel` state as `f32`.
+    /// Returns a snapshot of the current `MuJoCo` `qvel` state as `f32`.
     #[must_use]
     pub fn qvel_snapshot(&self) -> Vec<f32> {
         self.data
@@ -267,7 +292,7 @@ impl MujocoTransport {
             .clone_from(&self.robot_config.default_pose);
     }
 
-    /// Saves the current full MuJoCo physics state.
+    /// Saves the current full `MuJoCo` physics state.
     #[must_use]
     pub fn full_physics_state(&self) -> Vec<f64> {
         self.data
@@ -275,7 +300,7 @@ impl MujocoTransport {
             .into_vec()
     }
 
-    /// Restores a previously saved full MuJoCo physics state.
+    /// Restores a previously saved full `MuJoCo` physics state.
     ///
     /// # Errors
     ///
@@ -314,7 +339,7 @@ impl MujocoTransport {
         }
     }
 
-    /// Captures an RGB frame from a named MuJoCo camera or a built-in preset.
+    /// Captures an RGB frame from a named `MuJoCo` camera or a built-in preset.
     ///
     /// # Errors
     ///
@@ -326,9 +351,15 @@ impl MujocoTransport {
         width: usize,
         height: usize,
     ) -> Result<MujocoCameraFrame, SimError> {
+        let renderer_width = u32::try_from(width).map_err(|_| SimError::RenderFailed {
+            reason: format!("camera width {width} exceeds u32::MAX"),
+        })?;
+        let renderer_height = u32::try_from(height).map_err(|_| SimError::RenderFailed {
+            reason: format!("camera height {height} exceeds u32::MAX"),
+        })?;
         let mut renderer = MjRenderer::builder()
-            .width(width as u32)
-            .height(height as u32)
+            .width(renderer_width)
+            .height(renderer_height)
             .rgb(true)
             .depth(false)
             .camera(self.camera_for_name(camera_name))
@@ -356,6 +387,20 @@ impl MujocoTransport {
             width,
             height,
             rgb,
+        })
+    }
+
+    #[cfg(feature = "mujoco-viewer")]
+    fn render_viewer_if_enabled(&mut self) -> Result<(), SimError> {
+        let Some(viewer) = self.viewer.as_mut() else {
+            return Ok(());
+        };
+        if !viewer.running() {
+            return Ok(());
+        }
+        viewer.sync_data(&mut self.data);
+        viewer.render().map_err(|error| SimError::ViewerFailed {
+            reason: error.to_string(),
         })
     }
 
@@ -552,6 +597,12 @@ impl RobotTransport for MujocoTransport {
             self.data.step();
         }
 
+        #[cfg(feature = "mujoco-viewer")]
+        self.render_viewer_if_enabled()
+            .map_err(|error| CommError::PublishFailed {
+                reason: error.to_string(),
+            })?;
+
         Ok(())
     }
 }
@@ -628,7 +679,8 @@ fn load_model_resolving_assets(model_path: &Path) -> Result<LoadedModel, SimErro
 }
 
 fn control_frequency_hz(config: &MujocoConfig) -> u32 {
-    let control_dt = config.timestep * config.substeps as f64;
+    let substeps = u32::try_from(config.substeps).unwrap_or(u32::MAX);
+    let control_dt = config.timestep * f64::from(substeps);
     if control_dt <= f64::EPSILON {
         return 0;
     }
@@ -685,8 +737,8 @@ fn ensure_mujoco_mesh_plugins_loaded() -> Result<(), SimError> {
 
 fn resolve_mujoco_plugin_dir() -> Option<PathBuf> {
     plugin_dir_from_env("MUJOCO_PLUGIN_DIR")
-        .or_else(|| plugin_dir_from_dynamic_link_dir())
-        .or_else(|| plugin_dir_from_download_dir())
+        .or_else(plugin_dir_from_dynamic_link_dir)
+        .or_else(plugin_dir_from_download_dir)
 }
 
 fn plugin_dir_from_env(var_name: &str) -> Option<PathBuf> {
@@ -736,7 +788,7 @@ fn collect_missing_mesh_assets(model_path: &Path, mjcf: &str) -> Result<Vec<Path
                 model_path.display()
             ),
         })?;
-    let mesh_dir = first_self_closing_tag(&mjcf, "compiler")
+    let mesh_dir = first_self_closing_tag(mjcf, "compiler")
         .and_then(|tag| xml_attribute(tag, "meshdir"))
         .map_or_else(
             || model_dir.to_path_buf(),
@@ -744,7 +796,7 @@ fn collect_missing_mesh_assets(model_path: &Path, mjcf: &str) -> Result<Vec<Path
         );
 
     let mut missing = BTreeSet::new();
-    for mesh_tag in self_closing_tags(&mjcf, "mesh") {
+    for mesh_tag in self_closing_tags(mjcf, "mesh") {
         let Some(file) = xml_attribute(mesh_tag, "file") else {
             continue;
         };

--- a/crates/robowbc-teleop/src/keyboard.rs
+++ b/crates/robowbc-teleop/src/keyboard.rs
@@ -174,6 +174,7 @@ impl KeyboardTeleop {
                 self.wz = 0.0;
                 TeleopEvent::Reset
             }
+            TeleopAction::ToggleElasticBand => TeleopEvent::ToggleElasticBand,
             TeleopAction::Quit => TeleopEvent::Quit,
         }
     }
@@ -338,6 +339,16 @@ mod tests {
         let event = teleop.handle_key(key_press(KeyCode::Char('r'))).unwrap();
         assert_eq!(event, TeleopEvent::Reset);
         assert_eq!(teleop.velocity(), (0.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn nine_toggles_elastic_band_without_clearing_accumulator() {
+        let mut teleop = KeyboardTeleop::new();
+        teleop.handle_key(key_press(KeyCode::Char('w')));
+        let pre = teleop.velocity();
+        let event = teleop.handle_key(key_press(KeyCode::Char('9'))).unwrap();
+        assert_eq!(event, TeleopEvent::ToggleElasticBand);
+        assert_eq!(teleop.velocity(), pre);
     }
 
     #[test]

--- a/crates/robowbc-teleop/src/keymap.rs
+++ b/crates/robowbc-teleop/src/keymap.rs
@@ -41,6 +41,8 @@ pub enum TeleopAction {
     Engage,
     /// Re-enter `RL_Init` / interpolate back to `default_dof_pos`.
     Reset,
+    /// Toggle the simulator elastic support band.
+    ToggleElasticBand,
     /// Quit the runtime gracefully.
     Quit,
 }
@@ -93,6 +95,8 @@ pub struct KeymapOverlay {
     pub engage: Option<String>,
     /// Spec for [`TeleopAction::Reset`].
     pub reset: Option<String>,
+    /// Spec for [`TeleopAction::ToggleElasticBand`].
+    pub toggle_elastic_band: Option<String>,
     /// Spec for [`TeleopAction::Quit`].
     pub quit: Option<String>,
 }
@@ -123,6 +127,7 @@ impl Default for KeymapConfig {
             (KeyCode::Char('o'), TeleopAction::EmergencyStop),
             (KeyCode::Char(']'), TeleopAction::Engage),
             (KeyCode::Char('r'), TeleopAction::Reset),
+            (KeyCode::Char('9'), TeleopAction::ToggleElasticBand),
             (KeyCode::Esc, TeleopAction::Quit),
         ];
         let mut bindings = HashMap::with_capacity(pairs.len());
@@ -164,6 +169,10 @@ impl KeymapConfig {
             (TeleopAction::EmergencyStop, &overlay.emergency_stop),
             (TeleopAction::Engage, &overlay.engage),
             (TeleopAction::Reset, &overlay.reset),
+            (
+                TeleopAction::ToggleElasticBand,
+                &overlay.toggle_elastic_band,
+            ),
             (TeleopAction::Quit, &overlay.quit),
         ];
 
@@ -327,6 +336,10 @@ mod tests {
         assert_eq!(
             map.lookup(key(KeyCode::Char('r'))),
             Some(TeleopAction::Reset)
+        );
+        assert_eq!(
+            map.lookup(key(KeyCode::Char('9'))),
+            Some(TeleopAction::ToggleElasticBand)
         );
         assert_eq!(map.lookup(key(KeyCode::Esc)), Some(TeleopAction::Quit));
     }

--- a/crates/robowbc-teleop/src/lib.rs
+++ b/crates/robowbc-teleop/src/lib.rs
@@ -73,6 +73,10 @@ pub enum TeleopEvent {
     Engage,
     /// Return to the configured `default_dof_pos` (re-enter `RL_Init`).
     Reset,
+    /// Toggle the simulator elastic support band.
+    ///
+    /// Matches GR00T's `9` key convention.
+    ToggleElasticBand,
     /// Quit the runtime gracefully.
     Quit,
 }
@@ -89,7 +93,11 @@ impl TeleopEvent {
                 linear: [vx, vy, 0.0],
                 angular: [0.0, 0.0, wz],
             })),
-            Self::EmergencyStop | Self::Engage | Self::Reset | Self::Quit => None,
+            Self::EmergencyStop
+            | Self::Engage
+            | Self::Reset
+            | Self::ToggleElasticBand
+            | Self::Quit => None,
         }
     }
 }
@@ -160,6 +168,7 @@ mod tests {
         assert!(TeleopEvent::EmergencyStop.to_wbc_command().is_none());
         assert!(TeleopEvent::Engage.to_wbc_command().is_none());
         assert!(TeleopEvent::Reset.to_wbc_command().is_none());
+        assert!(TeleopEvent::ToggleElasticBand.to_wbc_command().is_none());
         assert!(TeleopEvent::Quit.to_wbc_command().is_none());
     }
 }

--- a/crates/unitree-hg-idl/src/lib.rs
+++ b/crates/unitree-hg-idl/src/lib.rs
@@ -502,7 +502,7 @@ pub const G1_MOTOR_COUNT: usize = 35;
 ///
 /// The `crc` field is computed by [`crc32_core`] over the first
 /// `(1276 / 4) - 1 = 318` u32 words of the encoded struct.
-/// Call [`LowCmd::set_crc`] before sending.
+/// Call [`LowCmd::encode_with_crc`] before sending.
 #[derive(Debug, Clone, PartialEq)]
 pub struct LowCmd {
     /// PR mode selector (0 = PR mode, 1 = AB mode).
@@ -517,7 +517,7 @@ pub struct LowCmd {
     pub fan: u8,
     /// Reserved (must be zero).
     pub reserve: [u8; 3],
-    /// CRC32 checksum — computed by [`LowCmd::set_crc`].
+    /// CRC32 checksum — computed by [`LowCmd::encode_with_crc`].
     pub crc: u32,
 }
 

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,19 @@
+# Domain Docs
+
+This is a single-context repo.
+
+## Before exploring, read these
+
+- `docs/founding-document.md` — project goals, landscape, design decisions, roadmap
+- `docs/architecture.md` — current architecture
+- Relevant topic docs under `docs/`, such as `docs/adding-a-model.md`, `docs/adding-a-robot.md`, and `docs/configuration.md`
+
+If `CONTEXT.md`, `CONTEXT-MAP.md`, or `docs/adr/` are added later, read them as higher-specificity domain context.
+
+## Use project vocabulary
+
+Use the project's existing domain language: WBC policies, inference runtime, `WbcPolicy`, observations, commands, joint position targets, policy registry, Unitree G1, ONNX Runtime, PyO3, and zenoh.
+
+## Flag conflicts
+
+If a proposal contradicts `docs/founding-document.md`, `docs/architecture.md`, or a future ADR, surface the conflict explicitly.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,13 @@
+# Issue Tracker: GitHub
+
+Issues and PRDs for this repo live in GitHub Issues for `MiaoDX/robowbc`.
+
+Use GitHub MCP tools for GitHub operations. Do not assume the `gh` CLI is installed.
+
+## Conventions
+
+- Create issues in `MiaoDX/robowbc`.
+- Read issues with comments and labels before triage or implementation.
+- Apply and remove labels using the mapping in `docs/agents/triage-labels.md`.
+- When a skill says "publish to the issue tracker", create a GitHub issue.
+- When a skill says "fetch the relevant ticket", read the GitHub issue, including comments and labels.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,11 @@
+# Triage Labels
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role, use the corresponding label string from this table.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -229,6 +229,24 @@ The checked-in reference example is `examples/python/mujoco_kinematic_pose_sessi
 
 ## Optional artifact sections
 
+### `[sim.elastic_band]`
+
+The MuJoCo transport can apply an upstream-style virtual support band before
+each physics substep. This is intended for local humanoid teleop demos, matching
+GR00T's G1 simulator behavior.
+
+```toml
+[sim.elastic_band]
+body_name = "pelvis"
+anchor = [0.0, 0.0, 1.0]
+kp_pos = 10000.0
+kd_pos = 1000.0
+kp_ang = 1000.0
+kd_ang = 10.0
+```
+
+Omit the table to run without the support band.
+
 ### `[report]`
 
 The `[report]` section makes the CLI write a machine-readable JSON summary at

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -117,6 +117,15 @@ for backward compatibility. `motion_tokens = []` is rejected; use
 `standing_placeholder_tracking = true` when you want the explicit Gear-Sonic
 standing-placeholder alias instead of an empty-array magic value.
 
+Optional startup fields may also be set under `[runtime]`:
+
+- `init_pose_secs = 3.0` interpolates from the observed pose to the robot
+  default pose before running policy output.
+- `require_engage = true` holds that init pose until live teleop sends `]`.
+
+The keyboard demo uses both fields so policy output does not hit the robot
+before the operator has seen the standing pose settle.
+
 ### `gear_sonic`
 
 - Default public path: `velocity = [vx, vy, yaw_rate]`
@@ -191,6 +200,7 @@ no public `EndEffectorPoses` config surface in v1.
 - `comm.frequency_hz` / `communication.frequency_hz` must be greater than zero
 - `inference.backend` currently supports only `ort`
 - `inference.device` must be non-empty
+- `runtime.init_pose_secs` must be finite and greater than or equal to zero
 - Runtime command fields are mutually exclusive; set exactly one of `motion_tokens`, `velocity`, `velocity_schedule`, `kinematic_pose`, or `standing_placeholder_tracking`
 - `standing_placeholder_tracking` is only supported when `policy.name = "gear_sonic"`
 - Named `runtime.velocity_schedule.segments` must either all define
@@ -237,15 +247,20 @@ GR00T's G1 simulator behavior.
 
 ```toml
 [sim.elastic_band]
+enabled = true
 body_name = "pelvis"
 anchor = [0.0, 0.0, 1.0]
+anchor_from_initial_pose = true
 kp_pos = 10000.0
 kd_pos = 1000.0
 kp_ang = 1000.0
 kd_ang = 10.0
 ```
 
-Omit the table to run without the support band.
+Omit the table to run without the support band. Set
+`anchor_from_initial_pose = true` for local teleop demos where the support band
+should catch a falling humanoid without lifting it away from its initialized
+standing height.
 
 ### `[report]`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -66,12 +66,13 @@ robowbc run --config configs/demo/gear_sonic_keyboard_mujoco.toml --teleop keybo
 ```
 
 Keep the terminal focused for keyboard input and watch the MuJoCo window:
-`WASD` changes linear velocity, `QE` changes yaw, `Space` zeroes velocity,
-`O` sends a zero-velocity emergency-stop tick, and `Esc` quits. The demo config
-uses the GR00T scene wrapper and virtual support band so the robot stays
-recoverable while you drive it. It also uses `[sim].viewer = true`, so it
-requires a Linux desktop/OpenGL session. For headless machines, use `make site`
-or `make showcase-verify` instead.
+`]` engages the policy after the init pose settles, `WASD` changes linear
+velocity, `QE` changes yaw, `Space` zeroes velocity, `9` toggles the support
+band, `O` sends a zero-velocity emergency-stop tick, and `Esc` quits. The demo
+config uses the GR00T scene wrapper and a neutral-height virtual support band
+so the robot stays recoverable without being lifted off the ground. It also
+uses `[sim].viewer = true`, so it requires a Linux desktop/OpenGL session. For
+headless machines, use `make site` or `make showcase-verify` instead.
 
 ## Generate a local policy showcase
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -57,8 +57,9 @@ For the "I just want to see the policy move a robot" path, use:
 make demo-keyboard
 ```
 
-This downloads the public GEAR-Sonic checkpoints if needed, builds the CLI with
-MuJoCo auto-download plus the live viewer feature, and runs:
+This downloads the public GEAR-Sonic checkpoints and the MuJoCo runtime if
+needed, builds the CLI with MuJoCo auto-download plus the live viewer feature,
+and runs:
 
 ```bash
 robowbc run --config configs/demo/gear_sonic_keyboard_mujoco.toml --teleop keyboard
@@ -67,8 +68,10 @@ robowbc run --config configs/demo/gear_sonic_keyboard_mujoco.toml --teleop keybo
 Keep the terminal focused for keyboard input and watch the MuJoCo window:
 `WASD` changes linear velocity, `QE` changes yaw, `Space` zeroes velocity,
 `O` sends a zero-velocity emergency-stop tick, and `Esc` quits. The demo config
-uses `[sim].viewer = true`, so it requires a Linux desktop/OpenGL session. For
-headless machines, use `make site` or `make showcase-verify` instead.
+uses the GR00T scene wrapper and virtual support band so the robot stays
+recoverable while you drive it. It also uses `[sim].viewer = true`, so it
+requires a Linux desktop/OpenGL session. For headless machines, use `make site`
+or `make showcase-verify` instead.
 
 ## Generate a local policy showcase
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -49,6 +49,27 @@ If an ONNX-backed run stalls before the first tick on Linux/x86_64, set
 `ROBOWBC_ORT_DYLIB_PATH` to a fully extracted `libonnxruntime.so.1.24.2` under
 `target/debug/build/robowbc-ort-*/out/onnxruntime-linux-x64-1.24.2/lib/`.
 
+## Run the interactive MuJoCo keyboard demo
+
+For the "I just want to see the policy move a robot" path, use:
+
+```bash
+make demo-keyboard
+```
+
+This downloads the public GEAR-Sonic checkpoints if needed, builds the CLI with
+MuJoCo auto-download plus the live viewer feature, and runs:
+
+```bash
+robowbc run --config configs/demo/gear_sonic_keyboard_mujoco.toml --teleop keyboard
+```
+
+Keep the terminal focused for keyboard input and watch the MuJoCo window:
+`WASD` changes linear velocity, `QE` changes yaw, `Space` zeroes velocity,
+`O` sends a zero-velocity emergency-stop tick, and `Esc` quits. The demo config
+uses `[sim].viewer = true`, so it requires a Linux desktop/OpenGL session. For
+headless machines, use `make site` or `make showcase-verify` instead.
+
 ## Generate a local policy showcase
 
 The repository includes a single site builder that assembles the policy pages,


### PR DESCRIPTION
## Summary

Adds the clone-and-run keyboard demo path for the GEAR-Sonic MuJoCo policy:

- `make demo-keyboard` downloads public GEAR-Sonic checkpoints, prepares MuJoCo, starts the viewer, and runs `robowbc --teleop keyboard`.
- Adds a GR00T-style scene wrapper with brighter lighting and a ground plane that makes foot contact visible.
- Adds keyboard controls for velocity, engage (`]`), reset, emergency stop, support-band toggle (`9`), and quit.
- Adds startup/init-pose handling so policy output does not hit the robot until the standing pose has settled and the operator engages it.
- Adds a configurable MuJoCo elastic support band anchored from the initialized pelvis pose so the robot is recoverable without being lifted off the ground.
- Updates README, getting-started/configuration docs, and agent docs/guardrails for the demo path.

## Test Coverage

All new behavior has targeted coverage:

- CLI argument parsing for `--teleop keyboard`.
- Teleop velocity, engage, reset, emergency stop, support-band toggle, and quit behavior.
- Startup init-pose interpolation and `require_engage` hold behavior.
- Demo config guardrails for scene wrapper, elastic band, init pose, and engage requirement.
- MuJoCo startup stability test that verifies the demo model holds standing height without falling or being lifted.
- Live teleop ignores runtime tick caps and runs until user exit.

## Pre-Landing Review

No remaining issues found. One review issue was fixed before PR creation: live keyboard teleop now has an explicit helper/test proving it runs until user exit, and the demo config no longer carries a misleading `max_ticks = 200` line.

## Design Review

No frontend files changed. Design review skipped.

## Eval Results

No prompt-related files changed. Evals skipped.

## Plan Completion

No plan file detected.

## TODOS

No TODO items completed in this PR.

## Test plan

- [x] `rustc --version`
- [x] `cargo --version`
- [x] `cargo build`
- [x] `cargo check`
- [x] `cargo test -p robowbc-cli`
- [x] `cargo test`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo fmt --check`
- [x] `cargo doc --no-deps`
- [x] `MUJOCO_DOWNLOAD_DIR="$(pwd)/.cache/mujoco" MUJOCO_DYNAMIC_LINK_DIR="$(pwd)/.cache/mujoco/mujoco-3.6.0/lib" LD_LIBRARY_PATH="$(pwd)/.cache/mujoco/mujoco-3.6.0/lib:${LD_LIBRARY_PATH:-}" cargo test -p robowbc-sim --features mujoco-auto-download gear_sonic_demo_model_holds_default_pose_for_startup_window`
